### PR TITLE
Fixed Men's Matches File

### DIFF
--- a/charting-m-matches.csv
+++ b/charting-m-matches.csv
@@ -1,226 +1,510 @@
 match_id,Player 1,Player 2,Pl 1 hand,Pl 2 hand,Gender,Date,Tournament,Round,Time,Court,Surface,Umpire,Best of,Final TB?,Charted by
-20170206-M-Davis_Cup_World_Group_R1-RR-Kyle_Edmund-Denis_Shapovalov,Kyle Edmund,Denis Shapovalov,R,L,M,20170206,Davis Cup World Group R1,RR,,,Hard,Arnaud Gabas,5,0,@CanuckKicker
-20170203-M-Burnie_CH-SF-Akira_Santillan-Blake_Mott,Akira Santillan,Blake Mott,R,R,M,20170203,Burnie CH,SF,,,Hard,,3,1,jeffsackmann
-20170129-M-Australian_Open-F-Rafael_Nadal-Roger_Federer,Rafael Nadal,Roger Federer,L,R,M,20170129,Australian Open,F,19:30,RLA,Hard,James Keothavong,5,0,jeffsackmann
-20170124-M-Australian_Open-QF-Milos_Raonic-Rafael_Nadal,Milos Raonic,Rafael Nadal,R,L,M,20170124,Australian Open,QF,,,Hard,Eva Asderaki-Moore,5,0,@CanuckKicker
-20170122-M-Australian_Open-R16-Roger_Federer-Kei_Nishikori,Roger Federer,Kei Nishikori,R,R,M,20170122,Australian Open,R16,,RLA,Hard,,5,0,Isaac
-20170122-M-Australian_Open-R16-Andy_Murray-Mischa_Zverev,Andy Murray,Mischa Zverev,R,L,M,20170122,Australian Open,R16,,RLA,Hard,Renaud Lichtenstein,5,0,jeffsackmann
-20170121-M-Australian_Open-R32-Milos_Raonic-Gilles_Simon,Milos Raonic,Gilles Simon,R,R,M,20170121,Australian Open,R32,,Hisense,Hard,Nico Helwerth,5,0,@CanuckKicker
-20170120-M-Australian_Open-R32-Tomas_Berdych-Roger_Federer,Tomas Berdych,Roger Federer,R,R,M,20170120,Australian Open,R32,,Rod Laver Arena,Hard,,5,0,camyu19
-20170120-M-Australian_Open-R32-Bernard_Tomic-Daniel_Evans,Bernard Tomic,Daniel Evans,R,R,M,20170120,Australian Open,R32,,Hisense,Hard,Emmanuel Joseph,5,0,jeffsackmann
-20170118-M-Australian_Open-R64-Nick_Kyrgios-Andreas_Seppi,Nick Kyrgios,Andreas Seppi,R,R,M,20170118,Australian Open,R64,,Hisense,Hard,Carlos Ramos,5,0,Bobby
-20170114-M-Sydney-F-Gilles_Muller-Daniel_Evans,Gilles Muller,Daniel Evans,L,R,M,20170114,Sydney,F,,Centre,Hard,Ali Nili,3,1,jeffsackmann
-20170114-M-Australian_Open-Q3-Reilly_Opelka-Casper_Ruud,Reilly Opelka,Casper Ruud,R,R,M,20170114,Australian Open,Q3,,Show Court 3,Hard,,3,1,jeffsackmann
-20170113-M-Australian_Open-Q2-Casper_Ruud-Jonathan_Eysseric,Casper Ruud,Jonathan Eysseric,R,L,M,20170113,Australian Open,Q2,,Show Court 3,Hard,James Keothavong,3,1,jeffsackmann
-20170112-M-Sydney-QF-Daniel_Evans-Dominic_Thiem,Daniel Evans,Dominic Thiem,R,R,M,20170112,Sydney,QF,,Centre,Hard,John Blom,3,1,jeffsackmann
-20170112-M-Auckland-QF-Steve_Johnson-John_Isner,Steve Johnson,John Isner,R,R,M,20170112,Auckland,QF,,,Hard,,3,1,Isaac
-20170107-M-Doha-F-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20170107,Doha,F,,,Hard,,3,1,Isaac
-20170107-M-Chennai-SF-Daniil_Medvedev-Dudi_Sela,Daniil Medvedev,Dudi Sela,R,R,M,20170107,Chennai,SF,,Centre,Hard,Mohamed Al Jennati,3,1,jeffsackmann
-20170107-M-Brisbane-F-Grigor_Dimitrov-Kei_Nishikori,Grigor Dimitrov,Kei Nishikori,R,R,M,20170107,Brisbane,F,,Centre,Hard,Fergus Murphy,3,1,jeffsackmann
-20170104-M-Doha-R16-Jo_Wilfried_Tsonga-Dustin_Brown,Jo Wilfried Tsonga,Dustin Brown,R,R,M,20170104,Doha,R16,,Centre,Hard,Adel Nour,3,1,Salvo
-20170102-M-Doha-R32-Vasek_Pospisil-Fernando_Verdasco,Vasek Pospisil,Fernando Verdasco,R,L,M,20170102,Doha,R32,9:00pm,Centre,Hard,,3,1,James Brown
-20161126-M-Andria_CH-SF-Egor_Gerasimov-Matteo_Berrettini,Egor Gerasimov,Matteo Berrettini,R,R,M,20161126,Andria CH,SF,,,Hard,,3,1,Isaac
-20161120-M-London-F-Andy_Murray-Novak_Djokovic,Andy Murray,Novak Djokovic,R,R,M,20161120,London,F,6:00 PM,Centre,Hard,Carlos Bernardes,3,1,Edo
-20161119-M-London-SF-Andy_Murray-Milos_Raonic,Andy Murray,Milos Raonic,R,R,M,20161119,London,SF,,Center,Hard,,3,1,jeffsackmann
-20161118-M-London-RR-Stanislas_Wawrinka-Andy_Murray,Stanislas Wawrinka,Andy Murray,R,R,M,20161118,London,RR,,,Hard,,3,1,Isaac
-20161117-M-Toyota_CH-R16-Luke_Saville-Duck_Hee_Lee,Luke Saville,Duck Hee Lee,R,R,M,20161117,Toyota CH,R16,,,Hard,,3,1,jeffsackmann
-20161116-M-London-RR-Andy_Murray-Kei_Nishikori,Andy Murray,Kei Nishikori,R,R,M,20161116,London,RR,,Center,Hard,Carlos Bernardes,3,1,jeffsackmann
-20161106-M-Paris_Masters-F-Andy_Murray-John_Isner,Andy Murray,John Isner,R,R,M,20161106,Paris Masters,F,3:00 PM,Centre,Hard,Damien Dumusois,3,1,Edo
-20161101-M-Eckental_CH-R32-Aldin_Setkic-Florian_Mayer,Aldin Setkic,Florian Mayer,R,R,M,20161101,Eckental CH,R32,,,Hard,,3,1,jeffsackmann
-20161101-M-Charlottesville_CH-R32-Peter_Polansky-Noah_Rubin,Peter Polansky,Noah Rubin,R,R,M,20161101,Charlottesville CH,R32,,,Hard,,3,1,Isaac
-20161101-M-Charlottesville_CH-R32-Denis_Kudla-Tommy_Paul,Denis Kudla,Tommy Paul,R,R,M,20161101,Charlottesville CH,R32,,,Hard,,3,1,Isaac
-20161030-M-Vienna-F-Andy_Murray-Jo_Wilfried_Tsonga,Andy Murray,Jo Wilfried Tsonga,R,R,M,20161030,Vienna,F,,Centre,Hard,Carlos Bernardes,3,1,jeffsackmann
-20161029-M-Basel-SF-Marin_Cilic-Mischa_Zverev,Marin Cilic,Mischa Zverev,R,L,M,20161029,Basel,SF,,Center,Hard,Mohamed Lahyani,3,1,jeffsackmann
-20161022-M-Antwerp-SF-Kyle_Edmund-Richard_Gasquet,Kyle Edmund,Richard Gasquet,R,R,M,20161022,Antwerp,SF,,Center,Hard,Mohamed El Jennati,3,1,jeffsackmann
-20161021-M-Santiago_CH-QF-Horacio_Zeballos-Pedro_Sousa,Horacio Zeballos,Pedro Sousa,L,R,M,20161021,Santiago CH,QF,,1,Clay,,3,1,jeffsackmann
-20161021-M-Moscow-QF-Pablo_Carreno_Busta-Alexander_Bublik,Pablo Carreno Busta,Alexander Bublik,R,R,M,20161021,Moscow,QF,,Center,Hard,,3,1,jeffsackmann
-20161016-M-Shanghai_Masters-F-Roberto_Bautista_Agut-Andy_Murray,Roberto Bautista Agut,Andy Murray,R,R,M,20161016,Shanghai Masters,F,5:00 PM,Stadium,Hard,Damien Dumusois,3,1,Edo
-20161013-M-Shanghai_Masters-R16-Mischa_Zverev-Marcel_Granollers,Mischa Zverev,Marcel Granollers,L,R,M,20161013,Shanghai Masters,R16,,Union Pay,Hard,,3,1,jeffsackmann
-20161010-M-Shanghai_Masters-R64-Kyle_Edmund-Federico_Delbonis,Kyle Edmund,Federico Delbonis,R,L,M,20161010,Shanghai Masters,R64,,Union Pay,Hard,,3,1,jeffsackmann
-20161009-M-Mohammedia_CH-F-Stefanos_Tsitsipas-Gerald_Melzer,Stefanos Tsitsipas,Gerald Melzer,R,L,M,20161009,Mohammedia CH,F,,,Clay,,3,1,jeffsackmann
-20161009-M-Beijing-F-Grigor_Dimitrov-Andy_Murray,Grigor Dimitrov,Andy Murray,R,R,M,20161009,Beijing,F,,Center,Hard,Mohamed Lahyani,3,1,jeffsackmann
-20161007-M-Beijing-QF-Andy_Murray-Kyle_Edmund,Andy Murray,Kyle Edmund,R,R,M,20161007,Beijing,QF,,Diamond,Hard,Cedric Mourier,3,1,jeffsackmann
-20161004-M-Stockton_CH-R32-Joris_De_Loore-Bjorn_Fratangelo,Joris De Loore,Bjorn Fratangelo,R,R,M,20161004,Stockton CH,R32,,,Hard,,3,1,jeffsackmann
-20161002-M-Medellin_CH-F-Facundo_Bagnis-Caio_Zampieri,Facundo Bagnis,Caio Zampieri,L,R,M,20161002,Medellin CH,F,,,Clay,,3,1,jeffsackmann
-20161002-M-Chengdu-F-Karen_Khachanov-Albert_Ramos,Karen Khachanov,Albert Ramos,R,L,M,20161002,Chengdu,F,,Center,Hard,Cedric Mourier,3,1,jeffsackmann
-20161001-M-Chengdu-SF-Viktor_Troicki-Karen_Khachanov,Viktor Troicki,Karen Khachanov,R,R,M,20161001,Chengdu,SF,,Center,Hard,Damian Steiner,3,1,jeffsackmann
-20160925-M-Sibiu_CH-F-Robin_Haase-Lorenzo_Giustino,Robin Haase,Lorenzo Giustino,R,R,M,20160925,Sibiu CH,F,,,Clay,,3,1,jeffsackmann
-20160923-M-Metz-QF-Gilles_Simon-Malek_Jaziri,Gilles Simon,Malek Jaziri,R,R,M,20160923,Metz,QF,,Central,Hard,Ahmed Abdel-Azim,3,1,jeffsackmann
-20160921-M-St_Petersburg-R32-Mikhail_Youzhny-Janko_Tipsarevic,Mikhail Youzhny,Janko Tipsarevic,R,R,M,20160921,St Petersburg,R32,,Center,Hard,Gianluca Moscarella,3,1,jeffsackmann
-20160919-M-St_Petersburg-R32-Alexander_Zverev-Karen_Khachanov,Alexander Zverev,Karen Khachanov,R,R,M,20160919,St Petersburg,R32,,Center,Hard,Damian Steiner,3,1,jeffsackmann
-20160918-M-Banja_Luka_CH-F-Miljan_Zekic-Adam_Pavlasek,Miljan Zekic,Adam Pavlasek,R,R,M,20160918,Banja Luka CH,F,,,Clay,,3,1,jeffsackmann
-20160916-M-Davis_Cup_World_Group_SF-RR-Andy_Murray-Juan_Martin_Del_Potro,Andy Murray,Juan Martin Del Potro,R,R,M,20160916,Davis Cup World Group SF,RR,,,Hard,Pascal Maria,5,1,jeffsackmann
-20160915-M-Szczecin_CH-R16-Casper_Ruud-Marco_Cecchinato,Casper Ruud,Marco Cecchinato,R,R,M,20160915,Szczecin CH,R16,,Centre,Clay,,3,1,jeffsackmann
-20160913-M-Szczecin_CH-R32-Casper_Ruud-Edoardo_Eremin,Casper Ruud,Edoardo Eremin,R,R,M,20160913,Szczecin CH,R32,,Center,Clay,,3,1,jeffsackmann
-20160911-M-US_Open-F-Novak_Djokovic-Stanislas_Wawrinka,Novak Djokovic,Stanislas Wawrinka,R,R,M,20160911,US Open,F,4:00 PM,Ashe,Hard,Ali Nili,5,1,Edo
-20160911-M-Seville_CH-F-Casper_Ruud-Taro_Daniel,Casper Ruud,Taro Daniel,R,R,M,20160911,Seville CH,F,,Centro,Clay,,3,1,jeffsackmann
-20160910-M-Seville_CH-SF-Casper_Ruud-Pedro_Cachin,Casper Ruud,Pedro Cachin,R,R,M,20160910,Seville CH,SF,,Centro,Clay,,3,1,jeffsackmann
-20160909-M-Seville_CH-QF-Inigo_Cervantes_Huegun-Casper_Ruud,Inigo Cervantes Huegun,Casper Ruud,R,R,M,20160909,Seville CH,QF,,Centro,Clay,,3,1,jeffsackmann
-20160908-M-US_Open-QF-Juan_Martin_Del_Potro-Stanislas_Wawrinka,Juan Martin Del Potro,Stanislas Wawrinka,R,R,M,20160908,US Open,QF,,Ashe,Hard,,5,1,Edged
-20160906-M-US_Open-QF-Lucas_Pouille-Gael_Monfils,Lucas Pouille,Gael Monfils,R,R,M,20160906,US Open,QF,,Arthur Ashe,Hard,,5,1,Edged
-20160821-M-Cincinnati_Masters-F-Andy_Murray-Marin_Cilic,Andy Murray,Marin Cilic,R,R,M,20160821,Cincinnati Masters,F,,Center,Hard,Fergus Murphy,3,1,jeffsackmann
-20160819-M-Meerbusch_CH-QF-Marc_Sieber-Florian_Mayer,Marc Sieber,Florian Mayer,L,R,M,20160819,Meerbusch CH,QF,,,Clay,,3,1,jeffsackmann
-20160814-M-Olympics-F-Andy_Murray-Juan_Martin_Del_Potro,Andy Murray,Juan Martin Del Potro,R,R,M,20160814,Olympics,F,,Center,Hard,Pascal Maria,5,1,jeffsackmann
-20160807-M-Olympics-R64-Novak_Djokovic-Juan_Martin_Del_Potro,Novak Djokovic,Juan Martin Del Potro,R,R,M,20160807,Olympics,R64,,Centre,Hard,Pascal Maria,3,1,jeffsackmann
-20160807-M-Granby_CH-F-Marcelo_Arevalo-Francis_Tiafoe,Marcelo Arevalo,Francis Tiafoe,R,R,M,20160807,Granby CH,F,,,Hard,,3,1,Isaac
-20160806-M-Finland_F1-F-Casper_Ruud-Mikael_Torpegaard,Casper Ruud,Mikael Torpegaard,R,R,M,20160806,Finland F1,F,,10,Clay,,3,1,jeffsackmann
-20160805-M-Atlanta-QF-Donald_Young-Reilly_Opelka,Donald Young,Reilly Opelka,L,R,M,20160805,Atlanta,QF,,Center,Hard,,3,1,jeffsackmann
-20160804-M-Granby_CH-R16-Gregoire_Barrere-Denis_Shapovalov,Gregoire Barrere,Denis Shapovalov,R,L,M,20160804,Granby CH,R16,,,Hard,,3,1,Isaac
-20160731-M-Canada_Masters-F-Novak_Djokovic-Kei_Nishikori,Novak Djokovic,Kei Nishikori,R,R,M,20160731,Canada Masters,F,,Centre,Hard,Carlos Bernardes,3,1,jeffsackmann
-20160731-M-Astana_CH-F-Evgeny_Donskoy-Konstantin_Kravchuk,Evgeny Donskoy,Konstantin Kravchuk,R,R,M,20160731,Astana CH,F,,,Hard,,3,1,Isaac
-20160730-M-Scheveningen_CH-SF-Yannik_Reuter-Adam_Pavlasek,Yannik Reuter,Adam Pavlasek,R,R,M,20160730,Scheveningen CH,SF,,,Clay,,3,1,jeffsackmann
-20160730-M-Lexington_CH-SF-Ernesto_Escobedo-Andrew_Whittington,Ernesto Escobedo,Andrew Whittington,R,R,M,20160730,Lexington CH,SF,,,Hard,,3,1,jeffsackmann
-20160730-M-Canada_Masters-SF-Novak_Djokovic-Gael_Monfils,Novak Djokovic,Gael Monfils,R,R,M,20160730,Canada Masters,SF,,,Hard,,3,1,Isaac
-20160729-M-Scheveningen_CH-QF-Alexey_Vatutin-Robin_Haase,Alexey Vatutin,Robin Haase,R,R,M,20160729,Scheveningen CH,QF,,,Clay,,3,1,Isaac
-20160726-M-Canada_Masters-R64-Lucas_Pouille-Emilio_Gomez,Lucas Pouille,Emilio Gomez,R,R,M,20160726,Canada Masters,R64,,1,Hard,,3,1,jeffsackmann
-20160725-M-Canada_Masters-R64-Mikhail_Youzhny-Stephane_Robert,Mikhail Youzhny,Stephane Robert,R,R,M,20160725,Canada Masters,R64,,1,Hard,Greg Allensworth,3,1,jeffsackmann
-20160725-M-Canada_Masters-R64-Kyle_Edmund-Steven_Diez,Kyle Edmund,Steven Diez,R,R,M,20160725,Canada Masters,R64,,1,Hard,Mohamed El Jennati,3,1,jeffsackmann
-20160725-M-Canada_Masters-R64-Denis_Shapovalov-Nick_Kyrgios,Denis Shapovalov,Nick Kyrgios,L,R,M,20160725,Canada Masters,R64,,Stadium,Hard,Mohamed Lahyani,3,1,jeffsackmann
-20160724-M-Washington-F-Gael_Monfils-Ivo_Karlovic,Gael Monfils,Ivo Karlovic,R,R,M,20160724,Washington,F,3:15 PM,Center,Hard,Carlos Bernardes,3,1,ChapelHeel66
-20160721-M-Umag-R16-Pablo_Cuevas-Gastao_Elias,Pablo Cuevas,Gastao Elias,R,R,M,20160721,Umag,R16,,Centre,Clay,Mohamed El Jennati,3,1,jeffsackmann
-20160720-M-Washington-R32-Taylor_Harry_Fritz-Alexander_Zverev,Taylor Harry Fritz,Alexander Zverev,R,R,M,20160720,Washington,R32,5:00 PM,Center,Hard,Zsolt Beda,3,1,ChapelHeel66
-20160719-M-Washington-R64-Ryan_Harrison-Stephane_Robert,Ryan Harrison,Stephane Robert,R,R,M,20160719,Washington,R64,,Grandstand,Hard,Carlos Bernardes,3,1,jeffsackmann
-20160718-M-Washington-R64-Dudi_Sela-Taylor_Harry_Fritz,Dudi Sela,Taylor Harry Fritz,R,R,M,20160718,Washington,R64,,Stadium,Hard,Richard Haigh,3,1,Edged
-20160718-M-Washington-R64-Dudi_Sela-Taylor_Fritz,Dudi Sela,Taylor Fritz,R,R,M,20160718,Washington,R64,,Stadium,Hard,Richard Haigh,3,1,Edged
-20160716-M-Hamburg-SF-Pablo_Cuevas-Renzo_Olivo,Pablo Cuevas,Renzo Olivo,R,R,M,20160716,Hamburg,SF,,Centre,Clay,Roland Herfel,3,1,Edged
-20160716-M-Hamburg-SF-Martin_Klizan-Stephane_Robert,Martin Klizan,Stephane Robert,L,R,M,20160716,Hamburg,SF,,Centre,Clay,Damian Steiner,3,1,Edged
-20160714-M-Hamburg-R16-Inigo_Cervantes_Huegun-Stephane_Robert,Inigo Cervantes Huegun,Stephane Robert,R,R,M,20160714,Hamburg,R16,11:00,Centre,Clay,Roland Herfel,3,1,jeffsackmann
-20160714-M-Hamburg-R16-Daniel_Gimeno_Traver-Daniil_Medvedev,Daniel Gimeno Traver,Daniil Medvedev,R,R,M,20160714,Hamburg,R16,,Centre,Clay,Damian Steiner,3,1,jeffsackmann
-20160711-M-Hamburg-R32-Florian_Mayer-Pablo_Cuevas,Florian Mayer,Pablo Cuevas,R,R,M,20160711,Hamburg,R32,,Centre,Clay,Cedric Mourier,3,1,jeffsackmann
-20160710-M-Winnetka_CH-F-Yoshihito_Nishioka-Francis_Tiafoe,Yoshihito Nishioka,Francis Tiafoe,L,R,M,20160710,Winnetka CH,F,,,Hard,,3,1,Isaac
-20160710-M-Wimbledon-F-Milos_Raonic-Andy_Murray,Milos Raonic,Andy Murray,R,R,M,20160710,Wimbledon,F,14:00:00,Centre,Grass,Jake Garner,5,0,Edo
-20160708-M-Wimbledon-SF-Milos_Raonic-Roger_Federer,Milos Raonic,Roger Federer,R,R,M,20160708,Wimbledon,SF,13:00:00,Centre,Grass,Damien Dumusois,5,0,Edged
-20160708-M-Wimbledon-SF-Andy_Murray-Tomas_Berdych,Andy Murray,Tomas Berdych,R,R,M,20160708,Wimbledon,SF,18:00,Centre,Grass,Carlos Bernardes,5,0,Edged
-20160707-M-Braunschweig_CH-R16-Mischa_Zverev-Facundo_Bagnis,Mischa Zverev,Facundo Bagnis,L,L,M,20160707,Braunschweig CH,R16,,,Clay,,3,1,jeffsackmann
-20160706-M-Wimbledon-QF-Marin_Cilic-Roger_Federer,Marin Cilic,Roger Federer,R,R,M,20160706,Wimbledon,QF,13:00:00,Centre,Grass,Pascal Maria,5,0,Edo
-20160622-M-Nottingham-R16-Daniel_Evans-Pablo_Cuevas,Daniel Evans,Pablo Cuevas,R,R,M,20160622,Nottingham,R16,,Centre,Grass,,3,1,jeffsackmann
-20160619-M-Queens_Club-F-Andy_Murray-Milos_Raonic,Andy Murray,Milos Raonic,R,R,M,20160619,Queens Club,F,,Centre,Grass,Fergus Murphy,3,1,jeffsackmann
-20160619-M-Halle-F-Florian_Mayer-Alexander_Zverev,Florian Mayer,Alexander Zverev,R,R,M,20160619,Halle,F,,Centre,Grass,Damien Dumusois,3,1,jeffsackmann
-20160619-M-Fergana_CH-F-Radu_Albot-Konstantin_Kravchuk,Radu Albot,Konstantin Kravchuk,R,R,M,20160619,Fergana CH,F,,,Hard,,3,1,Isaac
-20160615-M-Queens_Club-R32-Gilles_Simon-Kyle_Edmund,Gilles Simon,Kyle Edmund,R,R,M,20160615,Queens Club,R32,,Centre,Grass,Ali Nili,3,1,jeffsackmann
-20160614-M-Halle-R32-Brian_Baker-Florian_Mayer,Brian Baker,Florian Mayer,R,R,M,20160614,Halle,R32,11:00,Centre,Grass,Jaume Campistol,3,1,jeffsackmann
-20160613-M-Halle-R32-Lucas_Pouille-Kei_Nishikori,Lucas Pouille,Kei Nishikori,R,R,M,20160613,Halle,R32,,Centre,Grass,,3,1,jeffsackmann
-20160611-M-Stuttgart-SF-Roger_Federer-Dominic_Thiem,Roger Federer,Dominic Thiem,R,R,M,20160611,Stuttgart,SF,,,Grass,,3,0,Briton Park
-20160611-M-Caltanissetta_CH-SF-Alessandro_Giannessi-Paolo_Lorenzi,Alessandro Giannessi,Paolo Lorenzi,L,R,M,20160611,Caltanissetta CH,SF,,Centro,Clay,,3,1,jeffsackmann
-20160608-M-Halle-R16-Taylor_Harry_Fritz-Roger_Federer,Taylor Harry Fritz,Roger Federer,R,R,M,20160608,Halle,R16,,Centre,Grass,Carlos Bernardes,3,1,jeffsackmann
-20160607-M-Stuttgart-R32-Viktor_Troicki-Florian_Mayer,Viktor Troicki,Florian Mayer,R,R,M,20160607,Stuttgart,R32,,Center,Grass,Carlos Bernardes,3,1,ChapelHeel66
-20160606-M-Stuttgart-R32-Samuel_Groth-Illya_Marchenko,Samuel Groth,Illya Marchenko,R,R,M,20160606,Stuttgart,R32,,Centre,Grass,,3,1,jeffsackmann
-20160606-M-Stuttgart-Q2-Matthias_Bachinger-Florian_Mayer,Matthias Bachinger,Florian Mayer,R,R,M,20160606,Stuttgart,Q2,11:30,Centre,Grass,Roland Herfel,3,1,jeffsackmann
-20160605-M-Roland_Garros-F-Andy_Murray-Novak_Djokovic,Andy Murray,Novak Djokovic,R,R,M,20160605,Roland Garros,F,15:00,Chatrier,Clay,Damien Dumusois,5,0,jeffsackmann
-20160603-M-Roland_Garros-SF-Stanislas_Wawrinka-Andy_Murray,Stanislas Wawrinka,Andy Murray,R,R,M,20160603,Roland Garros,SF,,Philippe Chatrier,Clay,Carlos Ramos,5,0,Edged
-20160603-M-Roland_Garros-SF-Novak_Djokovic-Dominic_Thiem,Novak Djokovic,Dominic Thiem,R,R,M,20160603,Roland Garros,SF,,Suzanne Lenglen,Clay,James Keothavong,5,0,Edged
-20160528-M-Roland_Garros-R32-Alexander_Zverev-Dominic_Thiem,Alexander Zverev,Dominic Thiem,R,R,M,20160528,Roland Garros,R32,,Suzanne Lenglen Court,Clay,,5,0,Edged
-20160521-M-Nice-F-Dominic_Thiem-Alexander_Zverev,Dominic Thiem,Alexander Zverev,R,R,M,20160521,Nice,F,,Centre,Clay,Pierre Bacchi,3,1,jeffsackmann
-20160515-M-Rome_Masters-F-Andy_Murray-Novak_Djokovic,Andy Murray,Novak Djokovic,R,R,M,20160515,Rome Masters,F,,Centrale,Clay,Damian Steiner,3,1,Edged
-20160512-M-Rome_Masters-R16-David_Ferrer-Lucas_Pouille,David Ferrer,Lucas Pouille,R,R,M,20160512,Rome Masters,R16,,Grandstand,Clay,,3,1,jeffsackmann
-20160509-M-Seoul_CH-R32-Ho_Gi_Kang-Yuichi_Sugita,Ho Gi Kang,Yuichi Sugita,L,R,M,20160509,Seoul CH,R32,,,Hard,,3,1,Isaac
-20160508-M-Madrid_Masters-F-Andy_Murray-Novak_Djokovic,Andy Murray,Novak Djokovic,R,R,M,20160508,Madrid Masters,F,,Centro,Clay,Mohamed Lahyani,3,1,jeffsackmann
-20160506-M-Madrid_Masters-QF-Kei_Nishikori-Nick_Kyrgios,Kei Nishikori,Nick Kyrgios,R,R,M,20160506,Madrid Masters,QF,,Arantxa Sanchez Vicario,Clay,Renaud Lichtenstein,3,1,Edged
-20160506-M-Madrid_Masters-QF-Andy_Murray-Tomas_Berdych,Andy Murray,Tomas Berdych,R,R,M,20160506,Madrid Masters,QF,,Manolo Santana,Clay,Damian Steiner,3,1,Edged
-20160506-M-Karshi_CH-QF-Marko_Tepavac-Karen_Khachanov,Marko Tepavac,Karen Khachanov,R,R,M,20160506,Karshi CH,QF,,,Hard,,3,1,jeffsackmann
-20160505-M-Madrid-R16-Richard_Gasquet-Kei_Nishikori,Richard Gasquet,Kei Nishikori,R,R,M,20160505,Madrid,R16,,Court 3,Clay,Jaume Campistol,3,1,Edged
-20160502-M-Madrid_Masters-R64-Lucas_Pouille-David_Goffin,Lucas Pouille,David Goffin,R,R,M,20160502,Madrid Masters,R64,,Estadio 3,Clay,Greg Allensworth,3,1,jeffsackmann
-20160502-M-Karshi_CH-R32-Pavel_Tsoy-Nikola_Milojevic,Pavel Tsoy,Nikola Milojevic,R,R,M,20160502,Karshi CH,R32,,Centre Court,Hard,,3,1,Isaac
-20160501-M-Ostrava_CH-F-Zdenek_Kolar-Constant_Lestienne,Zdenek Kolar,Constant Lestienne,R,R,M,20160501,Ostrava CH,F,,,Clay,,3,1,jeffsackmann
-20160501-M-Munich-F-Dominic_Thiem-Philipp_Kohlschreiber,Dominic Thiem,Philipp Kohlschreiber,R,R,M,20160501,Munich,F,,Center Court,Clay,Damian Steiner,3,1,Edged
-20160501-M-Istanbul-F-Diego_Sebastian_Schwartzman-Grigor_Dimitrov,Diego Sebastian Schwartzman,Grigor Dimitrov,R,R,M,20160501,Istanbul,F,,,Clay,,3,1,jeffsackmann
-20160430-M-Taipei_CH-SF-Daniel_Evans-Ricardas_Berankis,Daniel Evans,Ricardas Berankis,R,R,M,20160430,Taipei CH,SF,,,Hard,,3,1,jeffsackmann
-20160427-M-Istanbul-R32-Teymuraz_Gabashvili-Damir_Dzumhur,Teymuraz Gabashvili,Damir Dzumhur,R,R,M,20160427,Istanbul,R32,,Center,Indoor Clay,Rolad Herfel,3,1,Edged
-20160425-M-Bucharest-F-Fernando_Verdasco-Lucas_Pouille,Fernando Verdasco,Lucas Pouille,L,R,M,20160425,Bucharest,F,,Center,Clay,Cedric Mourier,3,1,Edged
-20160424-M-Turin_CH-F-Enrique_Lopez_Perez-Gastao_Elias,Enrique Lopez Perez,Gastao Elias,R,R,M,20160424,Turin CH,F,,,Clay,,3,1,jeffsackmann
-20160423-M-Bucharest-SF-Federico_Delbonis-Lucas_Pouille,Federico Delbonis,Lucas Pouille,L,R,M,20160423,Bucharest,SF,,Centre,Clay,Mohamed El Jennati,3,1,jeffsackmann
-20160421-M-Barcelona-R16-Feliciano_Lopez-Philipp_Kohlschreiber,Feliciano Lopez,Philipp Kohlschreiber,L,R,M,20160421,Barcelona,R16,,Pista Central,Clay,Gianluca Moscarella,3,1,Edged
-20160420-M-Savannah_CH-R16-Tennys_Sandgren-Gerald_Melzer,Tennys Sandgren,Gerald Melzer,R,L,M,20160420,Savannah CH,R16,,Stadium Court,Clay,,3,1,Isaac
-20160417-M-Sarasota_CH-F-Gerald_Melzer-Mischa_Zverev,Gerald Melzer,Mischa Zverev,L,L,M,20160417,Sarasota CH,F,,,Clay,,3,1,jeffsackmann
-20160417-M-Monte_Carlo_Masters-F-Rafael_Nadal-Gael_Monfils,Rafael Nadal,Gael Monfils,L,R,M,20160417,Monte Carlo Masters,F,,,Clay,Carlos Bernardes,3,1,jeffsackmann
-20160416-M-Monte_Carlo_Masters-SF-Jo_Wilfried_Tsonga-Gael_Monfils,Jo Wilfried Tsonga,Gael Monfils,R,R,M,20160416,Monte Carlo Masters,SF,,Court Rainier III,Clay,Cedric Mourier,3,1,Edged
-20160415-M-Gwangju_CH-QF-Grega_Zemlja-Matt_Reid,Grega Zemlja,Matt Reid,R,R,M,20160415,Gwangju CH,QF,,,Hard,,3,1,Isaac
-20160414-M-Monte_Carlo_Masters-R16-Lucas_Pouille-Jo_Wilfried_Tsonga,Lucas Pouille,Jo Wilfried Tsonga,R,R,M,20160414,Monte Carlo Masters,R16,,,Clay,Damien Dumusois,3,1,jeffsackmann
-20160414-M-Monte_Carlo_Masters-R16-David_Goffin-Marcel_Granollers,David Goffin,Marcel Granollers,R,R,M,20160414,Monte Carlo Masters,R16,,Princes,Clay,Mohamed El Jennati,3,1,jeffsackmann
-20160413-M-Monte_Carlo_Masters-R32-Rafael_Nadal-Aljaz_Bedene,Rafael Nadal,Aljaz Bedene,L,R,M,20160413,Monte Carlo Masters,R32,,Court Rainier 3,Clay,,3,1,Isaac
-20160413-M-Monte_Carlo_Masters-R32-Paolo_Lorenzi-Gael_Monfils,Paolo Lorenzi,Gael Monfils,R,R,M,20160413,Monte Carlo Masters,R32,,,Clay,Ali Nili,3,1,jeffsackmann
-20160413-M-Monte_Carlo_Masters-R32-Novak_Djokovic-Jiri_Vesely,Novak Djokovic,Jiri Vesely,R,L,M,20160413,Monte Carlo Masters,R32,,Court Rainier III,Clay,Cedric Mourier,3,1,Edged
-20160413-M-Monte_Carlo_Masters-R32-Marcel_Granollers-Alexander_Zverev,Marcel Granollers,Alexander Zverev,R,R,M,20160413,Monte Carlo Masters,R32,,,Clay,Carlos Bernardes,3,1,jeffsackmann
-20160413-M-Monte_Carlo_Masters-R32-Dominic_Thiem-Taro_Daniel,Dominic Thiem,Taro Daniel,R,R,M,20160413,Monte Carlo Masters,R32,,2,Clay,,3,1,jeffsackmann
-20160412-M-Monte_Carlo_Masters-R64-Paolo_Lorenzi-Fabio_Fognini,Paolo Lorenzi,Fabio Fognini,R,R,M,20160412,Monte Carlo Masters,R64,,Princes,Clay,Cedric Mourier,3,1,jeffsackmann
-20160412-M-Monte_Carlo_Masters-R64-Joao_Sousa-Ivo_Karlovic,Joao Sousa,Ivo Karlovic,R,R,M,20160412,Monte Carlo Masters,R64,,9,Clay,Cedric Mourier,3,1,Edged
-20160410-M-Marrakech-F-Federico_Delbonis-Borna_Coric,Federico Delbonis,Borna Coric,L,R,M,20160410,Marrakech,F,,Centre,Clay,Mohamed Lahyani,3,1,Edged
-20160409-M-Houston-SF-John_Isner-Jack_Sock,John Isner,Jack Sock,R,R,M,20160409,Houston,SF,,Center,Clay,,3,1,Edged
-20160404-M-Marrakech-R32-Facundo_Bagnis-Lamine_Ouahab,Facundo Bagnis,Lamine Ouahab,L,R,M,20160404,Marrakech,R32,,Center,Clay,Arnaud Gabas,3,1,jeffsackmann
-20160404-M-Houston-R32-Denis_Kudla-Mischa_Zverev,Denis Kudla,Mischa Zverev,R,L,M,20160404,Houston,R32,,,Clay,,3,1,jeffsackmann
-20160403-M-Miami_Masters-F-Novak_Djokovic-Kei_Nishikori,Novak Djokovic,Kei Nishikori,R,R,M,20160403,Miami Masters,F,,Stadium,Hard,,3,1,Isaac
-20160329-M-Miami_Masters-R16-Andrey_Kuznetsov-Nick_Kyrgios,Andrey Kuznetsov,Nick Kyrgios,R,R,M,20160329,Miami Masters,R16,,,Hard,,3,1,jeffsackmann
-20160328-M-Miami_Masters-R32-Andrey_Kuznetsov-Adrian_Mannarino,Andrey Kuznetsov,Adrian Mannarino,R,L,M,20160328,Miami Masters,R32,,,Hard,,3,1,jeffsackmann
-20160328-M-Miami_Masters-R16-Roberto_Bautista_Agut-Jo_Wilfried_Tsonga,Roberto Bautista Agut,Jo Wilfried Tsonga,R,R,M,20160328,Miami Masters,R16,,Court 1,Hard,Ali Nili,3,1,Edged
-20160328-M-Miami_Masters-QF-Milos_Raonic-Nick_Kyrgios,Milos Raonic,Nick Kyrgios,R,R,M,20160328,Miami Masters,QF,,Stadium,Hard,Gianluca Moscarella,3,1,Edged
-20160327-M-Miami_Masters-R32-Viktor_Troicki-David_Goffin,Viktor Troicki,David Goffin,R,R,M,20160327,Miami Masters,R32,,Court 1,Hard,Damian Steiner,3,1,Edged
-20160327-M-Miami_Masters-R32-Tomas_Berdych-Steve_Johnson,Tomas Berdych,Steve Johnson,R,R,M,20160327,Miami Masters,R32,11:00 AM,Stadium,Hard,,3,0,Rossco
-20160327-M-Miami_Masters-R32-Richard_Gasquet-Benoit_Paire,Richard Gasquet,Benoit Paire,R,R,M,20160327,Miami Masters,R32,,Grandstand,Hard,Damien Dumusois,3,1,Edged
-20160326-M-San_Luis_Potosi_CH-SF-Marcelo_Arevalo-Federico_Gaio,Marcelo Arevalo,Federico Gaio,R,R,M,20160326,San Luis Potosi CH,SF,,,Clay,,3,1,Isaac
-20160326-M-San_Luis_Potosi_CH-SF-Albert_Montanes-Pedja_Krstin,Albert Montanes,Pedja Krstin,R,R,M,20160326,San Luis Potosi CH,SF,,,Clay,,3,1,Isaac
-20160326-M-Miami_Masters-R64-Stanislas_Wawrinka-Andrey_Kuznetsov,Stanislas Wawrinka,Andrey Kuznetsov,R,R,M,20160326,Miami Masters,R64,,,Hard,Damien Dumusois,3,1,jeffsackmann
-20160326-M-Miami_Masters-R64-John_Millman-Pablo_Cuevas,John Millman,Pablo Cuevas,R,R,M,20160326,Miami Masters,R64,,7,Hard,,3,1,jeffsackmann
-20160324-M-Miami_Masters-R128-Tommy_Paul-Tim_Smyczek,Tommy Paul,Tim Smyczek,R,R,M,20160324,Miami Masters,R128,,,Hard,Damian Steiner,3,1,jeffsackmann
-20160324-M-Miami_Masters-R128-John_Millman-Pablo_Carreno_Busta,John Millman,Pablo Carreno Busta,R,R,M,20160324,Miami Masters,R128,,,Hard,Adel Nour,3,1,jeffsackmann
-20160324-M-Miami-R128-Elias_Ymer-Federico_Delbonis,Elias Ymer,Federico Delbonis,R,L,M,20160324,Miami,R128,,,Hard,Gianluca Moscarella,3,1,jeffsackmann
-20160323-M-Miami_Masters-R128-Michael_Mmoh-Alexander_Zverev,Michael Mmoh,Alexander Zverev,R,R,M,20160323,Miami Masters,R128,,Center,Hard,Damien Dumusois,3,1,jeffsackmann
-20160323-M-Guadalajara_CH-R16-Dennis_Novikov-Eduardo_Struvay,Dennis Novikov,Eduardo Struvay,R,R,M,20160323,Guadalajara CH,R16,,,Hard,,3,1,Isaac
-20160320-M-Indian_Wells_Masters-F-Milos_Raonic-Novak_Djokovic,Milos Raonic,Novak Djokovic,R,R,M,20160320,Indian Wells Masters,F,,Stadium 1,Hard,,3,1,Isaac
-20160319-M-Indian_Wells_Masters-SF-Rafael_Nadal-Novak_Djokovic,Rafael Nadal,Novak Djokovic,L,R,M,20160319,Indian Wells Masters,SF,,Stadium 1,Hard,,3,1,Isaac
-20160318-M-Kazan_CH-QF-Ilya_Ivashka-Daniil_Medvedev,Ilya Ivashka,Daniil Medvedev,R,R,M,20160318,Kazan CH,QF,,1,Hard,,3,1,jeffsackmann
-20160317-M-Indian_Wells_Masters-QF-Marin_Cilic-David_Goffin,Marin Cilic,David Goffin,R,R,M,20160317,Indian Wells Masters,QF,,Stadium 1,Hard,Cedric Mourier,3,1,Edged
-20160316-M-Indian_Wells_Masters-R16-Jo_Wilfried_Tsonga-Dominic_Thiem,Jo Wilfried Tsonga,Dominic Thiem,R,R,M,20160316,Indian Wells Masters,R16,,Stadium 1,Hard,Fergus Murphy,3,1,Edged
-20160316-M-Indian_Wells_Masters-R16-Gael_Monfils-Federico_Delbonis,Gael Monfils,Federico Delbonis,R,L,M,20160316,Indian Wells Masters,R16,,Stadium 2,Hard,Fergus Murphy,3,1,jeffsackmann
-20160315-M-Indian_Wells_Masters-R32-Gilles_Simon-Alexander_Zverev,Gilles Simon,Alexander Zverev,R,R,M,20160315,Indian Wells Masters,R32,,Stadium 3,Hard,Mohamed Lahyani,3,1,Edged
-20160314-M-Indian_Wells_Masters-R32-Stanislas_Wawrinka-Andrey_Kuznetsov,Stanislas Wawrinka,Andrey Kuznetsov,R,R,M,20160314,Indian Wells Masters,R32,,Stadium 2,Hard,Cedric Mourier,3,1,jeffsackmann
-20160312-M-Indian_Wells_Masters-R64-Stanislas_Wawrinka-Illya_Marchenko,Stanislas Wawrinka,Illya Marchenko,R,R,M,20160312,Indian Wells Masters,R64,,Stadium 1,Hard,Renaud Lichtenstein,3,1,Edged
-20160312-M-Indian_Wells_Masters-R64-Milos_Raonic-Inigo_Cervantes_Huegun,Milos Raonic,Inigo Cervantes Huegun,R,R,M,20160312,Indian Wells Masters,R64,,Stadium 2,Hard,Mohamed Lahyani,3,1,Edged
-20160312-M-Indian_Wells_Masters-R64-Jeremy_Chardy-Andrey_Kuznetsov,Jeremy Chardy,Andrey Kuznetsov,R,R,M,20160312,Indian Wells Masters,R64,,Stadium 5,Hard,Fergus Murphy,3,1,Edged
-20160310-M-Puebla_CH-R16-Dennis_Novak-Agustin_Velotti,Dennis Novak,Agustin Velotti,R,R,M,20160310,Puebla CH,R16,,Court 1,Hard,,3,1,Isaac
-20160310-M-Indian_Wells_Masters-R128-Pablo_Carreno_Busta-Evgeny_Donskoy,Pablo Carreno Busta,Evgeny Donskoy,R,R,M,20160310,Indian Wells Masters,R128,,Stadium 5,Hard,F. Souza,3,1,Edged
-20160310-M-Indian_Wells_Masters-R128-Noah_Rubin-Rajeev_Ram,Noah Rubin,Rajeev Ram,R,R,M,20160310,Indian Wells Masters,R128,,,Hard,Fergus Murphy,3,1,jeffsackmann
-20160310-M-Indian_Wells_Masters-R128-Damir_Dzumhur-Marcel_Granollers,Damir Dzumhur,Marcel Granollers,R,R,M,20160310,Indian Wells Masters,R128,,Stadium 4,Hard,,3,1,Isaac
-20160307-M-Puebla_CH-Q3-Fernando_Romboli-Stefano_Napolitano,Fernando Romboli,Stefano Napolitano,R,R,M,20160307,Puebla CH,Q3,,Centre Court,Hard,,3,1,Isaac
-20160304-M-Quimper_CH-QF-Paul_Henri_Mathieu-Igor_Sijsling,Paul Henri Mathieu,Igor Sijsling,R,R,M,20160304,Quimper CH,QF,,,Hard,,3,1,Isaac
-20160304-M-Davis_Cup_World_Group_R1-RR-Frank_Dancevic-Gael_Monfils,Frank Dancevic,Gael Monfils,R,R,M,20160304,Davis Cup World Group R1,RR,11:00,"Velodrome Amedee-Detraux,Clay,Gianluca Moscarella,5,1,1HandBH
-20160228-M-Sao_Paulo-F-Pablo_Cuevas-Pablo_Carreno_Busta,Pablo Cuevas,Pablo Carreno Busta,R,R,M,20160228,Sao Paulo,F,,,Clay,,3,1,jeffsackmann
-20160227-M-Dubai-F-Stanislas_Wawrinka-Marcos_Baghdatis,Stanislas Wawrinka,Marcos Baghdatis,R,R,M,20160227,Dubai,F,,Center,Hard,Ali Nili,3,1,jeffsackmann
+20190327-M-Miami_Masters-R16-Daniil_Medvedev-Roger_Federer,Daniil Medvedev,Roger Federer,R,R,M,20190327.0,Miami Masters,R16,14:10,Stadium,Hard,Nacho Forcadell,3.0,1,tsitsi
+20190327-M-Miami_Masters-QF-John_Isner-Roberto_Bautista_Agut,John Isner,Roberto Bautista Agut,R,R,M,20190327.0,Miami Masters,QF,15:35,Stadium,Hard,Mohamed Lahyani,3.0,1,tsitsi
+20190326-M-Miami_Masters-R16-Borna_Coric-Nick_Kyrgios,Borna Coric,Nick Kyrgios,R,R,M,20190326.0,Miami Masters,R16,13:10,Grandstand,Hard,Gianluca Moscarella,3.0,1,tsitsi
+20190325-M-Miami_Masters-R32-Jordan_Thompson-Grigor_Dimitrov,Jordan Thompson,Grigor Dimitrov,R,R,M,20190325.0,Miami Masters,R32,10:15,1,Hard,Damian Steiner,3.0,1,tsitsi
+20190324-M-Miami_Masters-R32-Robin_Haase-Nikoloz_Basilashvili,Robin Haase,Nikoloz Basilashvili,R,R,M,20190324.0,Miami Masters,R32,15:05,1,Hard,,3.0,1,Zindaras
+20190324-M-Miami_Masters-R32-Roberto_Bautista_Agut-Fabio_Fognini,Roberto Bautista Agut,Fabio Fognini,R,R,M,20190324.0,Miami Masters,R32,12:15,1,Hard,Damian Steiner,3.0,1,tsitsi
+20190324-M-Miami_Masters-R32-Hubert_Hurkacz-Felix_Auger_Aliassime,Hubert Hurkacz,Felix Auger Aliassime,R,R,M,20190324.0,Miami Masters,R32,16:00,1,Hard,Mohamed Lahyani,3.0,1,tsitsi
+20190323-M-Miami_Masters-R64-Roger_Federer-Radu_Albot,Roger Federer,Radu Albot,R,R,M,20190323.0,Miami Masters,R64,17:50,Centre,Hard,Ali Nili,3.0,1,Zindaras
+20190323-M-Miami_Masters-R64-Marin_Cilic-Andrey_Rublev,Marin Cilic,Andrey Rublev,R,R,M,20190323.0,Miami Masters,R64,15:00,1,Hard,Mohamed Lahyani,3.0,1,tsitsi
+20190323-M-Miami_Masters-R64-David_Goffin-Pablo_Andujar,David Goffin,Pablo Andujar,R,R,M,20190323.0,Miami Masters,R64,12:10,8,Hard,Rafael Maia,3.0,1,tsitsi
+20190323-M-Miami_Masters-R64-Alexander_Zverev-David_Ferrer,Alexander Zverev,David Ferrer,R,R,M,20190323.0,Miami Masters,R64,20:35,Centre,Hard,Damian Steiner,3.0,1,Zindaras
+20190323-M-Miami_Masters-R32-Francis_Tiafoe-Miomir_Kecmanovic,Francis Tiafoe,Miomir Kecmanovic,R,R,M,20190323.0,Miami Masters,R32,18:55,1,Hard,Renaud Lichtenstein,3.0,1,tsitsi
+20190322-M-Miami_Masters-R64-Robin_Haase-Lloyd_George_Muirhead_Harris,Robin Haase,Lloyd George Muirhead Harris,R,R,M,20190322.0,Miami Masters,R64,16:30,Butch Buchholz,Hard,,3.0,1,Zindaras
+20190322-M-Miami_Masters-R64-Nick_Kyrgios-Alexander_Bublik,Nick Kyrgios,Alexander Bublik,R,R,M,20190322.0,Miami Masters,R64,15:35,Grandstand,Hard,Damian Steiner,3.0,1,tsitsi
+20190321-M-Miami_Masters-R64-Aljaz_Bedene-Adrian_Mannarino,Aljaz Bedene,Adrian Mannarino,R,L,M,20190321.0,Miami Masters,R64,9:00 PM,9,Hard,,3.0,1,Miha Mlakar
+20190321-M-Miami_Masters-R128-Lukas_Lacko-Robin_Haase,Lukas Lacko,Robin Haase,R,R,M,20190321.0,Miami Masters,R128,11:10,6,Hard,Damian Steiner,3.0,1,Zindaras
+20190321-M-Miami_Masters-R128-Leonardo_Mayer-Mikael_Ymer,Leonardo Mayer,Mikael Ymer,R,R,M,20190321.0,Miami Masters,R128,10:05,Butch Buchholz,Hard,Ali Nili,3.0,1,tsitsi
+20190321-M-Miami_Masters-R128-Chun_Hsin_Tseng-Joao_Sousa,Chun Hsin Tseng,Joao Sousa,R,R,M,20190321.0,Miami Masters,R128,16:30,1,Hard,Gianluca Moscarella,3.0,1,tsitsi
+20190317-M-Indian_Wells_Masters-F-Roger_Federer-Dominic_Thiem,Roger Federer,Dominic Thiem,R,R,M,20190317.0,Indian Wells Masters,F,16:10,Stadium 1,Hard,Mohamed Lahyani,3.0,1,Zindaras
+20190316-M-Indian_Wells_Masters-SF-Milos_Raonic-Dominic_Thiem,Milos Raonic,Dominic Thiem,R,R,M,20190316.0,Indian Wells Masters,SF,11:05,Stadium 1,Hard,Carlos Bernardes,3.0,1,tsitsi
+20190315-M-Indian_Wells_Masters-QF-Rafael_Nadal-Karen_Khachanov,Rafael Nadal,Karen Khachanov,L,R,M,20190315.0,Indian Wells Masters,QF,13:40,Stadium 1,Hard,Mohamed Lahyani,3.0,1,tsitsi
+20190315-M-Indian_Wells_Masters-QF-Hubert_Hurkacz-Roger_Federer,Hubert Hurkacz,Roger Federer,R,R,M,20190315.0,Indian Wells Masters,QF,11:10,Stadium 1,Hard,,3.0,1,Zindaras
+20190314-M-Indian_Wells_Masters-QF-Milos_Raonic-Miomir_Kecmanovic,Milos Raonic,Miomir Kecmanovic,R,R,M,20190314.0,Indian Wells Masters,QF,13:40,Stadium 1,Hard,Renaud Lichtenstein,3.0,1,tsitsi
+20190313-M-Indian_Wells_Masters-R16-Roger_Federer-Kyle_Edmund,Roger Federer,Kyle Edmund,R,R,M,20190313.0,Indian Wells Masters,R16,14:20,Stadium 1,Hard,,3.0,1,Zindaras
+20190313-M-Indian_Wells_Masters-R16-Hubert_Hurkacz-Denis_Shapovalov,Hubert Hurkacz,Denis Shapovalov,R,L,M,20190313.0,Indian Wells Masters,R16,12:50,Stadium 3,Hard,Renaud Lichtenstein,3.0,1,tsitsi
+20190313-M-Indian_Wells_Masters-R16-Gael_Monfils-Philipp_Kohlschreiber,Gael Monfils,Philipp Kohlschreiber,R,R,M,20190313.0,Indian Wells Masters,R16,20:45,Stadium 1,Hard,Mohamed Lahyani,3.0,1,Zindaras
+20190312-M-Indian_Wells_Masters-R32-Kyle_Edmund-Radu_Albot,Kyle Edmund,Radu Albot,R,R,M,20190312.0,Indian Wells Masters,R32,16:35,Stadium 2,Hard,Greg Allensworth,3.0,1,tsitsi
+20190312-M-Indian_Wells_Masters-R32-Filip_Krajinovic-Daniil_Medvedev,Filip Krajinovic,Daniil Medvedev,R,R,M,20190312.0,Indian Wells Masters,R32,11:10,Stadium 3,Hard,Jimmy Pinoargote,3.0,1,tsitsi
+20190311-M-Indian_Wells_Masters-R32-Novak_Djokovic-Philipp_Kohlschreiber,Novak Djokovic,Philipp Kohlschreiber,R,R,M,20190311.0,Indian Wells Masters,R32,20:10,Stadium 1,Hard,,3.0,1,Zindaras
+20190311-M-Indian_Wells_Masters-R32-Laslo_Djere-Miomir_Kecmanovic,Laslo Djere,Miomir Kecmanovic,R,R,M,20190311.0,Indian Wells Masters,R32,14:25,Stadium 4,Hard,Patricio Estevez,3.0,1,tsitsi
+20190311-M-Indian_Wells_Masters-R32-Jan_Lennard_Struff-Alexander_Zverev,Jan Lennard Struff,Alexander Zverev,R,R,M,20190311.0,Indian Wells Masters,R32,13:25,Stadium 1,Hard,Ali Nili,3.0,1,tsitsi
+20190311-M-Indian_Wells_Masters-R32-Ivo_Karlovic-Prajnesh_Gunneswaran,Ivo Karlovic,Prajnesh Gunneswaran,R,L,M,20190311.0,Indian Wells Masters,R32,12:55,Stadium 4,Hard,Mohamed Lahyani,3.0,1,Zindaras
+20190310-M-Indian_Wells_Masters-R64-Lucas_Pouille-Hubert_Hurkacz,Lucas Pouille,Hubert Hurkacz,R,R,M,20190310.0,Indian Wells Masters,R64,18:10,Stadium 9,Hard,Jimmy Pinoargote,3.0,1,tsitsi
+20190310-M-Indian_Wells_Masters-R64-Fabio_Fognini-Radu_Albot,Fabio Fognini,Radu Albot,R,R,M,20190310.0,Indian Wells Masters,R64,14:40,Stadium 6,Hard,Ali Nili,3.0,1,tsitsi
+20190310-M-Indian_Wells_Masters-R64-Andrey_Rublev-Robin_Haase,Andrey Rublev,Robin Haase,R,R,M,20190310.0,Indian Wells Masters,R64,11:00,Stadium 5,Hard,Renuad Lichtenstein,3.0,1,Zindaras
+20190310-M-Indian_Wells_Masters-R64-Alex_Bolt-Guido_Pella,Alex Bolt,Guido Pella,L,L,M,20190310.0,Indian Wells Masters,R64,14:30,Stadium 9,Hard,Greg Allensworth,3.0,1,tsitsi
+20190309-M-Indian_Wells_Masters-R64-Stefanos_Tsitsipas-Felix_Auger_Aliassime,Stefanos Tsitsipas,Felix Auger Aliassime,R,R,M,20190309.0,Indian Wells Masters,R64,11:10,Stadium 1,Hard,Fergus Murphy,3.0,1,tsitsi
+20190309-M-Indian_Wells_Masters-R64-Miomir_Kecmanovic-Maximilian_Marterer,Miomir Kecmanovic,Maximilian Marterer,R,L,M,20190309.0,Indian Wells Masters,R64,11:10,Stadium 5,Hard,Ali Nili,3.0,1,tsitsi
+20190309-M-Indian_Wells_Masters-R64-Marco_Cecchinato-Albert_Ramos,Marco Cecchinato,Albert Ramos,R,L,M,20190309.0,Indian Wells Masters,R64,13:35,Stadium 6,Hard,Patricio Estevez,3.0,1,tsitsi
+20190309-M-Indian_Wells_Masters-R64-Leonardo_Mayer-Gael_Monfils,Leonardo Mayer,Gael Monfils,R,R,M,20190309.0,Indian Wells Masters,R64,12:50,Stadium 1,Hard,Carlos Bernardes,3.0,1,Zindaras
+20190308-M-Indian_Wells_Masters-R128-Tomas_Berdych-Feliciano_Lopez,Tomas Berdych,Feliciano Lopez,R,L,M,20190308.0,Indian Wells Masters,R128,11:10,Stadium 2,Hard,Ali Nili,3.0,1,tsitsi
+20190308-M-Indian_Wells_Masters-R128-Taylor_Harry_Fritz-Steve_Johnson,Taylor Harry Fritz,Steve Johnson,R,R,M,20190308.0,Indian Wells Masters,R128,14:35,Stadium 1,Hard,Greg Allensworth,3.0,1,tsitsi
+20190308-M-Indian_Wells_Masters-R128-Taro_Daniel-Dusan_Lajovic,Taro Daniel,Dusan Lajovic,R,R,M,20190308.0,Indian Wells Masters,R128,12:45 PM,Stadium 4,Hard,Mohamed Fitouhi,3.0,1,tsitsi
+20190308-M-Indian_Wells_Masters-R128-Denis_Istomin-Robin_Haase,Denis Istomin,Robin Haase,R,R,M,20190308.0,Indian Wells Masters,R128,,Stadium 9,Hard,Mohamed Lahyani,3.0,1,Zindaras
+20190308-M-Indian_Wells_Masters-R128-Alexei_Popyrin-Jaume_Munar,Alexei Popyrin,Jaume Munar,R,R,M,20190308.0,Indian Wells Masters,R128,13:00,Stadium 5,Hard,Patricio Estevez,3.0,1,tsitsi
+20190307-M-Indian_Wells_Masters-R128-Martin_Klizan-Mischa_Zverev,Martin Klizan,Mischa Zverev,L,L,M,20190307.0,Indian Wells Masters,R128,Day,Stadium 4,Hard,Greg Allensworth,3.0,1,Adam Taylor
+20190307-M-Indian_Wells_Masters-R128-Marcos_Giron-Jeremy_Chardy,Marcos Giron,Jeremy Chardy,R,R,M,20190307.0,Indian Wells Masters,R128,14:55,Stadium 5,Hard,Mohamed Fitouhi,3.0,1,tsitsi
+20190307-M-Indian_Wells_Masters-R128-Ilya_Ivashka-Guido_Andreozzi,Ilya Ivashka,Guido Andreozzi,R,R,M,20190307.0,Indian Wells Masters,R128,11:10,Stadium 6,Hard,Ali Nili,3.0,1,tsitsi
+20190307-M-Indian_Wells_Masters-R128-Felix_Auger_Aliassime-Cameron_Norrie,Felix Auger Aliassime,Cameron Norrie,R,L,M,20190307.0,Indian Wells Masters,R128,11:10,Stadium 1,Hard,,3.0,1,Zindaras
+20190304-M-Zhuhai_CH-R64-Jose_Hernandez-Karim_Mohamed_Maamoun,Jose Hernandez,Karim Mohamed Maamoun,R,R,M,20190304.0,Zhuhai CH,R64,11:30 AM,2,Hard,,3.0,1,ahmedabdelaal
+20190302-M-Sao_Paulo-SF-Casper_Ruud-Christian_Garin,Casper Ruud,Christian Garin,R,R,M,20190302.0,Sao Paulo,SF,12:40,Centre,Clay,Nacho Forcadell,3.0,1,tsitsi
+20190302-M-Dubai-F-Stefanos_Tsitsipas-Roger_Federer,Stefanos Tsitsipas,Roger Federer,R,R,M,20190302.0,Dubai,F,19:15,Centre,Hard,Ali Nili,3.0,1,Zindaras
+20190301-M-Sao_Paulo-QF-Casper_Ruud-Hugo_Dellien,Casper Ruud,Hugo Dellien,R,R,M,20190301.0,Sao Paulo,QF,14:45,Centre,Clay,Fabio Souza,3.0,1,tsitsi
+20190301-M-Dubai-SF-Stefanos_Tsitsipas-Gael_Monfils,Stefanos Tsitsipas,Gael Monfils,R,R,M,20190301.0,Dubai,SF,17:10,Centre,Hard,Jaume Capistol,3.0,1,tsitsi
+20190301-M-Dubai-SF-Borna_Coric-Roger_Federer,Borna Coric,Roger Federer,R,R,M,20190301.0,Dubai,SF,20:25,Centre,Hard,Mohamed El Jennati,3.0,1,Zindaras
+20190301-M-Acapulco-SF-John_Isner-Nick_Kyrgios,John Isner,Nick Kyrgios,R,R,M,20190301.0,Acapulco,SF,22:45,Centre,Hard,Aurelie Tourte,3.0,1,tsitsi
+20190228-M-Dubai-QF-Stefanos_Tsitsipas-Hubert_Hurkacz,Stefanos Tsitsipas,Hubert Hurkacz,R,R,M,20190228.0,Dubai,QF,17:30,Centre,Hard,Ahmed Abdel-Azim,3.0,1,tsitsi
+20190228-M-Dubai-QF-Roger_Federer-Marton_Fucsovics,Roger Federer,Marton Fucsovics,R,R,M,20190228.0,Dubai,QF,20:10,Centre,Hard,Jaume Campistol,3.0,1,Zindaras
+20190228-M-Dubai-QF-Gael_Monfils-Ricardas_Berankis,Gael Monfils,Ricardas Berankis,R,R,M,20190228.0,Dubai,QF,15:15,Centre,Hard,Mohamed el Jenatti,3.0,1,Zindaras
+20190228-M-Dubai-QF-Borna_Coric-Nikoloz_Basilashvili,Borna Coric,Nikoloz Basilashvili,R,R,M,20190228.0,Dubai,QF,22:30,Centre,Hard,Julie Kjendlie,3.0,1,tsitsi
+20190228-M-Acapulco-QF-Nick_Kyrgios-Stanislas_Wawrinka,Nick Kyrgios,Stanislas Wawrinka,R,R,M,20190228.0,Acapulco,QF,20:30,Cancha Central,Hard,Damian Steiner,3.0,1,Zindaras
+20190228-M-Acapulco-QF-Mackenzie_Mcdonald-Cameron_Norrie,Mackenzie Mcdonald,Cameron Norrie,R,L,M,20190228.0,Acapulco,QF,17:15,Centre,Hard,Simon Cannavan,3.0,1,tsitsi
+20190227-M-Sao_Paulo-R16-Thiago_Seyboth_Wild-Marco_Trungelliti,Thiago Seyboth Wild,Marco Trungelliti,R,R,M,20190227.0,Sao Paulo,R16,22:05,Centre,Clay,Nacho Forcadell,3.0,1,tsitsi
+20190227-M-Dubai-R16-Roger_Federer-Fernando_Verdasco,Roger Federer,Fernando Verdasco,R,L,M,20190227.0,Dubai,R16,19:15,Centre,Hard,Ali Nili,3.0,1,Zindaras
+20190227-M-Dubai-R16-Ricardas_Berankis-Denis_Kudla,Ricardas Berankis,Denis Kudla,R,R,M,20190227.0,Dubai,R16,14:10,1,Hard,Julie Kjendlie,3.0,1,tsitsi
+20190227-M-Dubai-R16-Gael_Monfils-Marcos_Baghdatis,Gael Monfils,Marcos Baghdatis,R,R,M,20190227.0,Dubai,R16,17:50,Centre,Hard,Ahmed Abdel-Azim,3.0,1,Zindaras
+20190227-M-Acapulco-R16-Rafael_Nadal-Nick_Kyrgios,Rafael Nadal,Nick Kyrgios,L,R,M,20190227.0,Acapulco,R16,20:10,Cancha Central,Hard,Damian Steiner,3.0,1,Zindaras
+20190227-M-Acapulco-R16-David_Ferrer-Alexander_Zverev,David Ferrer,Alexander Zverev,R,R,M,20190227.0,Acapulco,R16,23:30,Cancha Central,Hard,,3.0,1,Zindaras
+20190226-M-Dubai-R32-Marin_Cilic-Gael_Monfils,Marin Cilic,Gael Monfils,R,R,M,20190226.0,Dubai,R32,19:15,Centre,Hard,Jaume Campistol,3.0,1,Zindaras
+20190226-M-Dubai-R32-Egor_Gerasimov-Robin_Haase,Egor Gerasimov,Robin Haase,R,R,M,20190226.0,Dubai,R32,14:00,1,Hard,Jaume Campistol,3.0,1,Zindaras
+20190226-M-Acapulco-R32-Rafael_Nadal-Mischa_Zverev,Rafael Nadal,Mischa Zverev,L,L,M,20190226.0,Acapulco,R32,19:45,Centre,Hard,Damian Steiner,3.0,1,Zindaras
+20190225-M-Dubai-R32-Nikoloz_Basilashvili-Karen_Khachanov,Nikoloz Basilashvili,Karen Khachanov,R,R,M,20190225.0,Dubai,R32,16:30,Centre,Hard,Jaume Campistol,3.0,1,Zindaras
+20190223-M-Marseille-SF-Ugo_Humbert-Mikhail_Kukushkin,Ugo Humbert,Mikhail Kukushkin,L,R,M,20190223.0,Marseille,SF,15:10,Centre,Hard,Manuel Messina,3.0,1,tsitsi
+20190223-M-Marseille-SF-Stefanos_Tsitsipas-David_Goffin,Stefanos Tsitsipas,David Goffin,R,R,M,20190223.0,Marseille,SF,17:05,Centre,Hard,Gianluca Moscarella,3.0,1,tsitsi
+20190223-M-Delray_Beach-SF-Mackenzie_Mcdonald-Radu_Albot,Mackenzie Mcdonald,Radu Albot,R,R,M,20190223.0,Delray Beach,SF,20:10,Centre,Hard,Fergus Murphy,3.0,1,tsitsi
+20190222-M-Rio_de_Janeiro-QF-Jaume_Munar-Felix_Auger_Aliassime,Jaume Munar,Felix Auger Aliassime,R,R,M,20190222.0,Rio de Janeiro,QF,19:55,Centre,Clay,Adel Nour,3.0,1,tsitsi
+20190222-M-Marseille-QF-Ugo_Humbert-Matthias_Bachinger,Ugo Humbert,Matthias Bachinger,L,R,M,20190222.0,Marseille,QF,15:30,Centre,Hard,Gianluca Moscarella,3.0,1,tsitsi
+20190222-M-Bergamo_CH-QF-Jannik_Sinner-Gianluigi_Quinzi,Jannik Sinner,Gianluigi Quinzi,R,L,M,20190222.0,Bergamo CH,QF,,,Hard,,3.0,1,Isaac
+20190221-M-Rio_de_Janeiro-R16-Pablo_Cuevas-Juan_Ignacio_Londero,Pablo Cuevas,Juan Ignacio Londero,R,R,M,20190221.0,Rio de Janeiro,R16,19:15,Centre,Clay,Mohamed Lahyani,3.0,1,tsitsi
+20190221-M-Marseille-R16-Ugo_Humbert-Borna_Coric,Ugo Humbert,Borna Coric,L,R,M,20190221.0,Marseille,R16,15:50,Centre,Hard,Richard Haigh,3.0,1,tsitsi
+20190220-M-Rio_de_Janeiro-R16-Roberto_Carballes_Baena-Hugo_Dellien,Roberto Carballes Baena,Hugo Dellien,R,R,M,20190220.0,Rio de Janeiro,R16,17:50,2,Clay,,3.0,1,tsitsi
+20190220-M-Delray_Beach-R16-Daniel_Evans-Lloyd_George_Muirhead_Harris,Daniel Evans,Lloyd George Muirhead Harris,R,R,M,20190220.0,Delray Beach,R16,14:45,Stadium,Hard,Fergus Murphy,3.0,1,tsitsi
+20190219-M-Rio_de_Janeiro-R32-Thiago_Monteiro-Pedro_Sousa,Thiago Monteiro,Pedro Sousa,L,R,M,20190219.0,Rio de Janeiro,R32,18:40,Centre,Clay,Mohamed Lahyani,3.0,1,tsitsi
+20190219-M-Bergamo_CH-R32-Elliot_Benchetrit-Tallon_Griekspoor,Elliot Benchetrit,Tallon Griekspoor,R,R,M,20190219.0,Bergamo CH,R32,13:45,Palazetto Alzano,Hard,,3.0,1,Zindaras
+20190217-M-Rotterdam-F-Stanislas_Wawrinka-Gael_Monfils,Stanislas Wawrinka,Gael Monfils,R,R,M,20190217.0,Rotterdam,F,15:20,Centre,Hard,,3.0,1,Zindaras
+20190217-M-New_York-F-Reilly_Opelka-Brayden_Schnur,Reilly Opelka,Brayden Schnur,R,R,M,20190217.0,New York,F,16:10,Centre,Hard,Fergus Murphy,3.0,1,tsitsi
+20190216-M-Rotterdam-SF-Stanislas_Wawrinka-Kei_Nishikori,Stanislas Wawrinka,Kei Nishikori,R,R,M,20190216.0,Rotterdam,SF,19:40,Centre,Hard,Manuel Messina,3.0,1,tsitsi
+20190216-M-New_York-SF-Sam_Querrey-Brayden_Schnur,Sam Querrey,Brayden Schnur,R,R,M,20190216.0,New York,SF,,,Hard,,3.0,1,Edged
+20190216-M-New_York-SF-John_Isner-Reilly_Opelka,John Isner,Reilly Opelka,R,R,M,20190216.0,New York,SF,19:15,Stadium Court,Hard,Damiano Torella,3.0,1,Zindaras
+20190216-M-Buenos_Aires-SF-Marco_Cecchinato-Guido_Pella,Marco Cecchinato,Guido Pella,R,L,M,20190216.0,Buenos Aires,SF,14:10,Vilas,Clay,Rafael Maia,3.0,1,tsitsi
+20190215-M-Rotterdam-QF-Gael_Monfils-Damir_Dzumhur,Gael Monfils,Damir Dzumhur,R,R,M,20190215.0,Rotterdam,QF,12:40,Centre,Hard,Richard Haigh,3.0,1,tsitsi
+20190215-M-Rotterdam-QF-Denis_Shapovalov-Stanislas_Wawrinka,Denis Shapovalov,Stanislas Wawrinka,L,R,M,20190215.0,Rotterdam,QF,,,Hard,,3.0,1,Edged
+20190215-M-New_York-QF-Reilly_Opelka-Guillermo_Garcia_Lopez,Reilly Opelka,Guillermo Garcia Lopez,R,R,M,20190215.0,New York,QF,16:55,Centre,Hard,Simon Cannavan,3.0,1,tsitsi
+20190215-M-New_York-QF-Paolo_Lorenzi-Brayden_Schnur,Paolo Lorenzi,Brayden Schnur,R,R,M,20190215.0,New York,QF,12:15,Centre,Hard,Gregory Allensworth,3.0,1,tsitsi
+20190215-M-Buenos_Aires-QF-Jaume_Munar-Guido_Pella,Jaume Munar,Guido Pella,R,L,M,20190215.0,Buenos Aires,QF,16:50,Centre,Clay,Mohamed Lahyani,3.0,1,tsitsi
+20190214-M-Rotterdam-R16-Mikhail_Kukushkin-Damir_Dzumhur,Mikhail Kukushkin,Damir Dzumhur,R,R,M,20190214.0,Rotterdam,R16,11:10,Centre,Hard,Richard Haigh,3.0,1,tsitsi
+20190214-M-Rotterdam-R16-Marton_Fucsovics-Nikoloz_Basilashvili,Marton Fucsovics,Nikoloz Basilashvili,R,R,M,20190214.0,Rotterdam,R16,9:20 PM,Centre,Hard,,3.0,1,Zindaras
+20190214-M-Rotterdam-R16-Jo_Wilfried_Tsonga-Tallon_Griekspoor,Jo Wilfried Tsonga,Tallon Griekspoor,R,R,M,20190214.0,Rotterdam,R16,15:10,Centre,Hard,,3.0,1,Zindaras
+20190214-M-Rotterdam-R16-Fernando_Verdasco-Daniil_Medvedev,Fernando Verdasco,Daniil Medvedev,L,R,M,20190214.0,Rotterdam,R16,,,Hard,,3.0,1,Edged
+20190214-M-New_York-R16-Jason_Jung-Francis_Tiafoe,Jason Jung,Francis Tiafoe,R,R,M,20190214.0,New York,R16,19:45,Centre,Hard,Fergus Murphy,3.0,1,tsitsi
+20190213-M-Rotterdam-R32-Marton_Fucsovics-Martin_Klizan,Marton Fucsovics,Martin Klizan,R,L,M,20190213.0,Rotterdam,R32,11:10,1,Hard,Renaud Lichtenstein,3.0,1,tsitsi
+20190213-M-New_York-R16-Jordan_Thompson-Christopher_Eubanks,Jordan Thompson,Christopher Eubanks,R,R,M,20190213.0,New York,R16,13:50,Grandstand,Hard,,3.0,1,tsitsi
+20190213-M-Buenos_Aires-R16-Roberto_Carballes_Baena-Lorenzo_Sonego,Roberto Carballes Baena,Lorenzo Sonego,R,R,M,20190213.0,Buenos Aires,R16,14:45,Centre,Clay,Damian Steiner,3.0,1,tsitsi
+20190212-M-Rotterdam-R32-Ernests_Gulbis-Marius_Copil,Ernests Gulbis,Marius Copil,R,R,M,20190212.0,Rotterdam,R32,11:15,1,Hard,Gianluca Moscarella,3.0,1,tsitsi
+20190212-M-Rotterdam-R32-Denis_Shapovalov-Franco_Skugor,Denis Shapovalov,Franco Skugor,L,R,M,20190212.0,Rotterdam,R32,13:10,Centre,Hard,,3.0,1,tsitsi
+20190212-M-Bangkok_CH-R32-Zhe_Li-Thiemo_De_Bakker,Zhe Li,Thiemo De Bakker,R,R,M,20190212.0,Bangkok CH,R32,13:55,4,Hard,,3.0,1,Zindaras
+20190211-M-Rotterdam-R32-Robin_Haase-Mikhail_Kukushkin,Robin Haase,Mikhail Kukushkin,R,R,M,20190211.0,Rotterdam,R32,15:30,Centre,Hard,,3.0,1,Zindaras
+20190211-M-Rotterdam-R32-Peter_Gojowczyk-Andreas_Seppi,Peter Gojowczyk,Andreas Seppi,R,R,M,20190211.0,Rotterdam,R32,13:10,Centre,Hard,Richard Haigh,3.0,1,tsitsi
+20190211-M-Rotterdam-R32-Nikoloz_Basilashvili-Hyeon_Chung,Nikoloz Basilashvili,Hyeon Chung,R,R,M,20190211.0,Rotterdam,R32,,,Hard,,3.0,1,Edged
+20190210-M-Sofia-F-Marton_Fucsovics-Daniil_Medvedev,Marton Fucsovics,Daniil Medvedev,R,R,M,20190210.0,Sofia,F,,,Hard,,3.0,1,Edged
+20190210-M-Cordoba-F-Guido_Pella-Juan_Ignacio_Londero,Guido Pella,Juan Ignacio Londero,L,R,M,20190210.0,Cordoba,F,19:35,Centre,Clay,Mohamed Lahyani,3.0,1,tsitsi
+20190210-M-Chennai_CH-F-Andrew_Harris-Corentin_Moutet,Andrew Harris,Corentin Moutet,R,L,M,20190210.0,Chennai CH,F,15:05,Centre,Hard,,3.0,1,tsitsi
+20190209-M-Sofia-SF-Gael_Monfils-Daniil_Medvedev,Gael Monfils,Daniil Medvedev,R,R,M,20190209.0,Sofia,SF,18:15,Centre,Hard,Adel Nour,3.0,1,tsitsi
+20190209-M-Montpellier-SF-Jo_Wilfried_Tsonga-Radu_Albot,Jo Wilfried Tsonga,Radu Albot,R,R,M,20190209.0,Montpellier,SF,17:05,Centre,Hard,Gianluca Moscarella,3.0,1,tsitsi
+20190208-M-Sofia-QF-Stefanos_Tsitsipas-Gael_Monfils,Stefanos Tsitsipas,Gael Monfils,R,R,M,20190208.0,Sofia,QF,,,Hard,,3.0,1,Isaac
+20190208-M-Sofia-QF-Fernando_Verdasco-Matteo_Berrettini,Fernando Verdasco,Matteo Berrettini,L,R,M,20190208.0,Sofia,QF,12:15,Centre,Hard,Mohamed Fitouhi,3.0,1,tsitsi
+20190208-M-Montpellier-QF-Denis_Shapovalov-Pierre_Hugues_Herbert,Denis Shapovalov,Pierre Hugues Herbert,L,R,M,20190208.0,Montpellier,QF,,,Hard,Gianluca Moscarella,3.0,1,Edged
+20190208-M-Dallas_CH-QF-Reilly_Opelka-Dominik_Koepfer,Reilly Opelka,Dominik Koepfer,R,L,M,20190208.0,Dallas CH,QF,,Centre,Hard,,3.0,1,Zindaras
+20190208-M-Cordoba-QF-Pedro_Cachin-Juan_Ignacio_Londero,Pedro Cachin,Juan Ignacio Londero,R,R,M,20190208.0,Cordoba,QF,18:10,Centre,Clay,Mohamed Lahyani,3.0,1,tsitsi
+20190208-M-Cordoba-QF-Jaume_Munar-Federico_Delbonis,Jaume Munar,Federico Delbonis,R,L,M,20190208.0,Cordoba,QF,15:50,Centre,Clay,Mohamed El Jennati,3.0,1,tsitsi
+20190207-M-Sofia-R16-Yannick_Maden-Marton_Fucsovics,Yannick Maden,Marton Fucsovics,R,R,M,20190207.0,Sofia,R16,11:10,1,Hard,,3.0,1,tsitsi
+20190207-M-Sofia-R16-Stefanos_Tsitsipas-Jan_Lennard_Struff,Stefanos Tsitsipas,Jan Lennard Struff,R,R,M,20190207.0,Sofia,R16,,Centre,Hard,,3.0,1,Michal
+20190206-M-Sofia-R32-Mikhail_Kukushkin-Laslo_Djere,Mikhail Kukushkin,Laslo Djere,R,R,M,20190206.0,Sofia,R32,11:10,1,Hard,,3.0,1,tsitsi
+20190206-M-Cordoba-R16-Juan_Ignacio_Londero-Lorenzo_Sonego,Juan Ignacio Londero,Lorenzo Sonego,R,R,M,20190206.0,Cordoba,R16,11:20,Centre,Clay,Mohamed El Jennati,3.0,1,tsitsi
+20190205-M-Sofia-R32-Gael_Monfils-Viktor_Troicki,Gael Monfils,Viktor Troicki,R,R,M,20190205.0,Sofia,R32,,,Hard,,3.0,1,Isaac
+20190205-M-Montpellier-R32-Hubert_Hurkacz-Ernests_Gulbis,Hubert Hurkacz,Ernests Gulbis,R,R,M,20190205.0,Montpellier,R32,12:10 PM,1,Hard,,3.0,1,tsitsi
+20190205-M-Cordoba-R32-Jaume_Munar-Guido_Andreozzi,Jaume Munar,Guido Andreozzi,R,R,M,20190205.0,Cordoba,R32,,,Clay,,3.0,1,Edged
+20190204-M-Dallas_CH-R64-Michael_Redlicki-Goncalo_Oliveira,Michael Redlicki,Goncalo Oliveira,L,L,M,20190204.0,Dallas CH,R64,,1,Hard,,3.0,1,Zindaras
+20190204-M-Dallas_CH-Q1-Gijs_Brouwer-Martin_Redlicki,Gijs Brouwer,Martin Redlicki,L,L,M,20190204.0,Dallas CH,Q1,10:00 AM,Centre,Hard,,3.0,1,Zindaras
+20190204-M-Cordoba-R32-Cameron_Norrie-Pedro_Cachin,Cameron Norrie,Pedro Cachin,L,R,M,20190204.0,Cordoba,R32,5:35 PM,Centre,Clay,Mohamed El Jennati,3.0,1,tsitsi
+20190204-M-Cordoba-R16-Albert_Ramos-Guido_Pella,Albert Ramos,Guido Pella,L,L,M,20190204.0,Cordoba,R16,Evening,,Clay,Rafael Maia,3.0,1,Adam Taylor
+20190203-M-Launceston_CH-F-Lorenzo_Giustino-Lloyd_George_Muirhead_Harris,Lorenzo Giustino,Lloyd George Muirhead Harris,R,R,M,20190203.0,Launceston CH,F,12:55 PM,Centre,Hard,,3.0,1,tsitsi
+20190202-M-Davis_Cup_Qualifiers-RR-Jiri_Lehecka-Robin_Haase,Jiri Lehecka,Robin Haase,R,R,M,20190202.0,Davis Cup Qualifiers,RR,16:20,,Hard,Manuel Absolu,3.0,1,Zindaras
+20190202-M-Davis_Cup_Qualifiers-RR-Felix_Auger_Aliassime-Norbert_Gombos,Felix Auger Aliassime,Norbert Gombos,R,R,M,20190202.0,Davis Cup Qualifiers,RR,,,Clay,,3.0,1,marct
+20190202-M-Davis_Cup_Qualifiers-RR-Denis_Shapovalov-Martin_Klizan,Denis Shapovalov,Martin Klizan,L,L,M,20190202.0,Davis Cup Qualifiers,RR,,Centre,Clay,,3.0,1,Michal
+20190201-M-Davis_Cup_Qualifiers-RR-Prajnesh_Gunneswaran-Matteo_Berrettini,Prajnesh Gunneswaran,Matteo Berrettini,L,R,M,20190201.0,Davis Cup Qualifiers,RR,12:55 PM,Kolkata,Grass,Thomas Sweeney,3.0,1,tsitsi
+20190201-M-Davis_Cup_Qualifiers-RR-Lukas_Rosol-Robin_Haase,Lukas Rosol,Robin Haase,R,R,M,20190201.0,Davis Cup Qualifiers,RR,17:55,,Hard,Nico Helwerth,3.0,1,Zindaras
+20190201-M-Davis_Cup_Qualifiers-RR-Felix_Auger_Aliassime-Martin_Klizan,Felix Auger Aliassime,Martin Klizan,R,L,M,20190201.0,Davis Cup Qualifiers,RR,5:10 PM,Bratislava,Clay,Pierre Bacchi,3.0,1,tsitsi
+20190127-M-Rennes_CH-F-Antonie_Hoang-Ricardas_Berankis,Antonie Hoang,Ricardas Berankis,R,R,M,20190127.0,Rennes CH,F,3:40 PM,Centre,Hard,,3.0,1,tsitsi
+20190127-M-Newport_Beach_CH-F-Taylor_Harry_Fritz-Brayden_Schnur,Taylor Harry Fritz,Brayden Schnur,R,R,M,20190127.0,Newport Beach CH,F,,Center,Hard,,3.0,1,Matej
+20190125-M-Australian_Open-SF-Novak_Djokovic-Lucas_Pouille,Novak Djokovic,Lucas Pouille,R,R,M,20190125.0,Australian Open,SF,7:50 PM,Rod Laver Arena,Hard,John Blom,5.0,A,MaGav
+20190124-M-Australian_Open-SF-Stefanos_Tsitsipas-Rafael_Nadal,Stefanos Tsitsipas,Rafael Nadal,R,L,M,20190124.0,Australian Open,SF,7:50 PM,Rod Laver Arena,Hard,Damien Dumusois,5.0,A,MaGav
+20190123-M-Australian_Open-QF-Novak_Djokovic-Kei_Nishikori,Novak Djokovic,Kei Nishikori,R,R,M,20190123.0,Australian Open,QF,7:45 PM,Rod Laver Arena,Hard,Carlos Bernardes,5.0,A,MaGav
+20190122-M-Australian_Open-QF-Rafael_Nadal-Francis_Tiafoe,Rafael Nadal,Francis Tiafoe,L,R,M,20190122.0,Australian Open,QF,9:10 PM,Rod Laver Arena,Hard,Eva Asderaki-Moore,5.0,A,MaGav
+20190121-M-Australian_Open-R16-Novak_Djokovic-Daniil_Medvedev,Novak Djokovic,Daniil Medvedev,R,R,M,20190121.0,Australian Open,R16,9:30 PM,Rod Laver Arena,Hard,Nico Helwerth,5.0,A,MaGav
+20190121-M-Australian_Open-R16-Milos_Raonic-Alexander_Zverev,Milos Raonic,Alexander Zverev,R,R,M,20190121.0,Australian Open,R16,2:45 PM,Rod Laver Arena,Hard,Carlos Ramos,5.0,A,MaGav
+20190120-M-Australian_Open-R16-Stefanos_Tsitsipas-Roger_Federer,Stefanos Tsitsipas,Roger Federer,R,R,M,20190120.0,Australian Open,R16,7:10 PM,Rod Laver Arena,Hard,James Keothavong,5.0,A,MaGav
+20190119-M-Australian_Open-R32-Fabio_Fognini-Pablo_Carreno_Busta,Fabio Fognini,Pablo Carreno Busta,R,R,M,20190119.0,Australian Open,R32,2:45 PM,1573 Arena,Hard,Nico Helwerth,5.0,A,MaGav
+20190119-M-Australian_Open-R32-Alexei_Popyrin-Lucas_Pouille,Alexei Popyrin,Lucas Pouille,R,R,M,20190119.0,Australian Open,R32,8:50 PM,Margaret Court Arena,Hard,Gregory Allensworth,5.0,A,MaGav
+20190118-M-Australian_Open-R32-Stefanos_Tsitsipas-Nikoloz_Basilashvili,Stefanos Tsitsipas,Nikoloz Basilashvili,R,R,M,20190118.0,Australian Open,R32,11:10,Margaret Court Arena,Hard,Alexandre Robein,5.0,A,MaGav
+20190118-M-Australian_Open-R32-Fernando_Verdasco-Marin_Cilic,Fernando Verdasco,Marin Cilic,L,R,M,20190118.0,Australian Open,R32,8:40 PM,Margaret Court Arena,Hard,John Blom,5.0,A,MaGav
+20190117-M-Australian_Open-R64-Marius_Copil-David_Goffin,Marius Copil,David Goffin,R,R,M,20190117.0,Australian Open,R64,5:00 PM,7,Hard,Nacho Forcadell,5.0,A,MaGav
+20190117-M-Australian_Open-R64-Denis_Shapovalov-Taro_Daniel,Denis Shapovalov,Taro Daniel,L,R,M,20190117.0,Australian Open,R64,5:40 PM,1573 Arena,Hard,Carlos Bernardes,5.0,A,MaGav
+20190116-M-Australian_Open-R64-Kevin_Anderson-Francis_Tiafoe,Kevin Anderson,Francis Tiafoe,R,R,M,20190116.0,Australian Open,R64,1:25 PM,Margaret Court Arena,Hard,Simon Cannavan,5.0,A,MaGav
+20190115-M-Australian_Open-R128-Ugo_Humbert-Jeremy_Chardy,Ugo Humbert,Jeremy Chardy,L,R,M,20190115.0,Australian Open,R128,5:15 PM,10,Hard,Nacho Forcadell,5.0,A,tsitsi
+20190115-M-Australian_Open-R128-Pierre_Hugues_Herbert-Sam_Querrey,Pierre Hugues Herbert,Sam Querrey,R,R,M,20190115.0,Australian Open,R128,11:10,20,Hard,,5.0,A,MaGav
+20190115-M-Australian_Open-R128-Dominic_Thiem-Benoit_Paire,Dominic Thiem,Benoit Paire,R,R,M,20190115.0,Australian Open,R128,10:30 PM,Margaret Court Arena,Hard,Carlos Bernardes,5.0,A,MaGav
+20190115-M-Australian_Open-R128-Alexander_Zverev-Aljaz_Bedene,Alexander Zverev,Aljaz Bedene,R,R,M,20190115.0,Australian Open,R128,14:00 PM,Laver,Hard,,5.0,A,Miha Mlakar
+20190114-M-Australian_Open-R128-Taylor_Harry_Fritz-Cameron_Norrie,Taylor Harry Fritz,Cameron Norrie,R,L,M,20190114.0,Australian Open,R128,6:25 PM,14,Hard,,5.0,A,MaGav
+20190114-M-Australian_Open-R128-Stefanos_Tsitsipas-Matteo_Berrettini,Stefanos Tsitsipas,Matteo Berrettini,R,R,M,20190114.0,Australian Open,R128,12:30 PM,3,Hard,Louis Boucharinc,5.0,A,MaGav
+20190114-M-Australian_Open-R128-Mirza_Basic-Henri_Laaksonen,Mirza Basic,Henri Laaksonen,R,R,M,20190114.0,Australian Open,R128,4:30 PM,12,Hard,Alireza Chitgar,5.0,A,tsitsi
+20190114-M-Australian_Open-R128-Jason_Kubler-Thomas_Fabbiano,Jason Kubler,Thomas Fabbiano,R,R,M,20190114.0,Australian Open,R128,1:45 PM,13,Hard,Katarzyna Radwan,5.0,A,MaGav
+20190112-M-Sydney-F-Alex_De_Minaur-Andreas_Seppi,Alex De Minaur,Andreas Seppi,R,R,M,20190112.0,Sydney,F,8:10 PM,Ken Rosewall Arena,Hard,Renaud Lichtenstein,3.0,1,MaGav
+20190112-M-Canberra_CH-F-Ilya_Ivashka-Hubert_Hurkacz,Ilya Ivashka,Hubert Hurkacz,R,R,M,20190112.0,Canberra CH,F,11:10,Centre,Hard,,3.0,1,MaGav
+20190111-M-Auckland-SF-Tennys_Sandgren-Philipp_Kohlschreiber,Tennys Sandgren,Philipp Kohlschreiber,R,R,M,20190111.0,Auckland,SF,3:15 PM,Center,Hard,Fabio Souza,3.0,1,ChapelHeel66
+20190110-M-Sydney-QF-Stefanos_Tsitsipas-Andreas_Seppi,Stefanos Tsitsipas,Andreas Seppi,R,R,M,20190110.0,Sydney,QF,,,Hard,Fergus Murphy,3.0,1,Edged
+20190110-M-Sydney-QF-John_Millman-Gilles_Simon,John Millman,Gilles Simon,R,R,M,20190110.0,Sydney,QF,11:00 PM,Court 1,Hard,Carlos Ramos,3.0,1,MaGav
+20190108-M-Sydney-R16-John_Millman-Marton_Fucsovics,John Millman,Marton Fucsovics,R,R,M,20190108.0,Sydney,R16,,,Hard,Ali Nili,3.0,1,Edged
+20190107-M-Auckland-R32-Denis_Shapovalov-Joao_Sousa,Denis Shapovalov,Joao Sousa,L,R,M,20190107.0,Auckland,R32,,Centre,Hard,Fabio Souza,3.0,1,Edged
+20190106-M-Sydney-Q1-Guillermo_Garcia_Lopez-Aljaz_Bedene,Guillermo Garcia Lopez,Aljaz Bedene,R,R,M,20190106.0,Sydney,Q1,,,Hard,,3.0,1,Miha Mlakar
+20190105-M-Brisbane-SF-Jeremy_Chardy-Kei_Nishikori,Jeremy Chardy,Kei Nishikori,R,R,M,20190105.0,Brisbane,SF,,Rafter,Hard,,3.0,1,Otako
+20190104-M-Pune-SF-Kevin_Anderson-Gilles_Simon,Kevin Anderson,Gilles Simon,R,R,M,20190104.0,Pune,SF,9:30 PM,Centre,Hard,Adel Nour,3.0,1,MaGav
+20190104-M-Doha-SF-Novak_Djokovic-Roberto_Bautista_Agut,Novak Djokovic,Roberto Bautista Agut,R,R,M,20190104.0,Doha,SF,6:40 PM,Centre,Hard,Manuel Messina,3.0,1,MaGav
+20190104-M-Doha-SF-Marco_Cecchinato-Tomas_Berdych,Marco Cecchinato,Tomas Berdych,R,R,M,20190104.0,Doha,SF,9:40 PM,Centre,Hard,Mohamed El Jennati,3.0,1,MaGav
+20190104-M-Brisbane-QF-Milos_Raonic-Daniil_Medvedev,Milos Raonic,Daniil Medvedev,R,R,M,20190104.0,Brisbane,QF,,,Hard,Simon Cannavan,3.0,1,Edged
+20190104-M-Brisbane-QF-Alex_De_Minaur-Jo_Wilfried_Tsonga,Alex De Minaur,Jo Wilfried Tsonga,R,R,M,20190104.0,Brisbane,QF,8:50 PM,Pat Rafter Arena,Hard,Fergus Murphy,3.0,1,MaGav
+20190103-M-Doha-QF-Novak_Djokovic-Nikoloz_Basilashvili,Novak Djokovic,Nikoloz Basilashvili,R,R,M,20190103.0,Doha,QF,6:00 PM,Centre,Hard,Mohamed El Jennati,3.0,1,MaGav
+20190103-M-Doha-QF-Marco_Cecchinato-Dusan_Lajovic,Marco Cecchinato,Dusan Lajovic,R,R,M,20190103.0,Doha,QF,,Centre,Hard,Nacho Forcadell,3.0,1,Edged
+20190103-M-Brisbane-QF-Jeremy_Chardy-Yasutaka_Uchiyama,Jeremy Chardy,Yasutaka Uchiyama,R,R,M,20190103.0,Brisbane,QF,1:10 PM,Pat Rafter Arena,Hard,Fergus Murphy,3.0,1,MaGav
+20190102-M-Pune-R16-Ernests_Gulbis-Hyeon_Chung,Ernests Gulbis,Hyeon Chung,R,R,M,20190102.0,Pune,R16,3:00 PM,Centre,Hard,Adel Nour,3.0,1,MaGav
+20190102-M-Doha-R16-Nikoloz_Basilashvili-Andrey_Rublev,Nikoloz Basilashvili,Andrey Rublev,R,R,M,20190102.0,Doha,R16,,Centre,Hard,Nacho Forcadell,3.0,1,Edged
+20190102-M-Doha-R16-Nicolas_Jarry-Stanislas_Wawrinka,Nicolas Jarry,Stanislas Wawrinka,R,R,M,20190102.0,Doha,R16,3:30 PM,Centre,Hard,,3.0,1,MaGav
+20190102-M-Brisbane-R16-Grigor_Dimitrov-John_Millman,Grigor Dimitrov,John Millman,R,R,M,20190102.0,Brisbane,R16,,Centre,Hard,,3.0,1,Edged
+20181125-M-Davis_Cup_World_Group_F-RR-Lucas_Pouille-Marin_Cilic,Lucas Pouille,Marin Cilic,R,R,M,20181125.0,Davis Cup World Group F,RR,1:00 PM,Lille,Clay,Marijana Veljovic,5.0,1,MaGav
+20181123-M-Davis_Cup_World_Group_F-RR-Marin_Cilic-Jo_Wilfried_Tsonga,Marin Cilic,Jo Wilfried Tsonga,R,R,M,20181123.0,Davis Cup World Group F,RR,5:00 PM,Lille,Clay,Marijana Veljovic,5.0,1,MaGav
+20181123-M-Davis_Cup_World_Group_F-RR-Jeremy_Chardy-Borna_Coric,Jeremy Chardy,Borna Coric,R,R,M,20181123.0,Davis Cup World Group F,RR,2:00 PM,Lille,Clay,James Keothavong,5.0,1,MaGav
+20181117-M-Tour_Finals-SF-Kevin_Anderson-Novak_Djokovic,Kevin Anderson,Novak Djokovic,R,R,M,20181117.0,Tour Finals,SF,8:00 PM,Centre,Hard,Ali Nili,3.0,1,MaGav
+20181115-M-Tour_Finals-RR-Kevin_Anderson-Roger_Federer,Kevin Anderson,Roger Federer,R,R,M,20181115.0,Tour Finals,RR,8:00 PM,Centre,Hard,Ali Nili,3.0,1,MaGav
+20181114-M-Tour_Finals-RR-John_Isner-Marin_Cilic,John Isner,Marin Cilic,R,R,M,20181114.0,Tour Finals,RR,8:00 PM,Centre,Hard,Carlos Bernardes,3.0,1,MaGav
+20181114-M-Tour_Finals-RR-Dominic_Thiem-Roger_Federer,Dominic Thiem,Roger Federer,R,R,M,20181114.0,Tour Finals,RR,8:00 PM,Centre,Hard,Ali Nili,3.0,1,MaGav
+20181112-M-Tour_Finals-RR-John_Isner-Novak_Djokovic,John Isner,Novak Djokovic,R,R,M,20181112.0,Tour Finals,RR,8:00 PM,Centre,Hard,Carlos Bernardes,3.0,1,MaGav
+20181104-M-Paris_Masters-F-Novak_Djokovic-Karen_Khachanov,Novak Djokovic,Karen Khachanov,R,R,M,20181104.0,Paris Masters,F,3pm,Centre,Carpet,Cedric Mourier,3.0,1,Edo
+20181103-M-Paris_Masters-SF-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20181103.0,Paris Masters,SF,4:00 PM,Centre,Hard,Carlos Bernardes,3.0,1,Palaver
+20181103-M-Paris_Masters-SF-Dominic_Thiem-Karen_Khachanov,Dominic Thiem,Karen Khachanov,R,R,M,20181103.0,Paris Masters,SF,,Centre,Hard,Damien Dumusois,3.0,1,Palaver
+20181101-M-Paris_Masters-R16-Dominic_Thiem-Borna_Coric,Dominic Thiem,Borna Coric,R,R,M,20181101.0,Paris Masters,R16,4:35 PM,Centre,Hard,Nacho Forcadell,3.0,1,ChapelHeel66
+20181101-M-Paris_Masters-R16-Diego_Sebastian_Schwartzman-Alexander_Zverev,Diego Sebastian Schwartzman,Alexander Zverev,R,R,M,20181101.0,Paris Masters,R16,,,Hard,Carlos Bernardes,3.0,1,Isaac
+20181031-M-Paris_Masters-R32-Daniil_Medvedev-Borna_Coric,Daniil Medvedev,Borna Coric,R,R,M,20181031.0,Paris Masters,R32,11:30 AM,Centre,Hard,Nacho Forcadell,3.0,1,ChapelHeel66
+20181028-M-Basel-F-Roger_Federer-Marius_Copil,Roger Federer,Marius Copil,R,R,M,20181028.0,Basel,F,3pm,Centre,Hard,Damien Dumusois,3.0,1,Edo
+20181021-M-Stockholm-F-Stefanos_Tsitsipas-Ernests_Gulbis,Stefanos Tsitsipas,Ernests Gulbis,R,R,M,20181021.0,Stockholm,F,3:45 PM,Center,Hard,Mohamed Lahyani,3.0,1,ChapelHeel66
+20181020-M-Moscow-SF-Adrian_Mannarino-Andreas_Seppi,Adrian Mannarino,Andreas Seppi,L,R,M,20181020.0,Moscow,SF,4:00 PM,Centre,Hard,Damian Steiner,3.0,1,Michal
+20181019-M-Moscow-QF-Ricardas_Berankis-Daniil_Medvedev,Ricardas Berankis,Daniil Medvedev,R,R,M,20181019.0,Moscow,QF,7:45 PM,Centre,Hard,Jaume Campistol,3.0,1,Michal
+20181017-M-Moscow-R16-Marco_Cecchinato-Adrian_Mannarino,Marco Cecchinato,Adrian Mannarino,R,L,M,20181017.0,Moscow,R16,9:15 PM,Centre,Hard,Jaume Campistol,3.0,1,Michal
+20181017-M-Moscow-R16-Lukas_Rosol-Karen_Khachanov,Lukas Rosol,Karen Khachanov,R,R,M,20181017.0,Moscow,R16,4:50 PM,Centre,Hard,Gianluca Moscarella,3.0,1,Michal
+20181016-M-Stockholm-R32-Philipp_Kohlschreiber-Alex_De_Minaur,Philipp Kohlschreiber,Alex De Minaur,R,R,M,20181016.0,Stockholm,R32,8:55 PM,Center,Hard,Richard Haigh,3.0,1,ChapelHeel66
+20181015-M-Moscow-R32-Laslo_Djere-Aljaz_Bedene,Laslo Djere,Aljaz Bedene,R,R,M,20181015.0,Moscow,R32,,Centre,Hard,,3.0,1,Miha Mlakar
+20181014-M-Shanghai_Masters-F-Novak_Djokovic-Borna_Coric,Novak Djokovic,Borna Coric,R,R,M,20181014.0,Shanghai Masters,F,4pm,Centre,Hard,Cedric Mourier,3.0,1,Edo
+20181013-M-Shanghai_Masters-SF-Roger_Federer-Borna_Coric,Roger Federer,Borna Coric,R,R,M,20181013.0,Shanghai Masters,SF,,,Hard,,3.0,1,Isaac
+20181012-M-Shanghai_Masters-QF-Matthew_Ebden-Borna_Coric,Matthew Ebden,Borna Coric,R,R,M,20181012.0,Shanghai Masters,QF,7:00 PM,Centre,Hard,Adel Nour,3.0,1,MaGav
+20181003-M-Tokyo-R32-Yoshihito_Nishioka-Nick_Kyrgios,Yoshihito Nishioka,Nick Kyrgios,L,R,M,20181003.0,Tokyo,R32,1:00 PM,Centre,Hard,Cedric Mourier,3.0,1,MaGav
+20181002-M-Tokyo-R32-Gilles_Simon-Alex_De_Minaur,Gilles Simon,Alex De Minaur,R,R,M,20181002.0,Tokyo,R32,12:10 PM,Arena 2,Hard,Fergus Murphy,3.0,1,ChapelHeel66
+20181001-M-Tokyo-R32-Denis_Kudla-Richard_Gasquet,Denis Kudla,Richard Gasquet,R,R,M,20181001.0,Tokyo,R32,12:15 PM,Arena 1,Hard,Robert Balmforth,3.0,1,ChapelHeel66
+20180928-M-Shenzhen-QF-Andy_Murray-Fernando_Verdasco,Andy Murray,Fernando Verdasco,R,L,M,20180928.0,Shenzhen,QF,22:00,Centre,Hard,Pierre Bacchi,3.0,1,MaGav
+20180928-M-Shenzhen-QF-Alex_De_Minaur-Damir_Dzumhur,Alex De Minaur,Damir Dzumhur,R,R,M,20180928.0,Shenzhen,QF,5:10 PM,Center,Hard,Jaime Campistol,3.0,1,ChapelHeel66
+20180926-M-Orleans_CH-R16-Constant_Lestienne-Aljaz_Bedene,Constant Lestienne,Aljaz Bedene,R,R,M,20180926.0,Orleans CH,R16,,Centre,Hard,,3.0,1,Miha Mlakar
+20180923-M-Metz-F-Matthias_Bachinger-Gilles_Simon,Matthias Bachinger,Gilles Simon,R,R,M,20180923.0,Metz,F,3:55 PM,Patrice Dominguez,Hard,Damien Dumusois,3.0,1,ChapelHeel66
+20180923-M-Kaohsiung_CH-F-Gael_Monfils-Soon_Woo_Kwon,Gael Monfils,Soon Woo Kwon,R,R,M,20180923.0,Kaohsiung CH,F,,Centre,Hard,,3.0,1,Zindaras
+20180922-M-Kaohsiung_CH-SF-Gael_Monfils-Duck_Hee_Lee,Gael Monfils,Duck Hee Lee,R,R,M,20180922.0,Kaohsiung CH,SF,,,Hard,,3.0,1,Zindaras
+20180921-M-Kaohsiung_CH-QF-Gael_Monfils-Ernests_Gulbis,Gael Monfils,Ernests Gulbis,R,R,M,20180921.0,Kaohsiung CH,QF,,,Hard,,3.0,1,Zindaras
+20180919-M-St_Petersburg-R16-Stanislas_Wawrinka-Karen_Khachanov,Stanislas Wawrinka,Karen Khachanov,R,R,M,20180919.0,St Petersburg,R16,4:35 PM,Center,Hard,Renaud Lichtenstein,3.0,1,ChapelHeel66
+20180916-M-Davis_Cup_World_Group_SF-RR-Marcel_Granollers-Nicolas_Mahut,Marcel Granollers,Nicolas Mahut,R,R,M,20180916.0,Davis Cup World Group SF,RR,2:55 PM,Stade Pierre Mauroy - Lille,Hard,James Keothavong,3.0,S,ChapelHeel66
+20180916-M-Davis_Cup_World_Group_SF-RR-Francis_Tiafoe-Borna_Coric,Francis Tiafoe,Borna Coric,R,R,M,20180916.0,Davis Cup World Group SF,RR,2:55 PM,Zadar-Croatia,Clay,Emmanuel Joseph,5.0,1,ChapelHeel66
+20180914-M-Davis_Cup_World_Group_PO-RR-Denis_Shapovalov-Robin_Haase,Denis Shapovalov,Robin Haase,L,R,M,20180914.0,Davis Cup World Group PO,RR,,,Hard,Ali Nili,5.0,1,Zindaras
+20180909-M-US_Open-F-Novak_Djokovic-Juan_Martin_Del_Potro,Novak Djokovic,Juan Martin Del Potro,R,R,M,20180909.0,US Open,F,4pm,Arthur Ashe,Hard,Alison Hughes,5.0,1,Edo
+20180907-M-US_Open-SF-Rafael_Nadal-Juan_Martin_Del_Potro,Rafael Nadal,Juan Martin Del Potro,L,R,M,20180907.0,US Open,SF,,Arthur Ashe Stadium,Hard,James Keothavong,5.0,1,Palaver
+20180907-M-US_Open-SF-Novak_Djokovic-Kei_Nishikori,Novak Djokovic,Kei Nishikori,R,R,M,20180907.0,US Open,SF,7pm,Ashe,Hard,Ali Nili,5.0,1,Edo
+20180905-M-US_Open-QF-Rafael_Nadal-Dominic_Thiem,Rafael Nadal,Dominic Thiem,L,R,M,20180905.0,US Open,QF,,Arthur Ashe Stadium,Hard,Nico Helwerth,5.0,1,Palaver
+20180903-M-US_Open-R16-Roger_Federer-John_Millman,Roger Federer,John Millman,R,R,M,20180903.0,US Open,R16,21:10,Arthur Ashe,Hard,,5.0,1,Palaver
+20180901-M-US_Open-R32-Roger_Federer-Nick_Kyrgios,Roger Federer,Nick Kyrgios,R,R,M,20180901.0,US Open,R32,14:30,Arthur Ashe,Hard,,5.0,1,Palaver
+20180831-M-US_Open-R32-Rafael_Nadal-Karen_Khachanov,Rafael Nadal,Karen Khachanov,L,R,M,20180831.0,US Open,R32,14:30,Arthur Ashe,Hard,Damien Dumusois,5.0,1,Palaver
+20180831-M-US_Open-R32-Kevin_Anderson-Denis_Shapovalov,Kevin Anderson,Denis Shapovalov,R,L,M,20180831.0,US Open,R32,3:00 PM,Louis Armstrong Stadium,Hard,Nico Helwerth,5.0,1,MaGav
+20180831-M-US_Open-R32-Borna_Coric-Daniil_Medvedev,Borna Coric,Daniil Medvedev,R,R,M,20180831.0,US Open,R32,,17,Hard,Alison Hughes,5.0,1,Adam Taylor
+20180830-M-US_Open-R64-Benoit_Paire-Roger_Federer,Benoit Paire,Roger Federer,R,R,M,20180830.0,US Open,R64,15:00,Arthur Ashe,Hard,,5.0,1,Palaver
+20180829-M-US_Open-R64-Andy_Murray-Fernando_Verdasco,Andy Murray,Fernando Verdasco,R,L,M,20180829.0,US Open,R64,3:00 PM,Arthur Ashe Stadium,Hard,Nico Helwerth,5.0,1,MaGav
+20180828-M-US_Open-R128-Yoshihito_Nishioka-Roger_Federer,Yoshihito Nishioka,Roger Federer,L,R,M,20180828.0,US Open,R128,17:15,Arthur Ashe,Hard,Damien Dumusois,5.0,1,Palaver
+20180828-M-US_Open-R128-Nikoloz_Basilashvili-Aljaz_Bedene,Nikoloz Basilashvili,Aljaz Bedene,R,R,M,20180828.0,US Open,R128,,9,Hard,,5.0,1,Miha Mlakar
+20180819-M-Cincinnati_Masters-F-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20180819.0,Cincinnati Masters,F,16:45,Center,Hard,Damien Dumusois,3.0,1,Palaver
+20180816-M-Gwangju_CH-R16-Akira_Santillan-Karim_Mohamed_Maamoun,Akira Santillan,Karim Mohamed Maamoun,R,R,M,20180816.0,Gwangju CH,R16,3:00 PM,,Hard,,3.0,1,ahmedabdelaal
+20180811-M-Canada_Masters-SF-Rafael_Nadal-Karen_Khachanov,Rafael Nadal,Karen Khachanov,L,R,M,20180811.0,Canada Masters,SF,,,Hard,Mohamed Lahyani,3.0,1,Isaac
+20180805-M-Washington-F-Alex_De_Minaur-Alexander_Zverev,Alex De Minaur,Alexander Zverev,R,R,M,20180805.0,Washington,F,,Stadium,Hard,,3.0,1,Baybar
+20180803-M-Washington-R16-Hyeon_Chung-Alex_De_Minaur,Hyeon Chung,Alex De Minaur,R,R,M,20180803.0,Washington,R16,11:05 PM,Grandstand 2,Hard,,3.0,1,ChapelHeel66
+20180729-M-Atlanta-F-John_Isner-Ryan_Harrison,John Isner,Ryan Harrison,R,R,M,20180729.0,Atlanta,F,5:00 PM,Stadium,Hard,Mohamed Lahyani,3.0,1,ChapelHeel66
+20180722-M-Bastad-F-Fabio_Fognini-Richard_Gasquet,Fabio Fognini,Richard Gasquet,R,R,M,20180722.0,Bastad,F,2:10 PM,Centre,Clay,Mohamed El Jennati,3.0,1,ChapelHeel66
+20180718-M-Bastad-R16-Matteo_Berrettini-Henri_Laaksonen,Matteo Berrettini,Henri Laaksonen,R,R,M,20180718.0,Bastad,R16,,,Clay,,3.0,1,MihaMlakar
+20180715-M-Wimbledon-F-Kevin_Anderson-Novak_Djokovic,Kevin Anderson,Novak Djokovic,R,R,M,20180715.0,Wimbledon,F,2pm,Centre,Grass,James Keothavong,5.0,0,Edo
+20180715-M-Perugia_CH-F-Gianluigi_Quinzi-Ulises_Blanch,Gianluigi Quinzi,Ulises Blanch,L,R,M,20180715.0,Perugia CH,F,9:30 PM,Centre,Clay,,3.0,1,MaGav
+20180713-M-Wimbledon-SF-Rafael_Nadal-Novak_Djokovic,Rafael Nadal,Novak Djokovic,L,R,M,20180713.0,Wimbledon,SF,20:10,Centre,Grass,Damian Steiner,5.0,0,Palaver
+20180713-M-Wimbledon-SF-Kevin_Anderson-John_Isner,Kevin Anderson,John Isner,R,R,M,20180713.0,Wimbledon,SF,13:10,Centre,Grass,Marija Cicak,5.0,0,Palaver
+20180711-M-Wimbledon-QF-Rafael_Nadal-Juan_Martin_Del_Potro,Rafael Nadal,Juan Martin Del Potro,L,R,M,20180711.0,Wimbledon,QF,16:00,Centre,Grass,Jake Garner,5.0,0,Palaver
+20180711-M-Wimbledon-QF-Novak_Djokovic-Kei_Nishikori,Novak Djokovic,Kei Nishikori,R,R,M,20180711.0,Wimbledon,QF,13:10,Centre,Grass,Carlos Ramos,5.0,0,Palaver
+20180711-M-Wimbledon-QF-Milos_Raonic-John_Isner,Milos Raonic,John Isner,R,R,M,20180711.0,Wimbledon,QF,5:45 PM,1,Grass,Mohamed Lahyani,5.0,0,MaGav
+20180711-M-Wimbledon-QF-Kevin_Anderson-Roger_Federer,Kevin Anderson,Roger Federer,R,R,M,20180711.0,Wimbledon,QF,13:10,1,Grass,Ali Nili,5.0,0,Palaver
+20180709-M-Wimbledon-R16-Adrian_Mannarino-Roger_Federer,Adrian Mannarino,Roger Federer,L,R,M,20180709.0,Wimbledon,R16,13:10,Centre,Grass,Nico Helwerth,5.0,0,Palaver
+20180706-M-Wimbledon-R32-Roger_Federer-Jan_Lennard_Struff,Roger Federer,Jan Lennard Struff,R,R,M,20180706.0,Wimbledon,R32,18:45,Centre,Grass,Jaume Campistol,5.0,0,Palaver
+20180704-M-Wimbledon-R64-Lukas_Lacko-Roger_Federer,Lukas Lacko,Roger Federer,R,R,M,20180704.0,Wimbledon,R64,15:40,Centre,Grass,,5.0,0,Palaver
+20180702-M-Wimbledon-R128-Dusan_Lajovic-Roger_Federer,Dusan Lajovic,Roger Federer,R,R,M,20180702.0,Wimbledon,R128,14:10,Centre,Grass,,5.0,0,Palaver
+20180624-M-Queens_Club-F-Novak_Djokovic-Marin_Cilic,Novak Djokovic,Marin Cilic,R,R,M,20180624.0,Queens Club,F,3pm,Centre,Grass,Mohamed Lahyani,3.0,1,Edo
+20180624-M-Halle-F-Borna_Coric-Roger_Federer,Borna Coric,Roger Federer,R,R,M,20180624.0,Halle,F,1pm,Centre,Grass,Damien Dumusois,3.0,1,Edo
+20180623-M-Halle-SF-Roger_Federer-Denis_Kudla,Roger Federer,Denis Kudla,R,R,M,20180623.0,Halle,SF,11:30 AM,Stadion,Grass,Nico Helwerth ,3.0,1,MK
+20180622-M-Queens_Club-QF-Novak_Djokovic-Adrian_Mannarino,Novak Djokovic,Adrian Mannarino,R,L,M,20180622.0,Queens Club,QF,3:30 PM,Centre,Grass,Fergus Murphy,3.0,1,MK
+20180622-M-Halle-QF-Matthew_Ebden-Roger_Federer,Matthew Ebden,Roger Federer,R,R,M,20180622.0,Halle,QF,2:00 PM,Stadion,Grass,Carlos Bernardes,3.0,1,MK
+20180621-M-Queens_Club-R16-Novak_Djokovic-Grigor_Dimitrov,Novak Djokovic,Grigor Dimitrov,R,R,M,20180621.0,Queens Club,R16,4:30 PM,Centre,Grass,James Keothovang,3.0,1,MK
+20180621-M-Halle-R16-Roger_Federer-Benoit_Paire,Roger Federer,Benoit Paire,R,R,M,20180621.0,Halle,R16,3:50 PM,Stadion,Grass,Carlos Bernardes,3.0,1,MK
+20180619-M-Halle-R32-Roger_Federer-Aljaz_Bedene,Roger Federer,Aljaz Bedene,R,R,M,20180619.0,Halle,R32,4:00 PM,Stadion,Grass,Carlos Bernardes,3.0,1,MK
+20180617-M-s_Hertogenbosch-F-Richard_Gasquet-Jeremy_Chardy,Richard Gasquet,Jeremy Chardy,R,R,M,20180617.0,s Hertogenbosch,F,2:50 PM,Centre,Grass,Carlos Bernardes,3.0,1,ChapelHeel66
+20180617-M-Stuttgart-F-Milos_Raonic-Roger_Federer,Milos Raonic,Roger Federer,R,R,M,20180617.0,Stuttgart,F,1pm,Centre,Grass,Mohamed Lahyani,3.0,1,Edo
+20180616-M-Stuttgart-SF-Roger_Federer-Nick_Kyrgios,Roger Federer,Nick Kyrgios,R,R,M,20180616.0,Stuttgart,SF,3:00 PM,Centre,Grass,Mohamed Layhani,3.0,1,Han
+20180615-M-Stuttgart-QF-Feliciano_Lopez-Nick_Kyrgios,Feliciano Lopez,Nick Kyrgios,L,R,M,20180615.0,Stuttgart,QF,4:50 PM,Centre,Grass,Mohamed Lahyani,3.0,1,MaGav
+20180613-M-Stuttgart-R16-Mischa_Zverev-Roger_Federer,Mischa Zverev,Roger Federer,L,R,M,20180613.0,Stuttgart,R16,3:00 PM,Centre,Grass,Mohamed Lahyani,3.0,1,MaGav
+20180610-M-Roland_Garros-F-Rafael_Nadal-Dominic_Thiem,Rafael Nadal,Dominic Thiem,L,R,M,20180610.0,Roland Garros,F,14:00,Philippe Chatrier,Clay,Damien Dumusois,5.0,0,Palaver
+20180608-M-Roland_Garros-SF-Rafael_Nadal-Juan_Martin_Del_Potro,Rafael Nadal,Juan Martin Del Potro,L,R,M,20180608.0,Roland Garros,SF,15:00,Philippe Chatrier,Clay,Jake Garner,5.0,0,Palaver
+20180608-M-Roland_Garros-SF-Marco_Cecchinato-Dominic_Thiem,Marco Cecchinato,Dominic Thiem,R,R,M,20180608.0,Roland Garros,SF,13:00,Philippe Chatrier,Clay,,5.0,0,Palaver
+20180607-M-Roland_Garros-QF-Marin_Cilic-Juan_Martin_Del_Potro,Marin Cilic,Juan Martin Del Potro,R,R,M,20180607.0,Roland Garros,QF,11:00,,Clay,,5.0,0,Palaver
+20180605-M-Roland_Garros-QF-Marco_Cecchinato-Novak_Djokovic,Marco Cecchinato,Novak Djokovic,R,R,M,20180605.0,Roland Garros,QF,15:55,Suzanne Lenglen,Clay,Carlos Ramos,5.0,0,Palaver
+20180605-M-Roland_Garros-QF-Alexander_Zverev-Dominic_Thiem,Alexander Zverev,Dominic Thiem,R,R,M,20180605.0,Roland Garros,QF,14:15,Philippe Chatrier,Clay,,5.0,0,Palaver
+20180604-M-Roland_Garros-R16-John_Isner-Juan_Martin_Del_Potro,John Isner,Juan Martin Del Potro,R,R,M,20180604.0,Roland Garros,R16,16:55,Suzanne Lenglen,Clay,,5.0,0,Palaver
+20180602-M-Roland_Garros-R32-Gael_Monfils-David_Goffin,Gael Monfils,David Goffin,R,R,M,20180602.0,Roland Garros,R32,5:10 PM,Court Suzanne Lenglen,Clay,John Blom,5.0,0,ChapelHeel66
+20180531-M-Roland_Garros-R64-Marton_Fucsovics-Kyle_Edmund,Marton Fucsovics,Kyle Edmund,R,R,M,20180531.0,Roland Garros,R64,1:00 PM,Court 3,Clay,Gregory Allensworth,5.0,0,ChapelHeel66
+20180530-M-Roland_Garros-R64-Novak_Djokovic-Jaume_Munar,Novak Djokovic,Jaume Munar,R,R,M,20180530.0,Roland Garros,R64,12:55,Suzanne Lenglen,Clay,Emmanuel Joseph,5.0,0,tsitsi
+20180528-M-Roland_Garros-R128-Borna_Coric-Philipp_Kohlschreiber,Borna Coric,Philipp Kohlschreiber,R,R,M,20180528.0,Roland Garros,R128,2:00 PM,Court 6,Clay,Aurelie Tourte,5.0,0,ChapelHeel66
+20180520-M-Rome_Masters-F-Rafael_Nadal-Alexander_Zverev,Rafael Nadal,Alexander Zverev,L,R,M,20180520.0,Rome Masters,F,4pm,Centrale,Clay,Damian Steiner,3.0,1,Edo
+20180519-M-Rome_Masters-SF-Rafael_Nadal-Novak_Djokovic,Rafael Nadal,Novak Djokovic,L,R,M,20180519.0,Rome Masters,SF,4:15 PM,Centrale,Clay,Renaud Lichtenstein,3.0,1,Palaver
+20180517-M-Rome_Masters-R16-Denis_Shapovalov-Rafael_Nadal,Denis Shapovalov,Rafael Nadal,L,L,M,20180517.0,Rome Masters,R16,4:00 PM,Centre,Clay,Mohamed Lahyani,3.0,1,MaGav
+20180513-M-Madrid_Masters-F-Dominic_Thiem-Alexander_Zverev,Dominic Thiem,Alexander Zverev,R,R,M,20180513.0,Madrid Masters,F,6pm,Manolo Santana,Clay,Mohamed Lahyani,3.0,1,Edo
+20180511-M-Madrid_Masters-QF-Rafael_Nadal-Dominic_Thiem,Rafael Nadal,Dominic Thiem,L,R,M,20180511.0,Madrid Masters,QF,4pm,Manolo Santana,Clay,James Keothavong,3.0,1,Edo
+20180506-M-Munich-F-Philipp_Kohlschreiber-Alexander_Zverev,Philipp Kohlschreiber,Alexander Zverev,R,R,M,20180506.0,Munich,F,12:45 PM,Centre,Clay,,3.0,1,ChapelHeel66
+20180505-M-Munich-SF-Maximilian_Marterer-Philipp_Kohlschreiber,Maximilian Marterer,Philipp Kohlschreiber,L,R,M,20180505.0,Munich,SF,2:35 PM,Centre,Clay,,3.0,1,ChapelHeel66
+20180504-M-Munich-QF-Roberto_Bautista_Agut-Philipp_Kohlschreiber,Roberto Bautista Agut,Philipp Kohlschreiber,R,R,M,20180504.0,Munich,QF,2:05 PM,Centre,Clay,Fergus Murphy,3.0,1,ChapelHeel66
+20180503-M-Munich-R16-Mischa_Zverev-Philipp_Kohlschreiber,Mischa Zverev,Philipp Kohlschreiber,L,R,M,20180503.0,Munich,R16,2:00 PM,Centre,Clay,Timo Janzen,3.0,1,ChapelHeel66
+20180501-M-Munich-R32-Ivo_Karlovic-Philipp_Kohlschreiber,Ivo Karlovic,Philipp Kohlschreiber,R,R,M,20180501.0,Munich,R32,12:15 PM,Centre,Clay,Fergus Murphy,3.0,1,ChapelHeel66
+20180428-M-Budapest-SF-John_Millman-Aljaz_Bedene,John Millman,Aljaz Bedene,R,R,M,20180428.0,Budapest,SF,,Centre,Clay,,3.0,1,Miha Mlakar
+20180428-M-Barcelona-SF-Stefanos_Tsitsipas-Pablo_Carreno_Busta,Stefanos Tsitsipas,Pablo Carreno Busta,R,R,M,20180428.0,Barcelona,SF,1:45 PM,Centre,Clay,Renaud Lichtenstein,3.0,1,ChapelHeel66
+20180427-M-Barcelona-QF-Grigor_Dimitrov-Pablo_Carreno_Busta,Grigor Dimitrov,Pablo Carreno Busta,R,R,M,20180427.0,Barcelona,QF,2:25:00 PM,Pista Rafael Nadal,Clay,Carlos Bernardes,3.0,1,ChapelHeel66
+20180426-M-Barcelona-R16-Pablo_Carreno_Busta-Adrian_Mannarino,Pablo Carreno Busta,Adrian Mannarino,R,L,M,20180426.0,Barcelona,R16,2:45 PM,Pista 1,Clay,Adel Nour,3.0,1,ChapelHeel66
+20180425-M-Barcelona-R32-Pablo_Carreno_Busta-Benoit_Paire,Pablo Carreno Busta,Benoit Paire,R,R,M,20180425.0,Barcelona,R32,5:25 PM,Centre,Clay,Carlos Bernardes,3.0,1,ChapelHeel66
+20180415-M-Houston-F-Steve_Johnson-Tennys_Sandgren,Steve Johnson,Tennys Sandgren,R,R,M,20180415.0,Houston,F,2:10 PM,Center,Clay,Damian Steiner,3.0,1,ChapelHeel66
+20180412-M-Marrakech-R16-Joao_Sousa-Mirza_Basic,Joao Sousa,Mirza Basic,R,R,M,20180412.0,Marrakech,R16,11:00,Centre,Clay,,3.0,1,MihaMlakar
+20180408-M-Davis_Cup_World_Group_QF-RR-David_Ferrer-Philipp_Kohlschreiber,David Ferrer,Philipp Kohlschreiber,R,R,M,20180408.0,Davis Cup World Group QF,RR,2:00 PM,Plaza de Toros de Valencia,Clay,Carlos Ramos,5.0,1,ChapelHeel66
+20180401-M-Miami_Masters-F-John_Isner-Alexander_Zverev,John Isner,Alexander Zverev,R,R,M,20180401.0,Miami Masters,F,1:10 PM,Stadium,Hard,,3.0,1,Palaver
+20180330-M-Miami_Masters-SF-John_Isner-Juan_Martin_Del_Potro,John Isner,Juan Martin Del Potro,R,R,M,20180330.0,Miami Masters,SF,1:10 PM,Center,Hard,,3.0,1,Palaver
+20180325-M-Miami_Masters-R64-Roger_Federer-Thanasi_Kokkinakis,Roger Federer,Thanasi Kokkinakis,R,R,M,20180325.0,Miami Masters,R64,,,Hard,Renaud Lichtenstein,3.0,1,Palaver
+20180318-M-Indian_Wells_Masters-F-Roger_Federer-Juan_Martin_Del_Potro,Roger Federer,Juan Martin Del Potro,R,R,M,20180318.0,Indian Wells Masters,F,3pm,Stadium 1,Hard,Fergus Murphy,3.0,1,Edo
+20180316-M-Indian_Wells_Masters-SF-Roger_Federer-Borna_Coric,Roger Federer,Borna Coric,R,R,M,20180316.0,Indian Wells Masters,SF,,Stadium 1,Hard,Damien Dumusois,3.0,1,Palaver
+20180316-M-Indian_Wells_Masters-SF-Milos_Raonic-Juan_Martin_Del_Potro,Milos Raonic,Juan Martin Del Potro,R,R,M,20180316.0,Indian Wells Masters,SF,,Stadium 1,Hard,Mohammed Lahyani,3.0,1,Palaver
+20180315-M-Indian_Wells_Masters-QF-Roger_Federer-Hyeon_Chung,Roger Federer,Hyeon Chung,R,R,M,20180315.0,Indian Wells Masters,QF,,Stadium 1,Hard,Mohammed Lahyani,3.0,1,Palaver
+20180314-M-Indian_Wells_Masters-R16-Jeremy_Chardy-Roger_Federer,Jeremy Chardy,Roger Federer,R,R,M,20180314.0,Indian Wells Masters,R16,,Stadium 1,Hard,Ali Nili,3.0,1,Palaver
+20180312-M-Indian_Wells_Masters-R32-Roger_Federer-Filip_Krajinovic,Roger Federer,Filip Krajinovic,R,R,M,20180312.0,Indian Wells Masters,R32,,Stadium 1,Hard,Mohammed Lahyani,3.0,1,Palaver
+20180311-M-Indian_Wells_Masters-R64-Roger_Federer-Federico_Delbonis,Roger Federer,Federico Delbonis,R,L,M,20180311.0,Indian Wells Masters,R64,,Stadium 1,Hard,Ali Nili,3.0,1,Palaver
+20180228-M-Dubai-R16-Karen_Khachanov-Lucas_Pouille,Karen Khachanov,Lucas Pouille,R,R,M,20180228.0,Dubai,R16,4:50 PM,Centre,Hard,Adel Nour,3.0,1,ChapelHeel66
+20180225-M-Marseille-F-Lucas_Pouille-Karen_Khachanov,Lucas Pouille,Karen Khachanov,R,R,M,20180225.0,Marseille,F,3:10 PM,Court Central,Hard,Cedric Mourier,3.0,1,ChapelHeel66
+20180225-M-Delray_Beach-F-Francis_Tiafoe-Peter_Gojowczyk,Francis Tiafoe,Peter Gojowczyk,R,R,M,20180225.0,Delray Beach,F,3:15 PM,Stadium,Hard,Fergus Murphy,3.0,1,ChapelHeel66
+20180217-M-Chennai_CH-R32-Jordan_Thompson-Karim_Mohamed_Maamoun,Jordan Thompson,Karim Mohamed Maamoun,R,R,M,20180217.0,Chennai CH,R32,10:00 AM,Center,Hard,,3.0,1,ahmedabdelaal
+20180215-M-Rotterdam-R16-Roger_Federer-Philipp_Kohlschreiber,Roger Federer,Philipp Kohlschreiber,R,R,M,20180215.0,Rotterdam,R16,7:40 PM,Centre,Hard,Cedric Mourier,3.0,1,ChapelHeel66
+20180210-M-Sofia-SF-Jozef_Kovalik-Marius_Copil,Jozef Kovalik,Marius Copil,R,R,M,20180210.0,Sofia,SF,14:10,Centre,Hard,Mohamed El Jennati,3.0,1,tsitsi
+20180208-M-Sofia-R16-Stanislas_Wawrinka-Martin_Klizan,Stanislas Wawrinka,Martin Klizan,R,L,M,20180208.0,Sofia,R16,18:45,Centre,Hard,Renaud Lichtenstein,3.0,1,MaGav
+20180128-M-Australian_Open-F-Marin_Cilic-Roger_Federer,Marin Cilic,Roger Federer,R,R,M,20180128.0,Australian Open,F,5:30 PM,Rod Laver Arena,Hard,Jake Garner,5.0,0,Palaver
+20180127-M-Newport_Beach_CH-SF-Bradley_Klahn-Christian_Garin,Bradley Klahn,Christian Garin,L,R,M,20180127.0,Newport Beach CH,SF,10:05,Centre,Hard,,3.0,1,tsitsi
+20180126-M-Australian_Open-SF-Hyeon_Chung-Roger_Federer,Hyeon Chung,Roger Federer,R,R,M,20180126.0,Australian Open,SF,19:30,Rod Laver Arena,Hard,Carlos Ramos,5.0,0,DanF
+20180124-M-Australian_Open-QF-Tomas_Berdych-Roger_Federer,Tomas Berdych,Roger Federer,R,R,M,20180124.0,Australian Open,QF,5:35 PM,Rod Laver Arena,Hard,Fergus Murphy,5.0,0,Palaver
+20180123-M-Australian_Open-QF-Rafael_Nadal-Marin_Cilic,Rafael Nadal,Marin Cilic,L,R,M,20180123.0,Australian Open,QF,5:15 PM,,Hard,Eva Asderaki,5.0,0,Palaver
+20180122-M-Australian_Open-R16-Roger_Federer-Marton_Fucsovics,Roger Federer,Marton Fucsovics,R,R,M,20180122.0,Australian Open,R16,5:35 PM,,Hard,Carlos Bernardes,5.0,0,Palaver
+20180121-M-Australian_Open-R16-Grigor_Dimitrov-Nick_Kyrgios,Grigor Dimitrov,Nick Kyrgios,R,R,M,20180121.0,Australian Open,R16,,RLA,Hard,,5.0,0,JEH
+20180120-M-Australian_Open-R32-Roger_Federer-Richard_Gasquet,Roger Federer,Richard Gasquet,R,R,M,20180120.0,Australian Open,R32,5:05 PM,Rod Laver Arena,Hard,Marija Cicak,5.0,0,Palaver
+20180118-M-Australian_Open-R64-Jan_Lennard_Struff-Roger_Federer,Jan Lennard Struff,Roger Federer,R,R,M,20180118.0,Australian Open,R64,5:35 PM,Rod Laver Arena,Hard,,5.0,0,Palaver
+20180117-M-Koblenz_CH-R32-Christopher_Heyman-Karim_Mohamed_Maamoun,Christopher Heyman,Karim Mohamed Maamoun,L,R,M,20180117.0,Koblenz CH,R32,,,Hard,,3.0,1,ahmedabdelaal
+20180117-M-Australian_Open-R64-Grigor_Dimitrov-Mackenzie_Mcdonald,Grigor Dimitrov,Mackenzie Mcdonald,R,R,M,20180117.0,Australian Open,R64,8:15 PM,Rod Laver Arena,Hard,Marijana Veljovic,5.0,0,MaGav
+20180116-M-Australian_Open-R128-Roger_Federer-Aljaz_Bedene,Roger Federer,Aljaz Bedene,R,R,M,20180116.0,Australian Open,R128,7:15 PM,Rod Laver Arena,Hard,Carlos Bernardes,5.0,0,Palaver
+20180107-M-Brisbane-F-Ryan_Harrison-Nick_Kyrgios,Ryan Harrison,Nick Kyrgios,R,R,M,20180107.0,Brisbane,F,,Centre,Hard,,3.0,1,JEH
+20180106-M-Brisbane-SF-Grigor_Dimitrov-Nick_Kyrgios,Grigor Dimitrov,Nick Kyrgios,R,R,M,20180106.0,Brisbane,SF,,Centre,Hard,,3.0,1,JEH
+20171119-M-Tour_Finals-F-Grigor_Dimitrov-David_Goffin,Grigor Dimitrov,David Goffin,R,R,M,20171119.0,Tour Finals,F,6:00 PM,Centre,Hard,Mohamed Lahyani,3.0,1,Edo
+20171113-M-Pune_CH-R32-N_Sriram_Balaji-Karim_Mohamed_Maamoun,N Sriram Balaji,Karim Mohamed Maamoun,R,R,M,20171113.0,Pune CH,R32,,Center,Hard,,3.0,1,ahmedabdelaal
+20171105-M-Paris_Masters-F-Filip_Krajinovic-Jack_Sock,Filip Krajinovic,Jack Sock,R,R,M,20171105.0,Paris Masters,F,3:00 PM,Centre,Hard,Damien Dumusois,3.0,1,Edo
+20171030-M-Eckental_CH-R32-Karim_Mohamed_Maamoun-Mirza_Basic,Karim Mohamed Maamoun,Mirza Basic,R,R,M,20171030.0,Eckental CH,R32,,1,Hard,,3.0,1,ahmedabdelaal
+20171029-M-Basel-F-Juan_Martin_Del_Potro-Roger_Federer,Juan Martin Del Potro,Roger Federer,R,R,M,20171029.0,Basel,F,3:00 PM,Centre,Hard,Damien Domusois,3.0,1,Edo
+20171015-M-Shanghai_Masters-F-Rafael_Nadal-Roger_Federer,Rafael Nadal,Roger Federer,L,R,M,20171015.0,Shanghai Masters,F,4:30:00 PM,Stadium,Hard,Cedric Mourier,3.0,1,Edo
+20171014-M-Shanghai_Masters-SF-Juan_Martin_Del_Potro-Roger_Federer,Juan Martin Del Potro,Roger Federer,R,R,M,20171014.0,Shanghai Masters,SF,,Center,Hard,Nacho Forcadell,3.0,0,mhaynes
+20170925-M-Chengdu-F-Denis_Istomin-Marcos_Baghdatis,Denis Istomin,Marcos Baghdatis,R,R,M,20170925.0,Chengdu,F,,,Hard,,3.0,1,DanF
+20170921-M-Metz-R16-Benoit_Paire-Marcel_Granollers,Benoit Paire,Marcel Granollers,R,R,M,20170921.0,Metz,R16,,,Hard,,3.0,1,Isaac
+20170921-M-Izmir_CH-R16-Aleksandr_Nedovyesov-Karim_Mohamed_Maamoun,Aleksandr Nedovyesov,Karim Mohamed Maamoun,R,R,M,20170921.0,Izmir CH,R16,,Center,Hard,,3.0,1,ahmedabdelaal
+20170919-M-Izmir_CH-R32-Malek_Jaziri-Karim_Mohamed_Maamoun,Malek Jaziri,Karim Mohamed Maamoun,R,R,M,20170919.0,Izmir CH,R32,,,Hard,,3.0,1,ahmedabdelaal
+20170916-M-Istanbul_CH-SF-Malek_Jaziri-Karim_Mohamed_Maamoun,Malek Jaziri,Karim Mohamed Maamoun,R,R,M,20170916.0,Istanbul CH,SF,,Center,Hard,,3.0,1,ahmedabdelaal
+20170915-M-Istanbul_CH-QF-Altug_Celikbilek-Karim_Mohamed_Maamoun,Altug Celikbilek,Karim Mohamed Maamoun,R,R,M,20170915.0,Istanbul CH,QF,,,Hard,,3.0,1,ahmedabdelaal
+20170913-M-Istanbul_CH-R16-Karim_Mohamed_Maamoun-Uladzimir_Ignatik,Karim Mohamed Maamoun,Uladzimir Ignatik,R,R,M,20170913.0,Istanbul CH,R16,,,Hard,,3.0,1,ahmedabdelaal
+20170910-M-US_Open-F-Kevin_Anderson-Rafael_Nadal,Kevin Anderson,Rafael Nadal,R,L,M,20170910.0,US Open,F,4:00 PM,Ashe,Hard,Jake Garner,5.0,1,Edo
+20170908-M-US_Open-SF-Rafael_Nadal-Juan_Martin_Del_Potro,Rafael Nadal,Juan Martin Del Potro,L,R,M,20170908.0,US Open,SF,7pm,Ashe,Hard,James Keothavong,5.0,1,Edo
+20170904-M-Alphen_Aan_Den_Rijn_CH-R32-Yannick_Maden-Karim_Mohamed_Maamoun,Yannick Maden,Karim Mohamed Maamoun,R,R,M,20170904.0,Alphen Aan Den Rijn CH,R32,,6,Clay,,3.0,1,ahmedabdelaal
+20170829-M-US_Open_-R128-Rafael_Nadal-Dusan_Lajovic,Rafael Nadal,Dusan Lajovic,L,R,M,20170829.0,US Open ,R128,,,Hard,,5.0,1,Isaac
+20170819-M-Meerbusch_CH-SF-Andreas_Haider_Maurer-Karim_Mohamed_Maamoun,Andreas Haider Maurer,Karim Mohamed Maamoun,R,R,M,20170819.0,Meerbusch CH,SF,,Center,Clay,,3.0,1,ahmedabdelaal
+20170818-M-Meerbusch_CH-QF-Jeremy_Jahn-Karim_Mohamed_Maamoun,Jeremy Jahn,Karim Mohamed Maamoun,R,R,M,20170818.0,Meerbusch CH,QF,,,Clay,,3.0,1,ahmedabdelaal
+20170817-M-Meerbusch_CH-R16-Marc_Sieber-Karim_Mohamed_Maamoun,Marc Sieber,Karim Mohamed Maamoun,L,R,M,20170817.0,Meerbusch CH,R16,,Center,Clay,,3.0,1,ahmedabdelaal
+20170805-M-Kitzbuhel-F-Philipp_Kohlschreiber-Joao_Sousa,Philipp Kohlschreiber,Joao Sousa,R,R,M,20170805.0,Kitzbuhel,F,11:30 AM,Centre Court,Clay,Cedric Mourier,3.0,1,ChapelHeel66
+20170804-M-Kitzbuhel-SF-Fabio_Fognini-Philipp_Kohlschreiber,Fabio Fognini,Philipp Kohlschreiber,R,R,M,20170804.0,Kitzbuhel,SF,1:10 PM,Centre Court,Clay,Cedric Mourier,3.0,1,ChapelHeel66
+20170803-M-Segovia_CH-R16-Karim_Mohamed_Maamoun-Alex_De_Minaur,Karim Mohamed Maamoun,Alex De Minaur,R,R,M,20170803.0,Segovia CH,R16,,Center,Hard,,3.0,1,ahmedabdelaal
+20170724-M-Bastad-F-Alexandr_Dolgopolov-David_Ferrer,Alexandr Dolgopolov,David Ferrer,R,R,M,20170724.0,Bastad,F,2:00 PM,Centre Court,Clay,Cedric Mourier,3.0,1,ChapelHeel66
+20170716-M-Wimbledon-F-Marin_Cilic-Roger_Federer,Marin Cilic,Roger Federer,R,R,M,20170716.0,Wimbledon,F,14:00:00,Centre,Grass,Damien Dumusois,5.0,0,Edo
+20170714-M-Wimbledon-SF-Tomas_Berdych-Roger_Federer,Tomas Berdych,Roger Federer,R,R,M,20170714.0,Wimbledon,SF,4.30pm,Centre,Grass,Pascal Maria,5.0,0,Edo
+20170714-M-Wimbledon-SF-Marin_Cilic-Sam_Querrey,Marin Cilic,Sam Querrey,R,R,M,20170714.0,Wimbledon,SF,1pm,Centre,Grass,James Keothavong,5.0,0,Edo
+20170710-M-Wimbledon-R16-Grigor_Dimitrov-Roger_Federer,Grigor Dimitrov,Roger Federer,R,R,M,20170710.0,Wimbledon,R16,5:12 PM,Centre,Grass,,5.0,0,Lowell
+20170710-M-Wimbledon-R16-Gilles_Muller-Rafael_Nadal,Gilles Muller,Rafael Nadal,L,L,M,20170710.0,Wimbledon,R16,15:45,Centre,Grass,Ali Nili,5.0,0,1HandBH
+20170621-M-Queens_Club-R16-Tomas_Berdych-Denis_Shapovalov,Tomas Berdych,Denis Shapovalov,R,L,M,20170621.0,Queens Club,R16,17:20,Centre,Grass,,3.0,1,marct
+20170619-M-Halle-F-Alexander_Zverev-Roger_Federer,Alexander Zverev,Roger Federer,R ,R,M,20170619.0,Halle,F,,,Grass,,3.0,1,DanF
+20170614-M-Stuttgart-R16-Tommy_Haas-Roger_Federer,Tommy Haas,Roger Federer,R,R,M,20170614.0,Stuttgart,R16,,Center,Grass,Fergus Murphy,3.0,1,Palaver
+20170611-M-Roland_Garros-F-Rafael_Nadal-Stanislas_Wawrinka,Rafael Nadal,Stanislas Wawrinka,R,L,M,20170611.0,Roland Garros,F,3:00 PM,Philippe Chatrier,Clay,Pascal Maria,5.0,0,Edo
+20170609-M-Roland_Garros-SF-Stanislas_Wawrinka-Andy_Murray,Stanislas Wawrinka,Andy Murray,R,R,M,20170609.0,Roland Garros,SF,1pm,Philippe Chatrier,Clay,Jake Garner,5.0,0,Edo
+20170531-M-Roland_Garros-R64-Sergiy_Stakhovsky-David_Goffin,Sergiy Stakhovsky,David Goffin,R,R,M,20170531.0,Roland Garros,R64,11:00 AM,2,Clay,Louise Azemar Engzell,5.0,0,ChapelHeel66
+20170530-M-Roland_Garros-R128-Nick_Kyrgios-Philipp_Kohlschreiber,Nick Kyrgios,Philipp Kohlschreiber,R,R,M,20170530.0,Roland Garros,R128,11:00 AM,2,Clay,Jake Garner,5.0,0,ChapelHeel66
+20170521-M-Rome_Masters-F-Novak_Djokovic-Alexander_Zverev,Novak Djokovic,Alexander Zverev,R,R,M,20170521.0,Rome Masters,F,16:00,Centrale,Clay,Fergus Murphy,3.0,1,Edo
+20170517-M-Samarkand_CH-R16-Karim_Mohamed_Maamoun-Nikola_Milojevic,Karim Mohamed Maamoun,Nikola Milojevic,R,R,M,20170517.0,Samarkand CH,R16,,Center,Clay,,3.0,1,ahmedabdelaal
+20170516-M-Samarkand_CH-R32-Sanjar_Fayziev-Karim_Mohamed_Maamoun,Sanjar Fayziev,Karim Mohamed Maamoun,R,R,M,20170516.0,Samarkand CH,R32,10:00 AM,1,Clay,,3.0,1,ahmedabdelaal
+20170514-M-Madrid_Masters-F-Rafael_Nadal-Dominic_Thiem,Rafael Nadal,Dominic Thiem,L,R,M,20170514.0,Madrid Masters,F,15:00,Manolo Santana,Clay,Mohamed Lahyani,3.0,1,Edo
+20170510-M-Karshi_CH-R16-Sergiy_Stakhovsky-Karim_Mohamed_Maamoun,Sergiy Stakhovsky,Karim Mohamed Maamoun,R,R,M,20170510.0,Karshi CH,R16,10:30 AM,Center,Hard,,3.0,1,ahmedabdelaal
+20170508-M-Karshi_CH-R32-Dzmitry_Zhyrmont-Karim_Mohamed_Maamoun,Dzmitry Zhyrmont,Karim Mohamed Maamoun,R,R,M,20170508.0,Karshi CH,R32,,Centre,Hard,,3.0,1,ahmedabdelaal
+20170430-M-Budapest-F-Lucas_Pouille-Aljaz_Bedene,Lucas Pouille,Aljaz Bedene,R,R,M,20170430.0,Budapest,F,,,Clay,,3.0,1,DanF
+20170423-M-Monte_Carlo_Masters-F-Rafael_Nadal-Albert_Ramos,Rafael Nadal,Albert Ramos,L,L,M,20170423.0,Monte Carlo Masters,F,2.45 PM,Ranieri III,Clay,Damien Dumusois,3.0,1,Edo
+20170418-M-Qingdao_CH-R32-Thomas_Fabbiano-Karim_Mohamed_Maamoun,Thomas Fabbiano,Karim Mohamed Maamoun,R,R,M,20170418.0,Qingdao CH,R32,10:00 AM,2,Clay,,3.0,1,ahmedabdelaal
+20170401-M-Miami_Masters-SF-Roger_Federer-Nick_Kyrgios,Roger Federer,Nick Kyrgios,R,R,M,20170401.0,Miami Masters,SF,7:00:00 PM,Centre,Hard,Mohamed Lahyani,3.0,1,Edo
+20170327-M-Miami_Masters-R16-Roger_Federer-Juan_Martin_Del_Potro,Roger Federer,Juan Martin Del Potro,R,R,M,20170327.0,Miami Masters,R16,3pm,Stadium,Hard,Mohamed Lahyani,3.0,1,Edo
+20170319-M-Indian_Wells_Masters-F-Roger_Federer-Stanislas_Wawrinka,Roger Federer,Stanislas Wawrinka,R,R,M,20170319.0,Indian Wells Masters,F,16:00:00 pm,Centre,Hard,Damien Dumusois,3.0,1,Edo
+20170318-M-Indian_Wells_Masters-SF-Stanislas_Wawrinka-Pablo_Carreno_Busta,Stanislas Wawrinka,Pablo Carreno Busta,R,R,M,20170318.0,Indian Wells Masters,SF,14:10,Stadium 1,Hard,Fergus Murphy,3.0,1,tsitsi
+20170318-M-Indian_Wells_Masters-SF-Roger_Federer-Jack_Sock,Roger Federer,Jack Sock,R,R,M,20170318.0,Indian Wells Masters,SF,15:35,Stadium 1,Hard,Damian Steiner,3.0,1,tsitsi
+20170318-M-Drummondville_CH-SF-Denis_Shapovalov-Felix_Auger_Aliassime,Denis Shapovalov,Felix Auger Aliassime,L,R,M,20170318.0,Drummondville CH,SF,13:15,Centre,Hard,,3.0,1,1HandBH
+20170227-M-Dubai-F-Andy_Murray-Fernando_Verdasco,Andy Murray,Fernando Verdasco,R,L,M,20170227.0,Dubai,F,,,Hard,,3.0,1,DanF
+20170226-M-Delray_Beach-SF-Milos_Raonic-Juan_Martin_Del_Potro,Milos Raonic,Juan Martin Del Potro,R,R,M,20170226.0,Delray Beach,SF,,,Hard,,3.0,1,Isaac
+20170225-M-Acapulco-F-Sam_Querrey-Rafael_Nadal,Sam Querrey,Rafael Nadal,R ,L,M,20170225.0,Acapulco,F,,Central,Hard,,3.0,1,DanF
+20170224-M-Marseille-QF-Lucas_Pouille-Daniil_Medvedev,Lucas Pouille,Daniil Medvedev,R,R,M,20170224.0,Marseille,QF,7:10 PM,Court Central,Hard,Damiano Torella,3.0,1,ChapelHeel66
+20170219-M-Buenos_Aires-F-Alexandr_Dolgopolov-Kei_Nishikori,Alexandr Dolgopolov,Kei Nishikori,R,R,M,20170219.0,Buenos Aires,F,12:15 PM,,Clay,Damian Steiner,3.0,1,ChapelHeel66
+20170216-M-Cherbourg_CH-R16-Axel_Michon-Peter_Gojowczyk,Axel Michon,Peter Gojowczyk,L,R,M,20170216.0,Cherbourg CH,R16,,,Hard,,3.0,1,Isaac
+20170212-M-Sofia-F-Grigor_Dimitrov-David_Goffin,Grigor Dimitrov,David Goffin,R,R,M,20170212.0,Sofia,F,,,Hard,,3.0,1,Isaac
+20170211-M-San_Francisco_CH-SF-Vasek_Pospisil-Michael_Mmoh,Vasek Pospisil,Michael Mmoh,R,R,M,20170211.0,San Francisco CH,SF,7:00pm,Kunal Patel Stadium Court,Hard,,3.0,1,@CanuckKicker
+20170210-M-San_Francisco_CH-QF-Vasek_Pospisil-Francis_Tiafoe,Vasek Pospisil,Francis Tiafoe,R,R,M,20170210.0,San Francisco CH,QF,9:00PM,Kunal Patel Stadium Cort,Hard,,3.0,1,@CanuckKicker
+20170206-M-Montpellier-F-Richard_Gasquet-Alexander_Zverev,Richard Gasquet,Alexander Zverev,R,R,M,20170206.0,Montpellier,F,,,Hard,,3.0,1,DanF
+20170206-M-Davis_Cup_World_Group_R1-RR-Kyle_Edmund-Denis_Shapovalov,Kyle Edmund,Denis Shapovalov,R,L,M,20170206.0,Davis Cup World Group R1,RR,,,Hard,Arnaud Gabas,5.0,0,@CanuckKicker
+20170127-M-Australian_Open-SF-Rafael_Nadal-Grigor_Dimitrov,Rafael Nadal,Grigor Dimitrov,L,R,M,20170127.0,Australian Open,SF,,,Hard,,5.0,0,Isaac
+20170126-M-Australian_Open-SF-Roger_Federer-Stanislas_Wawrinka,Roger Federer,Stanislas Wawrinka,R,R,M,20170126.0,Australian Open,SF,,Rod Laver Arena,Hard,,5.0,0,camyu19
+20170124-M-Australian_Open-QF-Roger_Federer-Mischa_Zverev,Roger Federer,Mischa Zverev,R,L,M,20170124.0,Australian Open,QF,19:25,Rod Laver Arena,Hard,Carlos Ramos,5.0,0,1HandBH
+20170124-M-Australian_Open-QF-Milos_Raonic-Rafael_Nadal,Milos Raonic,Rafael Nadal,R,L,M,20170124.0,Australian Open,QF,,,Hard,Eva Asderaki-Moore,5.0,0,@CanuckKicker
+20170122-M-Australian_Open-R16-Roger_Federer-Kei_Nishikori,Roger Federer,Kei Nishikori,R,R,M,20170122.0,Australian Open,R16,,RLA,Hard,,5.0,0,Isaac
+20170121-M-Australian_Open-R32-Rafael_Nadal-Alexander_Zverev,Rafael Nadal,Alexander Zverev,L,R,M,20170121.0,Australian Open,R32,,RLA,Hard,,5.0,0,JEH
+20170121-M-Australian_Open-R32-Milos_Raonic-Gilles_Simon,Milos Raonic,Gilles Simon,R,R,M,20170121.0,Australian Open,R32,,Hisense,Hard,Nico Helwerth,5.0,0,@CanuckKicker
+20170120-M-Australian_Open-R32-Tomas_Berdych-Roger_Federer,Tomas Berdych,Roger Federer,R,R,M,20170120.0,Australian Open,R32,,Rod Laver Arena,Hard,,5.0,0,camyu19
+20170119-M-Australian_Open-R64-Novak_Djokovic-Denis_Istomin,Novak Djokovic,Denis Istomin,R,R,M,20170119.0,Australian Open,R64,13:25,Rod Laver Arena,Hard,Mariana Alves,5.0,0,1HandBH
+20170118-M-Australian_Open-R64-Nick_Kyrgios-Andreas_Seppi,Nick Kyrgios,Andreas Seppi,R,R,M,20170118.0,Australian Open,R64,,Hisense,Hard,Carlos Ramos,5.0,0,Bobby
+20170112-M-Auckland-QF-Steve_Johnson-John_Isner,Steve Johnson,John Isner,R,R,M,20170112.0,Auckland,QF,,,Hard,,3.0,1,Isaac
+20170108-M-Chennai-F-Roberto_Bautista_Agut-Daniil_Medvedev,Roberto Bautista Agut,Daniil Medvedev,R ,R ,M,20170108.0,Chennai,F,,,Hard,,3.0,1,DanF
+20170107-M-Doha-F-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20170107.0,Doha,F,,,Hard,,3.0,1,Isaac
+20170104-M-Doha-R16-Jo_Wilfried_Tsonga-Dustin_Brown,Jo Wilfried Tsonga,Dustin Brown,R,R,M,20170104.0,Doha,R16,,Centre,Hard,Adel Nour,3.0,1,Salvo
+20170102-M-Doha-R32-Vasek_Pospisil-Fernando_Verdasco,Vasek Pospisil,Fernando Verdasco,R,L,M,20170102.0,Doha,R32,9:00pm,Centre,Hard,,3.0,1,James Brown
+20161126-M-Andria_CH-SF-Egor_Gerasimov-Matteo_Berrettini,Egor Gerasimov,Matteo Berrettini,R,R,M,20161126.0,Andria CH,SF,,,Hard,,3.0,1,Isaac
+20161120-M-London-F-Andy_Murray-Novak_Djokovic,Andy Murray,Novak Djokovic,R,R,M,20161120.0,London,F,6:00 PM,Centre,Hard,Carlos Bernardes,3.0,1,Edo
+20161118-M-London-RR-Stanislas_Wawrinka-Andy_Murray,Stanislas Wawrinka,Andy Murray,R,R,M,20161118.0,London,RR,,,Hard,,3.0,1,Isaac
+20161106-M-Paris_Masters-F-Andy_Murray-John_Isner,Andy Murray,John Isner,R,R,M,20161106.0,Paris Masters,F,3:00 PM,Centre,Hard,Damien Dumusois,3.0,1,Edo
+20161101-M-Charlottesville_CH-R32-Peter_Polansky-Noah_Rubin,Peter Polansky,Noah Rubin,R,R,M,20161101.0,Charlottesville CH,R32,,,Hard,,3.0,1,Isaac
+20161101-M-Charlottesville_CH-R32-Denis_Kudla-Tommy_Paul,Denis Kudla,Tommy Paul,R,R,M,20161101.0,Charlottesville CH,R32,,,Hard,,3.0,1,Isaac
+20161018-M-Stockholm-R32-Fernando_Verdasco-Mikael_Ymer,Fernando Verdasco,Mikael Ymer,L,R,M,20161018.0,Stockholm,R32,,Centre,Hard,,3.0,1,Matej
+20161017-M-Stockholm-F-Jack_Sock-Juan_Martin_Del_Potro,Jack Sock,Juan Martin Del Potro,R,R,M,20161017.0,Stockholm,F,,,Hard,,3.0,1,DanF
+20161016-M-Shanghai_Masters-F-Roberto_Bautista_Agut-Andy_Murray,Roberto Bautista Agut,Andy Murray,R,R,M,20161016.0,Shanghai Masters,F,5:00 PM,Stadium,Hard,Damien Dumusois,3.0,1,Edo
+20160919-M-Metz-F-Lucas_Pouille-Dominic_Thiem,Lucas Pouille,Dominic Thiem,R,R,M,20160919.0,Metz,F,,,Hard,,3.0,0,DanF
+20160911-M-US_Open-F-Novak_Djokovic-Stanislas_Wawrinka,Novak Djokovic,Stanislas Wawrinka,R,R,M,20160911.0,US Open,F,4:00 PM,Ashe,Hard,Ali Nili,5.0,1,Edo
+20160909-M-US_Open-SF-Stanislas_Wawrinka-Kei_Nishikori,Stanislas Wawrinka,Kei Nishikori,R,R,M,20160909.0,US Open,SF,6.30pm,Ashe,Hard,Jake Garner,5.0,1,Edo
+20160909-M-US_Open-SF-Novak_Djokovic-Gael_Monfils,Novak Djokovic,Gael Monfils,R,R,M,20160909.0,US Open,SF,3pm,Ashe,Hard,Eva Asderaki-Moore,5.0,1,Edo
+20160908-M-US_Open-QF-Juan_Martin_Del_Potro-Stanislas_Wawrinka,Juan Martin Del Potro,Stanislas Wawrinka,R,R,M,20160908.0,US Open,QF,,Ashe,Hard,,5.0,1,Edged
+20160906-M-US_Open-QF-Lucas_Pouille-Gael_Monfils,Lucas Pouille,Gael Monfils,R,R,M,20160906.0,US Open,QF,,Arthur Ashe,Hard,,5.0,1,Edged
+20160807-M-Granby_CH-F-Marcelo_Arevalo-Francis_Tiafoe,Marcelo Arevalo,Francis Tiafoe,R,R,M,20160807.0,Granby CH,F,,,Hard,,3.0,1,Isaac
+20160804-M-Granby_CH-R16-Gregoire_Barrere-Denis_Shapovalov,Gregoire Barrere,Denis Shapovalov,R,L,M,20160804.0,Granby CH,R16,,,Hard,,3.0,1,Isaac
+20160731-M-Astana_CH-F-Evgeny_Donskoy-Konstantin_Kravchuk,Evgeny Donskoy,Konstantin Kravchuk,R,R,M,20160731.0,Astana CH,F,,,Hard,,3.0,1,Isaac
+20160730-M-Canada_Masters-SF-Novak_Djokovic-Gael_Monfils,Novak Djokovic,Gael Monfils,R,R,M,20160730.0,Canada Masters,SF,,,Hard,,3.0,1,Isaac
+20160729-M-Scheveningen_CH-QF-Alexey_Vatutin-Robin_Haase,Alexey Vatutin,Robin Haase,R,R,M,20160729.0,Scheveningen CH,QF,,,Clay,,3.0,1,Isaac
+20160724-M-Washington-F-Gael_Monfils-Ivo_Karlovic,Gael Monfils,Ivo Karlovic,R,R,M,20160724.0,Washington,F,3:15 PM,Center,Hard,Carlos Bernardes,3.0,1,ChapelHeel66
+20160720-M-Washington-R32-Taylor_Harry_Fritz-Alexander_Zverev,Taylor Harry Fritz,Alexander Zverev,R,R,M,20160720.0,Washington,R32,5:00 PM,Center,Hard,Zsolt Beda,3.0,1,ChapelHeel66
+20160718-M-Washington-R64-Dudi_Sela-Taylor_Harry_Fritz,Dudi Sela,Taylor Harry Fritz,R,R,M,20160718.0,Washington,R64,,Stadium,Hard,Richard Haigh,3.0,1,Edged
+20160718-M-Washington-R64-Dudi_Sela-Taylor_Fritz,Dudi Sela,Taylor Fritz,R,R,M,20160718.0,Washington,R64,,Stadium,Hard,Richard Haigh,3.0,1,Edged
+20160716-M-Hamburg-SF-Pablo_Cuevas-Renzo_Olivo,Pablo Cuevas,Renzo Olivo,R,R,M,20160716.0,Hamburg,SF,,Centre,Clay,Roland Herfel,3.0,1,Edged
+20160716-M-Hamburg-SF-Martin_Klizan-Stephane_Robert,Martin Klizan,Stephane Robert,L,R,M,20160716.0,Hamburg,SF,,Centre,Clay,Damian Steiner,3.0,1,Edged
+20160710-M-Winnetka_CH-F-Yoshihito_Nishioka-Francis_Tiafoe,Yoshihito Nishioka,Francis Tiafoe,L,R,M,20160710.0,Winnetka CH,F,,,Hard,,3.0,1,Isaac
+20160710-M-Wimbledon-F-Milos_Raonic-Andy_Murray,Milos Raonic,Andy Murray,R,R,M,20160710.0,Wimbledon,F,14:00:00,Centre,Grass,Jake Garner,5.0,0,Edo
+20160708-M-Wimbledon-SF-Milos_Raonic-Roger_Federer,Milos Raonic,Roger Federer,R,R,M,20160708.0,Wimbledon,SF,13:00:00,Centre,Grass,Damien Dumusois,5.0,0,Edged
+20160708-M-Wimbledon-SF-Andy_Murray-Tomas_Berdych,Andy Murray,Tomas Berdych,R,R,M,20160708.0,Wimbledon,SF,18:00,Centre,Grass,Carlos Bernardes,5.0,0,Edged
+20160706-M-Wimbledon-QF-Marin_Cilic-Roger_Federer,Marin Cilic,Roger Federer,R,R,M,20160706.0,Wimbledon,QF,13:00:00,Centre,Grass,Pascal Maria,5.0,0,Edo
+20160629-M-Wimbledon-R64-Roger_Federer-Marcus_Willis,Roger Federer,Marcus Willis,R,L,M,20160629.0,Wimbledon,R64,17:00,Centre,Grass,Carlos Ramos,5.0,0,1HandBH
+20160619-M-Fergana_CH-F-Radu_Albot-Konstantin_Kravchuk,Radu Albot,Konstantin Kravchuk,R,R,M,20160619.0,Fergana CH,F,,,Hard,,3.0,1,Isaac
+20160611-M-Stuttgart-SF-Roger_Federer-Dominic_Thiem,Roger Federer,Dominic Thiem,R,R,M,20160611.0,Stuttgart,SF,,,Grass,,3.0,0,Briton Park
+20160607-M-Stuttgart-R32-Viktor_Troicki-Florian_Mayer,Viktor Troicki,Florian Mayer,R,R,M,20160607.0,Stuttgart,R32,,Center,Grass,Carlos Bernardes,3.0,1,ChapelHeel66
+20160603-M-Roland_Garros-SF-Stanislas_Wawrinka-Andy_Murray,Stanislas Wawrinka,Andy Murray,R,R,M,20160603.0,Roland Garros,SF,,Philippe Chatrier,Clay,Carlos Ramos,5.0,0,Edged
+20160603-M-Roland_Garros-SF-Novak_Djokovic-Dominic_Thiem,Novak Djokovic,Dominic Thiem,R,R,M,20160603.0,Roland Garros,SF,,Suzanne Lenglen,Clay,James Keothavong,5.0,0,Edged
+20160528-M-Roland_Garros-R32-Alexander_Zverev-Dominic_Thiem,Alexander Zverev,Dominic Thiem,R,R,M,20160528.0,Roland Garros,R32,,Suzanne Lenglen Court,Clay,,5.0,0,Edged
+20160515-M-Rome_Masters-F-Andy_Murray-Novak_Djokovic,Andy Murray,Novak Djokovic,R,R,M,20160515.0,Rome Masters,F,,Centrale,Clay,Damian Steiner,3.0,1,Edged
+20160513-M-Rome_Masters-QF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20160513.0,Rome Masters,QF,4.30pm,Centre,Clay,Carlos Bernardes,3.0,1,Edo
+20160509-M-Seoul_CH-R32-Ho_Gi_Kang-Yuichi_Sugita,Ho Gi Kang,Yuichi Sugita,L,R,M,20160509.0,Seoul CH,R32,,,Hard,,3.0,1,Isaac
+20160509-M-Rome-R64-Alexander_Zverev-Grigor_Dimitrov,Alexander Zverev,Grigor Dimitrov,R,R,M,20160509.0,Rome,R64,7:42 PM,Center,Clay,,3.0,1,Lowell
+20160506-M-Madrid_Masters-QF-Kei_Nishikori-Nick_Kyrgios,Kei Nishikori,Nick Kyrgios,R,R,M,20160506.0,Madrid Masters,QF,,Arantxa Sanchez Vicario,Clay,Renaud Lichtenstein,3.0,1,Edged
+20160506-M-Madrid_Masters-QF-Andy_Murray-Tomas_Berdych,Andy Murray,Tomas Berdych,R,R,M,20160506.0,Madrid Masters,QF,,Manolo Santana,Clay,Damian Steiner,3.0,1,Edged
+20160505-M-Madrid-R16-Richard_Gasquet-Kei_Nishikori,Richard Gasquet,Kei Nishikori,R,R,M,20160505.0,Madrid,R16,,Court 3,Clay,Jaume Campistol,3.0,1,Edged
+20160504-M-Madrid_Masters-R32-Novak_Djokovic-Borna_Coric,Novak Djokovic,Borna Coric,R,R,M,20160504.0,Madrid Masters,R32,,,Clay,,3.0,1,Isaac
+20160502-M-Karshi_CH-R32-Pavel_Tsoy-Nikola_Milojevic,Pavel Tsoy,Nikola Milojevic,R,R,M,20160502.0,Karshi CH,R32,,Centre Court,Hard,,3.0,1,Isaac
+20160501-M-Munich-F-Dominic_Thiem-Philipp_Kohlschreiber,Dominic Thiem,Philipp Kohlschreiber,R,R,M,20160501.0,Munich,F,,Center Court,Clay,Damian Steiner,3.0,1,Edged
+20160427-M-Istanbul-R32-Teymuraz_Gabashvili-Damir_Dzumhur,Teymuraz Gabashvili,Damir Dzumhur,R,R,M,20160427.0,Istanbul,R32,,Center,Indoor Clay,Rolad Herfel,3.0,1,Edged
+20160425-M-Bucharest-F-Fernando_Verdasco-Lucas_Pouille,Fernando Verdasco,Lucas Pouille,L,R,M,20160425.0,Bucharest,F,,Center,Clay,Cedric Mourier,3.0,1,Edged
+20160421-M-Barcelona-R16-Feliciano_Lopez-Philipp_Kohlschreiber,Feliciano Lopez,Philipp Kohlschreiber,L,R,M,20160421.0,Barcelona,R16,,Pista Central,Clay,Gianluca Moscarella,3.0,1,Edged
+20160420-M-Savannah_CH-R16-Tennys_Sandgren-Gerald_Melzer,Tennys Sandgren,Gerald Melzer,R,L,M,20160420.0,Savannah CH,R16,,Stadium Court,Clay,,3.0,1,Isaac
+20160416-M-Monte_Carlo_Masters-SF-Jo_Wilfried_Tsonga-Gael_Monfils,Jo Wilfried Tsonga,Gael Monfils,R,R,M,20160416.0,Monte Carlo Masters,SF,,Court Rainier III,Clay,Cedric Mourier,3.0,1,Edged
+20160415-M-Gwangju_CH-QF-Grega_Zemlja-Matt_Reid,Grega Zemlja,Matt Reid,R,R,M,20160415.0,Gwangju CH,QF,,,Hard,,3.0,1,Isaac
+20160413-M-Monte_Carlo_Masters-R32-Rafael_Nadal-Aljaz_Bedene,Rafael Nadal,Aljaz Bedene,L,R,M,20160413.0,Monte Carlo Masters,R32,,Court Rainier 3,Clay,,3.0,1,Isaac
+20160413-M-Monte_Carlo_Masters-R32-Novak_Djokovic-Jiri_Vesely,Novak Djokovic,Jiri Vesely,R,L,M,20160413.0,Monte Carlo Masters,R32,,Court Rainier III,Clay,Cedric Mourier,3.0,1,Edged
+20160412-M-Monte_Carlo_Masters-R64-Joao_Sousa-Ivo_Karlovic,Joao Sousa,Ivo Karlovic,R,R,M,20160412.0,Monte Carlo Masters,R64,,9,Clay,Cedric Mourier,3.0,1,Edged
+20160410-M-Marrakech-F-Federico_Delbonis-Borna_Coric,Federico Delbonis,Borna Coric,L,R,M,20160410.0,Marrakech,F,,Centre,Clay,Mohamed Lahyani,3.0,1,Edged
+20160409-M-Houston-SF-John_Isner-Jack_Sock,John Isner,Jack Sock,R,R,M,20160409.0,Houston,SF,,Center,Clay,,3.0,1,Edged
+20160403-M-Miami_Masters-F-Novak_Djokovic-Kei_Nishikori,Novak Djokovic,Kei Nishikori,R,R,M,20160403.0,Miami Masters,F,,Stadium,Hard,,3.0,1,Isaac
+20160328-M-Miami_Masters-R16-Roberto_Bautista_Agut-Jo_Wilfried_Tsonga,Roberto Bautista Agut,Jo Wilfried Tsonga,R,R,M,20160328.0,Miami Masters,R16,,Court 1,Hard,Ali Nili,3.0,1,Edged
+20160328-M-Miami_Masters-QF-Milos_Raonic-Nick_Kyrgios,Milos Raonic,Nick Kyrgios,R,R,M,20160328.0,Miami Masters,QF,,Stadium,Hard,Gianluca Moscarella,3.0,1,Edged
+20160327-M-Miami_Masters-R32-Viktor_Troicki-David_Goffin,Viktor Troicki,David Goffin,R,R,M,20160327.0,Miami Masters,R32,,Court 1,Hard,Damian Steiner,3.0,1,Edged
+20160327-M-Miami_Masters-R32-Tomas_Berdych-Steve_Johnson,Tomas Berdych,Steve Johnson,R,R,M,20160327.0,Miami Masters,R32,11:00 AM,Stadium,Hard,,3.0,0,Rossco
+20160327-M-Miami_Masters-R32-Richard_Gasquet-Benoit_Paire,Richard Gasquet,Benoit Paire,R,R,M,20160327.0,Miami Masters,R32,,Grandstand,Hard,Damien Dumusois,3.0,1,Edged
+20160326-M-San_Luis_Potosi_CH-SF-Marcelo_Arevalo-Federico_Gaio,Marcelo Arevalo,Federico Gaio,R,R,M,20160326.0,San Luis Potosi CH,SF,,,Clay,,3.0,1,Isaac
+20160326-M-San_Luis_Potosi_CH-SF-Albert_Montanes-Pedja_Krstin,Albert Montanes,Pedja Krstin,R,R,M,20160326.0,San Luis Potosi CH,SF,,,Clay,,3.0,1,Isaac
+20160323-M-Guadalajara_CH-R16-Dennis_Novikov-Eduardo_Struvay,Dennis Novikov,Eduardo Struvay,R,R,M,20160323.0,Guadalajara CH,R16,,,Hard,,3.0,1,Isaac
+20160320-M-Indian_Wells_Masters-F-Milos_Raonic-Novak_Djokovic,Milos Raonic,Novak Djokovic,R,R,M,20160320.0,Indian Wells Masters,F,,Stadium 1,Hard,,3.0,1,Isaac
+20160319-M-Indian_Wells_Masters-SF-Rafael_Nadal-Novak_Djokovic,Rafael Nadal,Novak Djokovic,L,R,M,20160319.0,Indian Wells Masters,SF,,Stadium 1,Hard,,3.0,1,Isaac
+20160317-M-Indian_Wells_Masters-QF-Marin_Cilic-David_Goffin,Marin Cilic,David Goffin,R,R,M,20160317.0,Indian Wells Masters,QF,,Stadium 1,Hard,Cedric Mourier,3.0,1,Edged
+20160316-M-Indian_Wells_Masters-R16-Jo_Wilfried_Tsonga-Dominic_Thiem,Jo Wilfried Tsonga,Dominic Thiem,R,R,M,20160316.0,Indian Wells Masters,R16,,Stadium 1,Hard,Fergus Murphy,3.0,1,Edged
+20160315-M-Indian_Wells_Masters-R32-Gilles_Simon-Alexander_Zverev,Gilles Simon,Alexander Zverev,R,R,M,20160315.0,Indian Wells Masters,R32,,Stadium 3,Hard,Mohamed Lahyani,3.0,1,Edged
+20160312-M-Indian_Wells_Masters-R64-Stanislas_Wawrinka-Illya_Marchenko,Stanislas Wawrinka,Illya Marchenko,R,R,M,20160312.0,Indian Wells Masters,R64,,Stadium 1,Hard,Renaud Lichtenstein,3.0,1,Edged
+20160312-M-Indian_Wells_Masters-R64-Milos_Raonic-Inigo_Cervantes_Huegun,Milos Raonic,Inigo Cervantes Huegun,R,R,M,20160312.0,Indian Wells Masters,R64,,Stadium 2,Hard,Mohamed Lahyani,3.0,1,Edged
+20160312-M-Indian_Wells_Masters-R64-Jeremy_Chardy-Andrey_Kuznetsov,Jeremy Chardy,Andrey Kuznetsov,R,R,M,20160312.0,Indian Wells Masters,R64,,Stadium 5,Hard,Fergus Murphy,3.0,1,Edged
+20160310-M-Puebla_CH-R16-Dennis_Novak-Agustin_Velotti,Dennis Novak,Agustin Velotti,R,R,M,20160310.0,Puebla CH,R16,,Court 1,Hard,,3.0,1,Isaac
+20160310-M-Indian_Wells_Masters-R128-Pablo_Carreno_Busta-Evgeny_Donskoy,Pablo Carreno Busta,Evgeny Donskoy,R,R,M,20160310.0,Indian Wells Masters,R128,,Stadium 5,Hard,F. Souza,3.0,1,Edged
+20160310-M-Indian_Wells_Masters-R128-Damir_Dzumhur-Marcel_Granollers,Damir Dzumhur,Marcel Granollers,R,R,M,20160310.0,Indian Wells Masters,R128,,Stadium 4,Hard,,3.0,1,Isaac
+20160307-M-Puebla_CH-Q3-Fernando_Romboli-Stefano_Napolitano,Fernando Romboli,Stefano Napolitano,R,R,M,20160307.0,Puebla CH,Q3,,Centre Court,Hard,,3.0,1,Isaac
+20160304-M-Quimper_CH-QF-Paul_Henri_Mathieu-Igor_Sijsling,Paul Henri Mathieu,Igor Sijsling,R,R,M,20160304.0,Quimper CH,QF,,,Hard,,3.0,1,Isaac
+20160304-M-Davis_Cup_World_Group_R1-RR-Frank_Dancevic-Gael_Monfils,Frank Dancevic,Gael Monfils,R,R,M,20160304.0,Davis Cup World Group R1,RR,11:00,Velodrome,Clay,Gianluca Moscarella,5.0,1,1HandBH
 20160227-M-Cherbourg_CH-SF-Jordan_Thompson-Vincent_Millot,Jordan Thompson,Vincent Millot,R,L,M,20160227,Cherbourg CH,SF,,,Hard,,3,1,Isaac
-20160226-M-Sao_Paulo-QF-Pablo_Cuevas-Thiago_Monteiro,Pablo Cuevas,Thiago Monteiro,R,L,M,20160226,Sao Paulo,QF,,Centro,Clay,Mohamed Lahyani,3,1,jeffsackmann
-20160226-M-Sao_Paolo-R16-Inigo_Cervantes_Huegun-Federico_Delbonis,Inigo Cervantes Huegun,Federico Delbonis,R,L,M,20160226,Sao Paolo,R16,,,Clay,,3,1,jeffsackmann
 20160225-M-Cherbourg_CH-R16-Ramkumar_Ramanathan-Adam_Pavlasek,Ramkumar Ramanathan,Adam Pavlasek,R,R,M,20160225,Cherbourg CH,R16,,Centre Court,Hard,,3,1,Isaac
 20160223-M-Cherbourg_CH-R32-Jurgen_Zopp-Jordan_Thompson,Jurgen Zopp,Jordan Thompson,R,R,M,20160223,Cherbourg CH,R32,,Centre Court,Hard,,3,1,Isaac
-20160221-M-Rio_de_Janeiro-F-Guido_Pella-Pablo_Cuevas,Guido Pella,Pablo Cuevas,L,R,M,20160221,Rio de Janeiro,F,,Center,Clay,Carlos Bernardes,3,1,jeffsackmann
-20160221-M-Delray_Beach-F-Sam_Querrey-Rajeev_Ram,Sam Querrey,Rajeev Ram,R,R,M,20160221,Delray Beach,F,,Center,Hard,,3,1,jeffsackmann
 20160220-M-Rio_de_Janeiro-SF-Dominic_Thiem-Guido_Pella,Dominic Thiem,Guido Pella,R,L,M,20160220,Rio de Janeiro,SF,,Quadra Central,Clay,Mohamed El Jennati,3,1,Edged
 20160220-M-Marseille-SF-Tomas_Berdych-Nick_Kyrgios,Tomas Berdych,Nick Kyrgios,R,R,M,20160220,Marseille,SF,,Court Central,Indoor Hard,,3,1,Edged
 20160220-M-Marseille-QF-Stanislas_Wawrinka-Benoit_Paire,Stanislas Wawrinka,Benoit Paire,R,R,M,20160220,Marseille,QF,6:40PM,Centre,Hard,,3,1,cameron10
 20160219-M-Wroclaw_CH-QF-Albano_Olivetti-Dustin_Brown,Albano Olivetti,Dustin Brown,R,R,M,20160219,Wroclaw CH,QF,,Center Court,Hard,,3,1,Isaac
 20160219-M-Marseille-QF-Richard_Gasquet-Nick_Kyrgios,Richard Gasquet,Nick Kyrgios,R,R,M,20160219,Marseille,QF,,Court Central,Hard,,3,1,Isaac
-20160219-M-Marseille-QF-Marin_Cilic-Andrey_Kuznetsov,Marin Cilic,Andrey Kuznetsov,R,R,M,20160219,Marseille,QF,,,Hard,,3,1,jeffsackmann
 20160219-M-Delray_Beach-QF-Juan_Martin_Del_Potro-Jeremy_Chardy,Juan Martin Del Potro,Jeremy Chardy,R,R,M,20160219,Delray Beach,QF,,,Hard,,3,1,Isaac
 20160218-M-Rio_de_Janeiro-R16-Inigo_Cervantes_Huegun-Alexandr_Dolgopolov,Inigo Cervantes Huegun,Alexandr Dolgopolov,R,R,M,20160218,Rio de Janeiro,R16,,Quadra Central,Clay,Carlos Bernardes,3,1,Edged
-20160218-M-Delray_Beach-R16-Sam_Querrey-Austin_Krajicek,Sam Querrey,Austin Krajicek,R,R,M,20160218,Delray Beach,R16,,,Hard,,3,1,jeffsackmann
 20160216-M-Delray_Beach-R32-Juan_Martin_Del_Potro-Denis_Kudla,Juan Martin Del Potro,Denis Kudla,R,R,M,20160216,Delray Beach,R32,,,Hard,,3,1,Isaac
-20160213-M-Memphis-SF-Taylor_Harry_Fritz-Ricardas_Berankis,Taylor Harry Fritz,Ricardas Berankis,R,R,M,20160213,Memphis,SF,,,Hard,,3,1,jeffsackmann
 20160213-M-Buenos_Aires-SF-Rafael_Nadal-Dominic_Thiem,Rafael Nadal,Dominic Thiem,L,R,M,20160213,Buenos Aires,SF,14:50,Court Central,Clay,,3,1,1HandBH
-20160211-M-Rotterdam-R16-Nicolas_Mahut-Jeremy_Chardy,Nicolas Mahut,Jeremy Chardy,R,R,M,20160211,Rotterdam,R16,,Center,Hard,,3,1,jeffsackmann
-20160211-M-Buenos_Aires-R16-Paolo_Lorenzi-Diego_Sebastian_Schwartzman,Paolo Lorenzi,Diego Sebastian Schwartzman,R,R,M,20160211,Buenos Aires,R16,,,Clay,Renaud Lichtenstein,3,1,jeffsackmann
-20160209-M-Buenos_Aires-R32-Pablo_Cuevas-Albert_Ramos,Pablo Cuevas,Albert Ramos,R,L,M,20160209,Buenos Aires,R32,,,Clay,,3,1,jeffsackmann
 20160208-M-Rotterdam-R32-Thiemo_De_Bakker-Borna_Coric,Thiemo de Bakker,Borna Coric,R,R,M,20160208,Rotterdam,R32,,Centre Court,Indoor Hard,,3,,Edged
-20160208-M-Rotterdam-R32-Nicolas_Mahut-Teymuraz_Gabashvili,Nicolas Mahut,Teymuraz Gabashvili,R,R,M,20160208,Rotterdam,R32,,Center,Hard,,3,1,jeffsackmann
 20160206-M-Sofia-SF-Roberto_Bautista_Agut-Gilles_Muller,Roberto Bautista Agut,Gilles Muller,R,L,M,20160206,Sofia,SF,,Centre Court,Indoor Hard,Mohamed El Jennat,3,1,Edged
-20160206-M-Quito-SF-Victor_Estrella-Albert_Ramos,Victor Estrella,Albert Ramos,R,L,M,20160206,Quito,SF,,Centro,Clay,Simon Cannavan,3,1,jeffsackmann
-20160206-M-Quito-SF-Paolo_Lorenzi-Thomaz_Bellucci,Paolo Lorenzi,Thomaz Bellucci,R,L,M,20160206,Quito,SF,,Centre,Clay,Renaud Lichtenstein,3,1,jeffsackmann
-20160205-M-Sofia-QF-Martin_Klizan-Andreas_Seppi,Martin Klizan,Andreas Seppi,L,R,M,20160205,Sofia,QF,,,Hard,Mohamed El Jennati,3,1,jeffsackmann
 20160205-M-Quito-QF-Bernard_Tomic-Paolo_Lorenzi,Bernard Tomic,Paolo Lorenzi,R,R,M,20160205,Quito,QF,,Cancha Central,Clay,Mohamed Layani,3,1,Edged
-20160204-M-Quito-R16-Rajeev_Ram-Albert_Ramos,Rajeev Ram,Albert Ramos,R,L,M,20160204,Quito,R16,,,Clay,,3,1,jeffsackmann
-20160204-M-Montpellier-R16-Gilles_Simon-Dustin_Brown,Gilles Simon,Dustin Brown,R,R,M,20160204,Montpellier,R16,,,Hard,,3,1,jeffsackmann
 20160202-M-Sofia-R32-Marius_Copil-Hyeon_Chung,Marius Copil,Hyeon Chung,R,R,M,20160202,Sofia,R32,,Centre Court,Indoor Hard,,3,1,Edged
 20160202-M-Quito-R32-Guido_Pella-Victor_Estrella,Guido Pella,Victor Estrella,L,R,M,20160202,Quito,R32,,Cancha Central,Clay,,3,1,Edged
-20160202-M-Quito-R32-Albert_Ramos-Dusan_Lajovic,Albert Ramos,Dusan Lajovic,L,R,M,20160202,Quito,R32,,,Clay,,3,1,jeffsackmann
 20160202-M-Dallas_CH-R32-Samuel_Groth-Francis_Tiafoe,Samuel Groth,Francis Tiafoe,R,R,M,20160202,Dallas CH,R32,,Stadium Court,Hard,,3,1,Isaac
-20160202-M-Dallas_CH-R32-Kyle_Edmund-Sekou_Bangoura,Kyle Edmund,Sekou Bangoura,R,R,M,20160202,Dallas CH,R32,,Center,Hard,,3,1,jeffsackmann
 20160131-M-Australian_Open-F-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20160131,Australian Open,F,,Rod Laver Arena,Hard,Carlos Ramos,5,0,Edged
 20160129-M-Australian_Open-SF-Andy_Murray-Milos_Raonic,Andy Murray,Milos Raonic,R,R,M,20160129,Australian Open,SF,,Rod Laver Arena,Hard,Jake Garner,5,0,Edged
 20160128-M-Maui_CH-R16-Michael_Mmoh-Kyle_Edmund,Michael Mmoh,Kyle Edmund,R,R,M,20160128,Maui CH,R16,,Center,Hard,,3,1,Isaac
@@ -232,271 +516,141 @@ match_id,Player 1,Player 2,Pl 1 hand,Pl 2 hand,Gender,Date,Tournament,Round,Time
 20160124-M-Australian_Open-R16-Novak_Djokovic-Gilles_Simon,Novak Djokovic,Gilles Simon,R,R,M,20160124,Australian Open,R16,,Rod Laver Arena,Hard,,5,0,Isaac
 20160123-M-Australian_Open-R32-Stanislas_Wawrinka-Lukas_Rosol,Stanislas Wawrinka,Lukas Rosol,R,R,M,20160123,Australian Open,R32,,,Hard,,5,0,Briton
 20160122-M-Australian_Open-R32-Gilles_Simon-Federico_Delbonis,Gilles Simon,Federico Delbonis,R,L,M,20160122,Australian Open,R32,,,Hard,,5,0,pvtennis
+20160120-M-Australian_Open-R64-Roger_Federer_-Alexandr_Dolgopolov,Roger Federer ,Alexandr Dolgopolov,R ,R ,M,20160120,Australian Open,R64,4:00 PM,Rod Laver Arena,Hard,,5,0,Brady Anderson
 20160119-M-Australian_Open-R128-Rafael_Nadal-Fernando_Verdasco,Rafael Nadal,Fernando Verdasco,L,L,M,20160119,Australian Open,R128,,Rod Laver Arena,Hard,,5,1,Isaac
 20160118-M-Manila_CH-R32-Ruben_Gonzales-Igor_Sijsling,Ruben Gonzales,Igor Sijsling,R,R,M,20160118,Manila CH,R32,,,Hard,,3,1,Isaac
-20160116-M-Sydney-SF-Viktor_Troicki-Teymuraz_Gabashvili,Viktor Troicki,Teymuraz Gabashvili,R,R,M,20160116,Sydney,SF,,Centre,Hard,Gianluca Moscarella,3,1,jeffsackmann
 20160116-M-Sydney-F-Viktor_Troicki-Grigor_Dimitrov,Viktor Troicki,Grigor Dimitrov,R,R,M,20160116,Sydney,F,,Ken Rosewall Arena,Hard,Ali Nili,3,1,Edged
 20160116-M-Chennai-F-Stanislas_Wawrinka-Borna_Coric,Stanislas Wawrinka,Borna Coric,R,R,M,20160116,Chennai,F,,,Hard,,3,1,Isaac
-20160115-M-Chennai-SF-Borna_Coric-Aljaz_Bedene,Borna Coric,Aljaz Bedene,R,R,M,20160115,Chennai,SF,,Center,Hard,,3,1,jeffsackmann
-20160114-M-Auckland-QF-Lukas_Rosol-David_Ferrer,Lukas Rosol,David Ferrer,R,R,M,20160114,Auckland,QF,,,Hard,Kader Nouni,3,1,jeffsackmann
-20160113-M-Auckland-R16-Kevin_Anderson-Robin_Haase,Kevin Anderson,Robin Haase,R,R,M,20160113,Auckland,R16,,Centre,Hard,Blaze Trifunovski,3,1,jeffsackmann
-20160111-M-Auckland-R32-Matthew_Barton-Steve_Johnson,Matthew Barton,Steve Johnson,R,R,M,20160111,Auckland,R32,,Centre,Hard,Blaze Trifunovski,3,1,jeffsackmann
 20160110-M-Doha-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20160110,Doha,F,,,Hard,,3,1,Isaac
 20160110-M-Brisbane-F-Roger_Federer-Milos_Raonic,Roger Federer,Milos Raonic,R,R,M,20160110,Brisbane,F,,Pat Rafter Arena,Hard,,3,1,Edged
 20160109-M-Doha-SF-Novak_Djokovic-Tomas_Berdych,Novak Djokovic,Tomas Berdych,R,R,M,20160109,Doha,SF,,,Hard,,3,1,Isaac
 20160109-M-Brisbane-SF-Roger_Federer-Dominic_Thiem,Roger Federer,Dominic Thiem,R,R,M,20160109,Brisbane,SF,,Pat Rafter Arena,Hard,,3,1,Edged
 20160109-M-Brisbane-SF-Milos_Raonic-Bernard_Tomic,Milos Raonic,Bernard Tomic,R,R,M,20160109,Brisbane,SF,,Pat Rafter Arena,Hard,,3,1,Edged
-20160109-M-Bangkok_CH-SF-Mikhail_Youzhny-Marco_Chiudinelli,Mikhail Youzhny,Marco Chiudinelli,R,R,M,20160109,Bangkok CH,SF,,Center,Hard,,3,1,jeffsackmann
-20160108-M-Hopman_Cup-RR-Andy_Murray-Alexander_Zverev,Andy Murray,Alexander Zverev,R,R,M,20160108,Hopman Cup,RR,,,Hard,,3,1,jeffsackmann
 20160108-M-Doha-SF-Rafael_Nadal-Illya_Marchenko,Rafael Nadal,Illya Marchenko,L,R,M,20160108,Doha,SF,,,Hard,,3,1,Isaac
-20160108-M-Chennai-QF-Ramkumar_Ramanathan-Aljaz_Bedene,Ramkumar Ramanathan,Aljaz Bedene,R,R,M,20160108,Chennai,QF,,Center,Hard,,3,1,jeffsackmann
 20160108-M-Brisbane-QF-Roger_Federer-Grigor_Dimitrov,Roger Federer,Grigor Dimitrov,R,R,M,20160108,Brisbane,QF,,,Hard,,3,1,Briton Park
 20160108-M-Brisbane-QF-Lucas_Pouille-Milos_Raonic,Lucas Pouille,Milos Raonic,R,R,M,20160108,Brisbane,QF,,Pat Rafter Arena,Hard,,3,1,Edged
-20160107-M-Doha-QF-Tomas_Berdych-Kyle_Edmund,Tomas Berdych,Kyle Edmund,R,R,M,20160107,Doha,QF,,Center,Hard,Mohamed El Jennati,3,1,jeffsackmann
-20160107-M-Doha-QF-Illya_Marchenko-Jeremy_Chardy,Illya Marchenko,Jeremy Chardy,R,R,M,20160107,Doha,QF,,Center,Hard,Manuel Messina,3,1,jeffsackmann
 20160106-M-Doha-R16-Rafael_Nadal-Robin_Haase,Rafael Nadal,Robin Haase,L,R,M,20160106,Doha,R16,,,Hard,,3,1,Isaac
 20160104-M-Hopman_Cup-RR-Jack_Sock-Alexandr_Dolgopolov,Jack Sock,Alexandr Dolgopolov,R,R,M,20160104,Hopman Cup,RR,11:30,,Hard,,3,1,1HandBH
 20160104-M-Doha-R32-Novak_Djokovic-Dustin_Brown,Novak Djokovic,Dustin Brown,R,R,M,20160104,Doha,R32,,,Hard,,3,1,Amy
-20160104-M-Doha-R32-Feliciano_Lopez-Daniel_Munoz_De_La_Nava,Feliciano Lopez,Daniel Munoz De La Nava,L,L,M,20160104,Doha,R32,,Center,Hard,Cedric Mourier,3,1,jeffsackmann
 20160104-M-Bangkok_CH-R32-Nattan_Benjasupawan-Konstantin_Kravchuk,Nattan Benjasupawan,Konstantin Kravchuk,R,R,M,20160104,Bangkok CH,R32,,,Hard,,3,1,Isaac
-20151129-M-Challenger_Tour_Finals-F-Daniel_Munoz_De_La_Nava-Inigo_Cervantes_Huegun,Daniel Munoz De La Nava,Inigo Cervantes Huegun,L,R,M,20151129,Challenger Tour Finals,F,,,Clay,,3,1,jeffsackmann
-20151127-M-Challenger_Tour_Finals-RR-Daniel_Munoz_De_La_Nava-Paolo_Lorenzi,Daniel Munoz De La Nava,Paolo Lorenzi,L,R,M,20151127,Challenger Tour Finals,RR,,,Clay,,3,1,jeffsackmann
-20151126-M-Challenger_Tour_Finals-RR-Paolo_Lorenzi-Inigo_Cervantes_Huegun,Paolo Lorenzi,Inigo Cervantes Huegun,R,R,M,20151126,Challenger Tour Finals,RR,,,Clay,,3,1,jeffsackmann
-20151125-M-CH_Tour_Finals-RR-Radu_Albot-Guido_Pella,Radu Albot,Guido Pella,R,L,M,20151125,CH Tour Finals,RR,,,Clay,,3,1,jeffsackmann
 20151123-M-Toyota_CH-R32-Sho_Katayama-Gavin_Van_Peperzeel,Sho Katayama,Gavin Van Peperzeel,R,R,M,20151123,Toyota CH,R32,,,Hard,,3,1,Isaac
 20151123-M-Toyota_CH-R32-Makoto_Ochi-Konstantin_Kravchuk,Makoto Ochi,Konstantin Kravchuk,L,R,M,20151123,Toyota CH,R32,,,Hard,,3,1,Isaac
 20151123-M-Andria_CH-R32-Adrien_Bossel-Dudi_Sela,Adrien Bossel,Dudi Sela,L,R,M,20151123,Andria CH,R32,,,Hard,,3,1,Isaac
 20151122-M-Tour_Finals-F-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20151122,Tour Finals,F,,,Hard,,3,1,Amy
-20151122-M-Montevideo_CH-F-Guido_Pella-Inigo_Cervantes_Huegun,Guido Pella,Inigo Cervantes Huegun,L,R,M,20151122,Montevideo CH,F,,,Clay,,3,1,jeffsackmann
 20151121-M-Tour_Finals-SF-Roger_Federer-Stanislas_Wawrinka,Roger Federer,Stanislas Wawrinka,R,R,M,20151121,Tour Finals,SF,8:00 PM,Centre,Hard,Ali Nili,3,1,Edo
 20151121-M-Tour_Finals-SF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20151121,Tour Finals,SF,,,Hard,,3,1,Amy
-20151121-M-Montevideo_CH-SF-Guido_Pella-Pablo_Cuevas,Guido Pella,Pablo Cuevas,L,R,M,20151121,Montevideo CH,SF,,,Clay,,3,1,jeffsackmann
-20151121-M-Montevideo_CH-SF-Diego_Sebastian_Schwartzman-Inigo_Cervantes_Huegun,Diego Sebastian Schwartzman,Inigo Cervantes Huegun,R,R,M,20151121,Montevideo CH,SF,,,Clay,,3,1,jeffsackmann
-20151120-M-Montevideo_CH-QF-Diego_Sebastian_Schwartzman-Horacio_Zeballos,Diego Sebastian Schwartzman,Horacio Zeballos,R,L,M,20151120,Montevideo CH,QF,,,Clay,,3,1,jeffsackmann
 20151119-M-Tour_Finals-RR-Roger_Federer-Kei_Nishikori,Roger Federer,Kei Nishikori,R,R,M,20151119,Tour Finals,RR,2:00 PM,Centre,Hard,Cedric Mourier,3,1,Edo
 20151119-M-Tour_Finals-RR-Novak_Djokovic-Tomas_Berdych,Novak Djokovic,Tomas Berdych,R,R,M,20151119,Tour Finals,RR,,,Hard,,3,1,Amy
-20151119-M-Champaign_CH-R16-Taylor_Harry_Fritz-Daniel_Evans,Taylor Harry Fritz,Daniel Evans,R,R,M,20151119,Champaign CH,R16,,,Hard,,3,1,jeffsackmann
-20151119-M-Champaign_CH-QF-Taylor_Harry_Fritz-Malek_Jaziri,Taylor Harry Fritz,Malek Jaziri,R,R,M,20151119,Champaign CH,QF,,,Hard,,3,1,jeffsackmann
+20151118-M-Tour_Finals-RR-Rafael_Nadal-Andy_Murray,Rafael Nadal,Andy Murray,L,R,M,20151118,Tour Finals,RR,,,Hard,,3,1,Isaac
 20151118-M-Tour_Finals-RR-David_Ferrer-Stanislas_Wawrinka,David Ferrer,Stanislas Wawrinka,R,R,M,20151118,Tour Finals,RR,,,Hard,,3,1,Amy
 20151117-M-Tour_Finals-RR-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20151117,Tour Finals,RR,8:00 PM,Centre,Hard,Mohamed Lahyani,3,1,Edo
-20151117-M-Montevideo_CH-R32-Andrea_Collarini-Kyle_Edmund,Andrea Collarini,Kyle Edmund,L,R,M,20151117,Montevideo CH,R32,,1,Clay,,3,1,jeffsackmann
 20151116-M-Tour_Finals-RR-Rafael_Nadal-Stanislas_Wawrinka,Rafael Nadal,Stanislas Wawrinka,L,R,M,20151116,Tour Finals,RR,,,Hard,,3,1,Edged
 20151116-M-Tour_Finals-RR-Andy_Murray-David_Ferrer,Andy Murray,David Ferrer,R,R,M,20151116,Tour Finals,RR,,,Hard,,3,1,Edged
-20151116-M-Montevideo_CH-R32-Diego_Sebastian_Schwartzman-Orlando_Luz,Diego Sebastian Schwartzman,Orlando Luz,R,R,M,20151116,Montevideo CH,R32,,,Clay,,3,1,jeffsackmann
 20151116-M-Montevideo_CH-R32-Dario_Acosta-Carlos_Berlocq,Dario Acosta,Carlos Berlocq,R,R,M,20151116,Montevideo CH,R32,,,Clay,,3,1,Isaac
 20151116-M-Brescia_CH-QF-Igor_Sijsling-Farrukh_Dustov,Igor Sijsling,Farrukh Dustov,R,R,M,20151116,Brescia CH,QF,,,Hard,,3,1,Isaac
 20151115-M-Tour_Finals-RR-Tomas_Berdych-Roger_Federer,Tomas Berdych,Roger Federer,R,R,M,20151115,Tour Finals,RR,9:00 PM,Centre,Hard,Damian Steiner,3,1,Edo
 20151115-M-Tour_Finals-RR-Novak_Djokovic-Kei_Nishikori,Novak Djokovic,Kei Nishikori,R,R,M,20151115,Tour Finals,RR,3:00 PM,Centre,Hard,Ali Nili,3,1,Edo
-20151115-M-Knoxville_CH-F-Francis_Tiafoe-Daniel_Evans,Francis Tiafoe,Daniel Evans,R,R,M,20151115,Knoxville CH,F,,,Hard,,3,1,jeffsackmann
-20151115-M-Bratislava_CH-F-Egor_Gerasimov-Lukas_Lacko,Egor Gerasimov,Lukas Lacko,R,R,M,20151115,Bratislava CH,F,,,Hard,,3,1,jeffsackmann
-20151112-M-Mouilleron_CH-R16-Paul_Henri_Mathieu-Calvin_Hemery,Paul Henri Mathieu,Calvin Hemery,R,R,M,20151112,Mouilleron CH,R16,,,Hard,,3,1,jeffsackmann
 20151109-M-Mouilleron_Le_Captif_CH-QF-Lucas_Pouille-Sergiy_Stakhovsky,Lucas Pouille,Sergiy Stakhovsky,R,R,M,20151109,Mouilleron Le Captif CH,QF,,,Hard,,3,1,Isaac
 20151109-M-Kobe_CH-R16-Yoshihito_Nishioka-Yuichi_Ito,Yoshihito Nishioka,Yuichi Ito,L,R,M,20151109,Kobe CH,R16,,,Hard,,3,1,Isaac
 20151109-M-Knoxville_CH-R32-Mischa_Zverev-Hunter_Reese,Mischa Zverev,Hunter Reese,L,R,M,20151109,Knoxville CH,R32,,,Hard,,3,1,Isaac
 20151108-M-Paris-F-Andy_Murray-Novak_Djokovic,Andy Murray,Novak Djokovic,R,R,M,20151108,Paris,F,3:30 PM,Centre,Hard,Cedric Mourier,3,1,Edo
 20151107-M-Paris-SF-Novak_Djokovic-Stanislas_Wawrinka,Novak Djokovic,Stanislas Wawrinka,R,R,M,20151107,Paris,SF,,,Hard,,3,1,Amy
 20151107-M-Paris-SF-David_Ferrer-Andy_Murray,David Ferrer,Andy Murray,R,R,M,20151107,Paris,SF,,,Hard,,3,1,Amy
-20151107-M-Guayaquil_CH-F-Diego_Sebastian_Schwartzman-Gastao_Elias,Diego Sebastian Schwartzman,Gastao Elias,R,R,M,20151107,Guayaquil CH,F,,,Clay,,3,1,jeffsackmann
-20151107-M-Charlottesville_CH-SF-Noah_Rubin-Henri_Laaksonen,Noah Rubin,Henri Laaksonen,R,R,M,20151107,Charlottesville CH,SF,,,Hard,,3,1,jeffsackmann
 20151106-M-Paris-QF-Tomas_Berdych-Novak_Djokovic,Tomas Berdych,Novak Djokovic,R,R,M,20151106,Paris,QF,,,Hard,,3,1,Amy
-20151106-M-Guayaquil_CH-SF-Diego_Sebastian_Schwartzman-Marco_Trungelliti,Diego Sebastian Schwartzman,Marco Trungelliti,R,R,M,20151106,Guayaquil CH,SF,,,Clay,,3,1,jeffsackmann
+20151105-M-Paris_Masters-R16-John_Isner-Roger_Federer,John Isner,Roger Federer,R,R,M,20151105,Paris Masters,R16,4:30 PM,Centre,Hard,Cedric Mourier,3,1,Edo
 20151105-M-Paris-R32-Novak_Djokovic-Thomaz_Bellucci,Novak Djokovic,Thomaz Bellucci,R,L,M,20151105,Paris,R32,,,Hard,,3,1,Amy
 20151105-M-Paris-R16-Tomas_Berdych-Jo_Wilfried_Tsonga,Tomas Berdych,Jo Wilfried Tsonga,R,R,M,20151105,Paris,R16,7:30 PM,Centre,Hard,Ali Nili,3,1,Edo
-20151105-M-Paris-R16-Stanislas_Wawrinka-Viktor_Troicki,Stanislas Wawrinka,Viktor Troicki,R,R,M,20151105,Paris,R16,,1,Hard,Damien Steiner,3,1,jeffsackmann
 20151105-M-Paris-R16-Rafael_Nadal-Kevin_Anderson,Rafael Nadal,Kevin Anderson,L,R,M,20151105,Paris,R16,9:00 PM,Centre,Hard,Damien Dumusois,3,1,Edo
 20151105-M-Paris-R16-Novak_Djokovic-Gilles_Simon,Novak Djokovic,Gilles Simon,R,R,M,20151105,Paris,R16,2:00 PM,Centre,Hard,Ali Nili,3,1,Amy
 20151105-M-Paris-R16-John_Isner-Roger_Federer,John Isner,Roger Federer,R,R,M,20151105,Paris,R16,4:30 PM,Centre,Hard,Cedric Mourier,3,1,Edo
 20151105-M-Paris-R16-Andy_Murray-David_Goffin,Andy Murray,David Goffin,R,R,M,20151105,Paris,R16,10:30 AM,Centre,Hard,Carlos Bernardes,3,1,Edo
+20151104-M-Paris_Masters-R32-Andreas_Seppi-Roger_Federer,Andreas Seppi,Roger Federer,R,R,M,20151104,Paris Masters,R32,7:00 PM,Centre,Hard,Damien Dumusois,3,1,Edo
 20151104-M-Paris-R32-Roberto_Bautista_Agut-Jo_Wilfried_Tsonga,Roberto Bautista Agut,Jo Wilfried Tsonga,R,R,M,20151104,Paris,R32,9:00 PM,Centre,Hard,Damian Steiner,3,1,Edo
-20151104-M-Paris-R32-John_Isner-Aljaz_Bedene,John Isner,Aljaz Bedene,R,R,M,20151104,Paris,R32,,1,Hard,,3,1,jeffsackmann
 20151104-M-Paris-R32-Andy_Murray-Borna_Coric,Andy Murray,Borna Coric,R,R,M,20151104,Paris,R32,3:00 PM,Centre,Hard,,3,1,Crinioc
-20151104-M-Paris-R32-Andreas_Seppi-Roger_Federer,Andreas Seppi,Roger Federer,R,R,M,20151104,Paris,R32,7:00 PM,Centre,Hard,Damien Dumusois,3,1,Edo
-20151104-M-Guayaquil_CH-R16-Diego_Sebastian_Schwartzman-Dennis_Novak,Diego Sebastian Schwartzman,Dennis Novak,R,R,M,20151104,Guayaquil CH,R16,,,Clay,,3,1,jeffsackmann
-20151103-M-Paris-R64-Viktor_Troicki-Jack_Sock,Viktor Troicki,Jack Sock,R,R,M,20151103,Paris,R64,,1,Hard,Cedric Mourier,3,1,jeffsackmann
-20151103-M-Paris-R64-Lucas_Pouille-Jeremy_Chardy,Lucas Pouille,Jeremy Chardy,R,R,M,20151103,Paris,R64,,Center,Hard,,3,1,jeffsackmann
 20151103-M-Paris-R32-Edouard_Roger_Vasselin-Ivo_Karlovic,Edouard Roger Vasselin,Ivo Karlovic,R,R,M,20151103,Paris,R32,11:00 AM,Court 1,Hard,Ali Nili,3,1,Edo
-20151102-M-Paris-R64-Teymuraz_Gabashvili-Thomaz_Bellucci,Teymuraz Gabashvili,Thomaz Bellucci,R,L,M,20151102,Paris,R64,,1,Hard,,3,1,jeffsackmann
-20151102-M-Paris-R64-Martin_Klizan-Leonardo_Mayer,Martin Klizan,Leonardo Mayer,L,R,M,20151102,Paris,R64,,1,Hard,,3,1,jeffsackmann
-20151102-M-Paris-R64-Borna_Coric-Fernando_Verdasco,Borna Coric,Fernando Verdasco,R,L,M,20151102,Paris,R64,,,Hard,,3,1,jeffsackmann
-20151102-M-Paris-R64-Benoit_Paire-Gael_Monfils,Benoit Paire,Gael Monfils,R,R,M,20151102,Paris,R64,,,Hard,Cedric Mourier,3,1,jeffsackmann
-20151102-M-Paris-R64-Aljaz_Bedene-Marcel_Granollers,Aljaz Bedene,Marcel Granollers,R,R,M,20151102,Paris,R64,,1,Hard,,3,1,jeffsackmann
-20151102-M-Paris-R64-Adrian_Mannarino-Dominic_Thiem,Adrian Mannarino,Dominic Thiem,L,R,M,20151102,Paris,R64,,,Hard,,3,1,jeffsackmann
 20151102-M-Canberra_CH-R32-Sebastian_Fanselow-Christopher_Oconnell,Sebastian Fanselow,Christopher Oconnell,R,R,M,20151102,Canberra CH,R32,,,Hard,,3,1,Isaac
 20151101-M-Valencia-F-Roberto_Bautista_Agut-Joao_Sousa,Roberto Bautista Agut,Joao Sousa,R,R,M,20151101,Valencia,F,3:10 PM,,Hard,Carlos Bernardes,3,1,ChapelHeel66
 20151101-M-Basel-F-Rafael_Nadal-Roger_Federer,Rafael Nadal,Roger Federer,L,R,M,20151101,Basel,F,,,Hard,Mohamed Lahyani,3,1,Isaac
-20151031-M-Valencia-SF-Vasek_Pospisil-Joao_Sousa,Vasek Pospisil,Joao Sousa,R,R,M,20151031,Valencia,SF,,Center,Hard,,3,1,jeffsackmann
-20151031-M-Valencia-SF-Roberto_Bautista_Agut-Steve_Johnson,Roberto Bautista Agut,Steve Johnson,R,R,M,20151031,Valencia,SF,,Center,Hard,Fergus Murphy,3,1,jeffsackmann
 20151031-M-Basel-SF-Roger_Federer-Jack_Sock,Roger Federer,Jack Sock,R,R,M,20151031,Basel,SF,5:00 PM,Centre,Hard,Damian Steiner,3,1,Edo
 20151031-M-Basel-SF-Rafael_Nadal-Richard_Gasquet,Rafael Nadal,Richard Gasquet,L,R,M,20151031,Basel,SF,3:00 PM,Centre,Hard,Ali Nili,3,1,Edo
-20151030-M-Valencia-QF-Steve_Johnson-Guillermo_Garcia_Lopez,Steve Johnson,Guillermo Garcia Lopez,R,R,M,20151030,Valencia,QF,,Center,Hard,Manuel Messina,3,1,jeffsackmann
-20151030-M-Valencia-QF-Joao_Sousa-Pablo_Cuevas,Joao Sousa,Pablo Cuevas,R,R,M,20151030,Valencia,QF,,,Hard,,3,1,jeffsackmann
-20151030-M-Valencia-QF-Joao_Sousa-Pablo_Cuevas,Joao Sousa,Pablo Cuevas,R,R,M,20151030,Valencia,QF,,Center,Hard,Carlos Bernardes,3,1,jeffsackmann
-20151030-M-Monterrey_CH-SF-Ernesto_Escobedo-Victor_Estrella,Ernesto Escobedo,Victor Estrella,R,R,M,20151030,Monterrey CH,SF,,,Hard,,3,1,jeffsackmann
 20151030-M-Basel-QF-Roger_Federer-David_Goffin,Roger Federer,David Goffin,R,R,M,20151030,Basel,QF,9:00 PM,Centre,Hard,Ali Nili,3,1,Edo
-20151030-M-Basel-QF-Donald_Young-Jack_Sock,Donald Young,Jack Sock,L,R,M,20151030,Basel,QF,,Center,Hard,Mohamed Lahyani,3,1,jeffsackmann
 20151029-M-Basel-R16-Rafael_Nadal-Grigor_Dimitrov,Rafael Nadal,Grigor Dimitrov,L,R,M,20151029,Basel,R16,8:30 PM,Centre,Hard,,3,1,Edo
 20151029-M-Basel-R16-Philipp_Kohlschreiber-Roger_Federer,Philipp Kohlschreiber,Roger Federer,R,R,M,20151029,Basel,R16,8:00 PM,Centre,Hard,Mohamed Lahyani,3,1,Edo
 20151027-M-Basel-R32-Roger_Federer-Mikhail_Kukushkin,Roger Federer,Mikhail Kukushkin,R,R,M,20151027,Basel,R32,6:00 PM,Centre,Hard,Damien Dumusois,3,1,Edo
 20151027-M-Basel-R32-John_Isner-Ernests_Gulbis,John Isner,Ernests Gulbis,R,R,M,20151027,Basel,R32,8:00 PM,Centre,Hard,Mohamed Lahyani,3,1,Edo
 20151027-M-Basel-R32-Grigor_Dimitrov-Sergiy_Stakhovsky,Grigor Dimitrov,Sergiy Stakhovsky,R,R,M,20151027,Basel,R32,4:00 PM,Centre,Hard,Ali Nili,3,1,Edo
-20151025-M-Vienna-F-Steve_Johnson-David_Ferrer,Steve Johnson,David Ferrer,R,R,M,20151025,Vienna,F,,Center,Hard,Carlos Bernardes,3,1,jeffsackmann
-20151025-M-Stockholm-F-Tomas_Berdych-Jack_Sock,Tomas Berdych,Jack Sock,R,R,M,20151025,Stockholm,F,,Center,Hard,Mohamed Lahyani,3,1,jeffsackmann
-20151024-M-Vienna-SF-Steve_Johnson-Ernests_Gulbis,Steve Johnson,Ernests Gulbis,R,R,M,20151024,Vienna,SF,,Center,Hard,Gianluca Moscarella,3,1,jeffsackmann
-20151024-M-Stockholm-SF-Richard_Gasquet-Jack_Sock,Richard Gasquet,Jack Sock,R,R,M,20151024,Stockholm,SF,,Center,Hard,,3,1,jeffsackmann
-20151023-M-Vienna-QF-Gael_Monfils-Lukas_Rosol,Gael Monfils,Lukas Rosol,R,R,M,20151023,Vienna,QF,,Center,Hard,Gianluca Moscarella,3,1,jeffsackmann
 20151023-M-Stockholm-QF-Richard_Gasquet-Jeremy_Chardy,Richard Gasquet,Jeremy Chardy,R,R,M,20151023,Stockholm,QF,3:45 PM,,Hard,Renaud Lichtenstein,3,1,ChapelHeel66
-20151023-M-Stockholm-QF-Jack_Sock-Gilles_Simon,Jack Sock,Gilles Simon,R,R,M,20151023,Stockholm,QF,,Center,Hard,,3,1,jeffsackmann
-20151023-M-Stockholm-QF-Gilles_Muller-Marcos_Baghdatis,Gilles Muller,Marcos Baghdatis,L,R,M,20151023,Stockholm,QF,,Center,Hard,,3,1,jeffsackmann
-20151022-M-Vienna-R16-Jo_Wilfried_Tsonga-Lukas_Rosol,Jo Wilfried Tsonga,Lukas Rosol,R,R,M,20151022,Vienna,R16,,,Hard,,3,1,jeffsackmann
-20151022-M-Stockholm-R16-Jeremy_Chardy-Federico_Delbonis,Jeremy Chardy,Federico Delbonis,R,L,M,20151022,Stockholm,R16,,,Hard,,3,1,jeffsackmann
-20151022-M-Ningbo_CH-R16-Flavio_Cipolla-Franco_Skugor,Flavio Cipolla,Franco Skugor,R,R,M,20151022,Ningbo CH,R16,,1,Hard,,3,1,jeffsackmann
-20151022-M-Brest_CH-R16-Andrea_Arnaboldi-Adrian_Ungur,Andrea Arnaboldi,Adrian Ungur,L,R,M,20151022,Brest CH,R16,,1,Hard,,3,1,jeffsackmann
 20151021-M-Vienna-R16-Sergiy_Stakhovsky-Ivo_Karlovic,Sergiy Stakhovsky,Ivo Karlovic,R,R,M,20151021,Vienna,R16,6:30 PM,Centre,Hard,Carlos Bernardes,3,1,Edo
-20151021-M-Stockholm-R16-Leonardo_Mayer-Gilles_Simon,Leonardo Mayer,Gilles Simon,R,R,M,20151021,Stockholm,R16,,Center,Hard,,3,1,jeffsackmann
-20151021-M-Santiago_CH-R16-Kimmer_Coppejans-Hans_Podlipnik_Castillo,Kimmer Coppejans,Hans Podlipnik Castillo,R,R,M,20151021,Santiago CH,R16,,Centro,Clay,,3,1,jeffsackmann
-20151020-M-Stockholm-R32-Sam_Querrey-Marcos_Baghdatis,Sam Querrey,Marcos Baghdatis,R,R,M,20151020,Stockholm,R32,,,Hard,Renaud Lichtenstein,3,1,jeffsackmann
 20151019-M-Santiago_CH-R32-Alejandro_Gonzalez-Carlos_Eduardo_Severino,Alejandro Gonzalez,Carlos Eduardo Severino,R,R,M,20151019,Santiago CH,R32,,,Clay,,3,1,Isaac
 20151019-M-Brest_CH-R32-David_Guez-Ruben_Ramirez_Hidalgo,David Guez,Ruben Ramirez Hidalgo,R,R,M,20151019,Brest CH,R32,,,Hard,,3,1,Isaac
 20151018-M-Shanghai_Masters-F-Jo_Wilfried_Tsonga-Novak_Djokovic,Jo Wilfried Tsonga,Novak Djokovic,R,R,M,20151018,Shanghai Masters,F,,,Hard,,3,1,Amy
-20151018-M-Ho_Chi_Minh_City_CH-F-Saketh_Myneni-Jordan_Thompson,Saketh Myneni,Jordan Thompson,R,R,M,20151018,Ho Chi Minh City CH,F,,Center,Hard,,3,1,jeffsackmann
-20151018-M-Corrientes_CH-F-Diego_Sebastian_Schwartzman-Maximo_Gonzalez,Diego Sebastian Schwartzman,Maximo Gonzalez,R,R,M,20151018,Corrientes CH,F,,Centro,Clay,,3,1,jeffsackmann
 20151017-M-Shanghai_Masters-SF-Andy_Murray-Novak_Djokovic,Andy Murray,Novak Djokovic,R,R,M,20151017,Shanghai Masters,SF,,,Hard,Carlos Bernardes,3,1,Amy
-20151017-M-Ho_Chi_Minh_City_CH-SF-Flavio_Cipolla-Jordan_Thompson,Flavio Cipolla,Jordan Thompson,R,R,M,20151017,Ho Chi Minh City CH,SF,,Center,Hard,,3,1,jeffsackmann
-20151017-M-Fairfield_CH-SF-Francis_Tiafoe-Dustin_Brown,Francis Tiafoe,Dustin Brown,R,R,M,20151017,Fairfield CH,SF,,,Hard,,3,1,jeffsackmann
-20151017-M-Corrientes_CH-SF-Facundo_Arguello-Diego_Sebastian_Schwartzman,Facundo Arguello,Diego Sebastian Schwartzman,R,R,M,20151017,Corrientes CH,SF,,Centro,Clay,,3,1,jeffsackmann
 20151016-M-Shanghai_Masters-QF-Tomas_Berdych-Andy_Murray,Tomas Berdych,Andy Murray,R,R,M,20151016,Shanghai Masters,QF,8:00 PM,Stadium,Hard,Damien Dumusois,3,1,Edo
 20151016-M-Shanghai_Masters-QF-Rafael_Nadal-Stanislas_Wawrinka,Rafael Nadal,Stanislas Wawrinka,L,R,M,20151016,Shanghai Masters,QF,16:30:00,Stadium,Hard,Cedric Mourier,3,1,Edo
-20151016-M-Shanghai_Masters-QF-Novak_Djokovic-Bernard_Tomic,Novak Djokovic,Bernard Tomic,R,R,M,20151016,Shanghai Masters,QF,,Center,Hard,,3,1,jeffsackmann
-20151016-M-Corrientes_CH-QF-Diego_Sebastian_Schwartzman-Michael_Linzer,Diego Sebastian Schwartzman,Michael Linzer,R,R,M,20151016,Corrientes CH,QF,,Centro,Clay,,3,1,jeffsackmann
 20151015-M-Shanghai_Masters-R16-Novak_Djokovic-Feliciano_Lopez,Novak Djokovic,Feliciano Lopez,R,L,M,20151015,Shanghai Masters,R16,,,Hard,,3,1,Amy
-20151015-M-Fairfield_CH-R16-Blaz_Kavcic-Jason_Jung,Blaz Kavcic,Jason Jung,R,R,M,20151015,Fairfield CH,R16,,,Hard,,3,1,jeffsackmann
-20151015-M-Corrientes_CH-R16-Diego_Sebastian_Schwartzman-Hugo_Dellien,Diego Sebastian Schwartzman,Hugo Dellien,R,R,M,20151015,Corrientes CH,R16,,Centro,Clay,,3,1,jeffsackmann
-20151014-M-Shanghai_Masters-R32-Viktor_Troicki-Stanislas_Wawrinka,Viktor Troicki,Stanislas Wawrinka,R,R,M,20151014,Shanghai Masters,R32,,Grandstand,Hard,Carlos Bernardes,3,1,jeffsackmann
 20151014-M-Shanghai_Masters-R32-Novak_Djokovic-Martin_Klizan,Novak Djokovic,Martin Klizan,R,L,M,20151014,Shanghai Masters,R32,,,Hard,,3,1,Amy
 20151014-M-Shanghai_Masters-R32-David_Ferrer-Bernard_Tomic,David Ferrer,Bernard Tomic,R,R,M,20151014,Shanghai Masters,R32,,,Hard,,3,1,Amy
-20151014-M-Ho_Chi_Minh_City_CH-R16-Luke_Saville-Flavio_Cipolla,Luke Saville,Flavio Cipolla,R,R,M,20151014,Ho Chi Minh City CH,R16,,Center,Hard,,3,1,jeffsackmann
 20151014-M-Ho_Chi_Minh_City_CH-R16-James_Duckworth-Sanam_Singh,James Duckworth,Sanam Singh,R,R,M,20151014,Ho Chi Minh City CH,R16,,,Hard,,3,1,Isaac
-20151014-M-Corrientes_CH-R32-Fernando_Romboli-Diego_Sebastian_Schwartzman,Fernando Romboli,Diego Sebastian Schwartzman,R,R,M,20151014,Corrientes CH,R32,,Centro,Clay,,3,1,jeffsackmann
-20151013-M-Tashkent_CH-R32-Ti_Chen-Maximilian_Marterer,Ti Chen,Maximilian Marterer,R,L,M,20151013,Tashkent CH,R32,,,Hard,,3,1,jeffsackmann
-20151013-M-Tashkent_CH-R32-Denis_Istomin-Uladzimir_Ignatik,Denis Istomin,Uladzimir Ignatik,R,R,M,20151013,Tashkent CH,R32,,Center,Hard,,3,1,jeffsackmann
-20151013-M-Shanghai_Masters-R64-Milos_Raonic-Thomaz_Bellucci,Milos Raonic,Thomaz Bellucci,R,L,M,20151013,Shanghai Masters,R64,,Center,Hard,Ali Nili,3,1,jeffsackmann
-20151013-M-Shanghai-R32-Roger_Federer-Albert_Ramos,Roger Federer,Albert Ramos,R,L,M,20151013,Shanghai,R32,,Center,Hard,,3,1,jeffsackmann
-20151013-M-Rennes_CH-R32-Jeremy_Jahn-Steve_Darcis,Jeremy Jahn,Steve Darcis,R,R,M,20151013,Rennes CH,R32,,,Hard,,3,1,jeffsackmann
-20151012-M-Shanghai_Masters-R64-Marin_Cilic-Di_Wu,Marin Cilic,Di Wu,R,R,M,20151012,Shanghai Masters,R64,,Stadium,Hard,Roland Herfel,3,1,jeffsackmann
 20151011-M-Tokyo-F-Stanislas_Wawrinka-Benoit_Paire,Stanislas Wawrinka,Benoit Paire,R,R,M,20151011,Tokyo,F,2:30 PM,Centrale,Hard,Damian Steiner,3,0,Edo
-20151011-M-Sacramento_CH-F-Jared_Donaldson-Taylor_Harry_Fritz,Jared Donaldson,Taylor Harry Fritz,R,R,M,20151011,Sacramento CH,F,,Center,Hard,,3,1,jeffsackmann
 20151011-M-Beijing-F-Rafael_Nadal-Novak_Djokovic,Rafael Nadal,Novak Djokovic,L,R,M,20151011,Beijing,F,19:30:00,Centre,Hard,Ali Nili,3,1,Edo
 20151010-M-Tokyo-SF-Kei_Nishikori-Benoit_Paire,Kei Nishikori,Benoit Paire,R,R,M,20151010,Tokyo,SF,,Centre,Hard,,3,,Edged
 20151010-M-Tokyo-SF-Gilles_Muller-Stanislas_Wawrinka,Gilles Muller,Stanislas Wawrinka,L,R,M,20151010,Tokyo,SF,,Centre,Hard,,3,,Edged
 20151010-M-Beijing-SF-David_Ferrer-Novak_Djokovic,David Ferrer,Novak Djokovic,R,R,M,20151010,Beijing,SF,,,Hard,,3,1,Amy
-20151009-M-Tokyo-QF-Nick_Kyrgios-Benoit_Paire,Nick Kyrgios,Benoit Paire,R,R,M,20151009,Tokyo,QF,,Center,Hard,,3,1,jeffsackmann
 20151009-M-Sacramento_CH-QF-Jared_Donaldson-Mackenzie_Mcdonald,Jared Donaldson,Mackenzie Mcdonald,R,R,M,20151009,Sacramento CH,QF,,,Hard,,3,1,Amy
-20151009-M-Sacramento_CH-QF-Daniel_Brands-Denis_Kudla,Daniel Brands,Denis Kudla,R,R,M,20151009,Sacramento CH,QF,,Center,Hard,,3,1,jeffsackmann
 20151009-M-Beijing-QF-John_Isner-Novak_Djokovic,John Isner,Novak Djokovic,R,R,M,20151009,Beijing,QF,,,Hard,,3,1,Amy
 20151008-M-Tokyo-R16-Roberto_Bautista_Agut-Nick_Kyrgios,Roberto Bautista Agut,Nick Kyrgios,R,R,M,20151008,Tokyo,R16,,Centre,Hard,,3,,Edged
 20151008-M-Sacramento_CH-R16-Jared_Donaldson-Tennys_Sandgren,Jared Donaldson,Tennys Sandgren,R,R,M,20151008,Sacramento CH,R16,,,Hard,,3,1,Amy
-20151008-M-Mons_CH-R16-Jan_Lennard_Struff-Mirza_Basic,Jan Lennard Struff,Mirza Basic,R,R,M,20151008,Mons CH,R16,,Center,Hard,,3,1,jeffsackmann
-20151008-M-Mohammedia_CH-QF-Jozef_Kovalik-Federico_Delbonis,Jozef Kovalik,Federico Delbonis,R,L,M,20151008,Mohammedia CH,QF,,,Clay,,3,1,jeffsackmann
-20151008-M-Beijing-R16-Pablo_Cuevas-Ivo_Karlovic,Pablo Cuevas,Ivo Karlovic,R,R,M,20151008,Beijing,R16,,Lotus,Hard,,3,1,jeffsackmann
 20151008-M-Beijing-R16-Novak_Djokovic-Ze_Zhang,Novak Djokovic,Ze Zhang,R,R,M,20151008,Beijing,R16,,,Hard,,3,1,Amy
-20151008-M-Beijing-R16-David_Goffin-Fabio_Fognini,David Goffin,Fabio Fognini,R,R,M,20151008,Beijing,R16,Ali Nili,National Tennis Stadium,Hard,,3,1,jeffsackmann
-20151007-M-Beijing-R16-Viktor_Troicki-Yen_Hsun_Lu,Viktor Troicki,Yen Hsun Lu,R,R,M,20151007,Beijing,R16,11:00,National Tennis Stadium,Hard,Fergus Murphy,3,1,jeffsackmann
 20151006-M-Beijing-R32-Novak_Djokovic-Simone_Bolelli,Novak Djokovic,Simone Bolelli,R,R,M,20151006,Beijing,R32,,,Hard,,3,1,Amy
-20151005-M-Tokyo-R32-Yasutaka_Uchiyama-Jiri_Vesely,Yasutaka Uchiyama,Jiri Vesely,R,L,M,20151005,Tokyo,R32,,Center,Hard,,3,1,jeffsackmann
-20151005-M-Tokyo-R32-Kei_Nishikori-Borna_Coric,Kei Nishikori,Borna Coric,R,R,M,20151005,Tokyo,R32,,Center,Hard,Cedric Mourier,3,1,jeffsackmann
 20151005-M-Mons_CH-Q3-Yannick_Mertens-Scott_Griekspoor,Yannick Mertens,Scott Griekspoor,R,R,M,20151005,Mons CH,Q3,,,Hard,,3,1,Isaac
 20151005-M-Mohammedia_CH-R32-David_Perez_Sanz-Pablo_Carreno_Busta,David Perez Sanz,Pablo Carreno Busta,R,R,M,20151005,Mohammedia CH,R32,,,Clay,,3,1,Isaac
 20151005-M-Beijing-R32-David_Goffin-Andreas_Seppi,David Goffin,Andreas Seppi,R,R,M,20151005,Beijing,R32,,Lotus Court,Hard,,3,1,Edged
-20151004-M-Porto_Alegre_CH-F-Guido_Pella-Diego_Sebastian_Schwartzman,Guido Pella,Diego Sebastian Schwartzman,L,R,M,20151004,Porto Alegre CH,F,,Center,Clay,,3,1,jeffsackmann
 20151004-M-Kuala_Lumpur-F-David_Ferrer-Feliciano_Lopez,David Ferrer,Feliciano Lopez,R,L,M,20151004,Kuala Lumpur,F,,,Hard,,3,1,Edged
-20151003-M-Tiburon_CH-SF-Quentin_Halys-Tim_Smyczek,Quentin Halys,Tim Smyczek,R,R,M,20151003,Tiburon CH,SF,,Center,Hard,,3,1,jeffsackmann
-20151003-M-Porto_Alegre_CH-SF-Carlos_Berlocq-Diego_Sebastian_Schwartzman,Carlos Berlocq,Diego Sebastian Schwartzman,R,R,M,20151003,Porto Alegre CH,SF,,,Clay,,3,1,jeffsackmann
 20151003-M-Kuala_Lumpur-SF-Feliciano_Lopez-Nick_Kyrgios,Feliciano Lopez,Nick Kyrgios,L,R,M,20151003,Kuala Lumpur,SF,3:25 PM,,Hard,Damian Steiner,3,1,ChapelHeel66
-20151002-M-Shenzhen-QF-Marin_Cilic-Hyeon_Chung,Marin Cilic,Hyeon Chung,R,R,M,20151002,Shenzhen,QF,,Center,Hard,Mohamed El Jennati,3,1,jeffsackmann
-20151001-M-Shenzhen-R16-Yan_Bai-Adrian_Mannarino,Yan Bai,Adrian Mannarino,R,R,M,20151001,Shenzhen,R16,,Center,Hard,,3,1,jeffsackmann
-20151001-M-Shenzhen-R16-John_Millman-Marin_Cilic,John Millman,Marin Cilic,R,R,M,20151001,Shenzhen,R16,,Center,Hard,Nacho,3,1,jeffsackmann
-20151001-M-Porto_Alegre_CH-R16-Diego_Sebastian_Schwartzman-Christian_Lindell,Diego Sebastian Schwartzman,Christian Lindell,R,R,M,20151001,Porto Alegre CH,R16,,Center,Clay,,3,1,jeffsackmann
 20150929-M-Tiburon_CH-R32-Jared_Donaldson-Darian_King,Jared Donaldson,Darian King,R,R,M,20150929,Tiburon CH,R32,,,Hard,,3,1,Amy
-20150929-M-Porto_Alegre_CH-R32-Orlando_Luz-Diego_Sebastian_Schwartzman,Orlando Luz,Diego Sebastian Schwartzman,R,R,M,20150929,Porto Alegre CH,R32,,Center,Clay,,3,1,jeffsackmann
 20150928-M-Pereira_CH-R16-Marcelo_Arevalo-Alejandro_Falla,Marcelo Arevalo,Alejandro Falla,R,L,M,20150928,Pereira CH,R16,,,Clay,,3,1,Isaac
 20150927-M-Metz-SF-Jo_Wilfried_Tsonga-Philipp_Kohlschreiber,Jo Wilfried Tsonga,Philipp Kohlschreiber,R,R,M,20150927,Metz,SF,,,Indoor Hard,,3,1,Edged
 20150927-M-Metz-F-Jo_Wilfried_Tsonga-Gilles_Simon,Jo Wilfried Tsonga,Gilles Simon,R,R,M,20150927,Metz,F,,,Indoor Hard,Fergus Murphy,3,1,Edged
-20150927-M-Campinas_CH-F-Facundo_Arguello-Diego_Sebastian_Schwartzman,Facundo Arguello,Diego Sebastian Schwartzman,R,R,M,20150927,Campinas CH,F,,Center,Clay,,3,1,jeffsackmann
-20150926-M-Metz-SF-Martin_Klizan-Gilles_Simon,Martin Klizan,Gilles Simon,L,R,M,20150926,Metz,SF,,,Hard,,3,1,jeffsackmann
-20150926-M-Campinas_CH-SF-Facundo_Bagnis-Diego_Sebastian_Schwartzman,Facundo Bagnis,Diego Sebastian Schwartzman,L,R,M,20150926,Campinas CH,SF,,Center,Clay,,3,1,jeffsackmann
 20150925-M-St_Petersburg-QF-Milos_Raonic-Tommy_Robredo,Milos Raonic,Tommy Robredo,R,R,M,20150925,St Petersburg,QF,,,Indoor Hard,,3,1,Edged
 20150925-M-Metz-QF-Martin_Klizan-Guillermo_Garcia_Lopez,Martin Klizan,Guillermo Garcia Lopez,L,R,M,20150925,Metz,QF,,,Indoor Hard,,3,1,Edged
-20150925-M-Metz-QF-Gilles_Muller-Gilles_Simon,Gilles Muller,Gilles Simon,L,R,M,20150925,Metz,QF,,Center,Hard,,3,1,jeffsackmann
-20150925-M-Campinas_CH-QF-Diego_Sebastian_Schwartzman-Nicolas_Kicker,Diego Sebastian Schwartzman,Nicolas Kicker,R,R,M,20150925,Campinas CH,QF,,Center,Clay,,3,1,jeffsackmann
 20150924-M-St_Petersburg-R16-Roberto_Bautista_Agut-Teymuraz_Gabashvili,Roberto Bautista Agut,Teymuraz Gabashvili,R,R,M,20150924,St Petersburg,R16,,,Indoor Hard,,3,,Edged
-20150924-M-Campinas_CH-R16-Guido_Andreozzi-Diego_Sebastian_Schwartzman,Guido Andreozzi,Diego Sebastian Schwartzman,R,R,M,20150924,Campinas CH,R16,,Center,Clay,,3,1,jeffsackmann
-20150923-M-St_Petersburg-R32-Yaraslau_Shyla-Teymuraz_Gabashvili,Yaraslau Shyla,Teymuraz Gabashvili,R,R,M,20150923,St Petersburg,R32,,Centre,Hard,,3,1,jeffsackmann
 20150923-M-St_Petersburg-R32-Thanasi_Kokkinakis-Marcel_Granollers,Thanasi Kokkinakis,Marcel Granollers,R,R,M,20150923,St Petersburg,R32,,,Indoor Hard,,3,,Edged
 20150923-M-St_Petersburg-R16-Andreas_Haider_Maurer-Dominic_Thiem,Andreas Haider Maurer,Dominic Thiem,R,R,M,20150923,St Petersburg,R16,,,Indoor Hard,,3,,Edged
-20150923-M-Campinas_CH-R32-Jose_Pereira-Diego_Sebastian_Schwartzman,Jose Pereira,Diego Sebastian Schwartzman,R,R,M,20150923,Campinas CH,R32,,Center,Clay,,3,1,jeffsackmann
-20150922-M-St_Petersburg-R32-Alexandre_Sidorenko-Evgeny_Donskoy,Alexandre Sidorenko,Evgeny Donskoy,R,L,M,20150922,St Petersburg,R32,,Center,Hard,,3,1,jeffsackmann
-20150922-M-Metz-R32-Paul_Henri_Mathieu-Martin_Klizan,Paul Henri Mathieu,Martin Klizan,R,L,M,20150922,Metz,R32,,,Hard,,3,1,jeffsackmann
-20150922-M-Kaohsiung_CH-R32-Somdev_Devvarman-Yuki_Bhambri,Somdev Devvarman,Yuki Bhambri,R,R,M,20150922,Kaohsiung CH,R32,,Center,Hard,,3,1,jeffsackmann
 20150921-M-Kaohsiung_CH-R32-Hyeon_Chung-Liang_Chi_Huang,Hyeon Chung,Liang Chi Huang,R,R,M,20150921,Kaohsiung CH,R32,,Centre,Hard,,3,1,Isaac
 20150921-M-Kaohsiung_CH-R32-Chieh_Fu_Wang-Jiri_Vesely,Chieh Fu Wang,Jiri Vesely,R,L,M,20150921,Kaohsiung CH,R32,,,Hard,,3,1,Isaac
 20150921-M-Izmir_CH-SF-Marius_Copil-Farrukh_Dustov,Marius Copil,Farrukh Dustov,R,R,M,20150921,Izmir CH,SF,,,Hard,,3,1,Isaac
 20150921-M-Izmir_CH-R16-Lukas_Lacko-Laurynas_Grigelis,Lukas Lacko,Laurynas Grigelis,R,R,M,20150921,Izmir CH,R16,,,Hard,,3,1,Isaac
-20150919-M-Davis_Cup_World_Group_PO-RR-Philipp_Kohlschreiber-Victor_Estrella,Philipp Kohlschreiber,Victor Estrella,R,R,M,20150919,Davis Cup World Group PO,RR,,,Hard,,5,0,jeffsackmann
-20150918-M-Istanbul_CH-QF-Elias_Ymer-Yannick_Mertens,Elias Ymer,Yannick Mertens,R,R,M,20150918,Istanbul CH,QF,13:00,Steigenberger,Hard,,3,1,jeffsackmann
-20150918-M-Istanbul_CH-QF-Aslan_Karatsev-Karen_Khachanov,Aslan Karatsev,Karen Khachanov,R,R,M,20150918,Istanbul CH,QF,,Center,Hard,,3,1,jeffsackmann
-20150917-M-Istanbul_CH-R16-Sergiy_Stakhovsky-Nils_Langer,Sergiy Stakhovsky,Nils Langer,R,R,M,20150917,Istanbul CH,R16,,Center,Hard,,3,1,jeffsackmann
 20150914-M-Szczecin_CH-R32-Inigo_Cervantes_Huegun-Vladimir_Ivanov,Inigo Cervantes Huegun,Vladimir Ivanov,R,R,M,20150914,Szczecin CH,R32,,,Clay,,3,1,Amy
 20150914-M-Istanbul_CH-SF-Karen_Khachanov-Yannick_Mertens,Karen Khachanov,Yannick Mertens,R,R,M,20150914,Istanbul CH,SF,,,Hard,,3,1,Isaac
 20150913-M-US_Open-F-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20150913,US Open,F,20:00:00,Arthur Ashe,Hard,Eva Asderaki-Moore,5,1,Edo
-20150913-M-Sevilla_CH-F-Pablo_Carreno_Busta-Pedro_Cachin,Pablo Carreno Busta,Pedro Cachin,R,R,M,20150913,Sevilla CH,F,,,Clay,,3,1,jeffsackmann
 20150911-M-US_Open-SF-Stanislas_Wawrinka-Roger_Federer,Stanislas Wawrinka,Roger Federer,R,R,M,20150911,US Open,SF,19:00:00,Arthur Ashe,Hard,James Keothavong,5,0,Edo
 20150911-M-US_Open-SF-Novak_Djokovic-Marin_Cilic,Novak Djokovic,Marin Cilic,R,R,M,20150911,US Open,SF,,,Hard,,5,1,Edged
 20150910-M-US_Open-QF-Roger_Federer-Richard_Gasquet,Roger Federer,Richard Gasquet,R,R,M,20150910,US Open,QF,19:00:00,Arthur Ashe,Hard,Ali Nili,5,0,Edo
-20150910-M-Genova_CH-R32-Jan_Satral-Nicolas_Almagro,Jan Satral,Nicolas Almagro,R,R,M,20150910,Genova CH,R32,,,Clay,,3,1,jeffsackmann
 20150909-M-US_Open-QF-Novak_Djokovic-Feliciano_Lopez,Novak Djokovic,Feliciano Lopez,R,L,M,20150909,US Open,QF,22:00:00,Arthur Ashe,Hard,Damien Dumusois,5,1,Edo
 20150908-M-US_Open-R16-Roger_Federer-John_Isner,Roger Federer,John Isner,R,R,M,20150908,US Open,R16,21:00:00,Arthur Ashe,Hard,Pascal Maria,5,0,Edo
 20150907-M-US_Open-R16-Andy_Murray-Kevin_Anderson,Andy Murray,Kevin Anderson,R,R,M,20150907,US Open,R16,,Louis Armstrong,Hard,,5,1,Amy
-20150906-M-US_Open-R16-Novak_Djokovic-Roberto_Bautista_Agut,Novak Djokovic,Roberto Bautista Agut,R,R,M,20150906,US Open,R16,,Ashe,Hard,Carlos Bernardes,3,1,jeffsackmann
 20150905-M-US_Open-R32-Roger_Federer-Philipp_Kohlschreiber,Roger Federer,Philipp Kohlschreiber,R,R,M,20150905,US Open,R32,13:00:00,Arthur Ashe,Hard,,5,0,Edo
-20150904-M-US_Open-R32-Rafael_Nadal-Fabio_Fognini,Rafael Nadal,Fabio Fognini,L,R,M,20150904,US Open,R32,,Ashe,Hard,Cedric Mourier,3,1,jeffsackmann
-20150904-M-Bangkok_CH-QF-Marco_Trungelliti-Alexander_Sarkissian,Marco Trungelliti,Alexander Sarkissian,R,R,M,20150904,Bangkok CH,QF,,Center,Hard,,3,1,jeffsackmann
 20150903-M-US_Open-R64-Steve_Darcis-Roger_Federer,Steve Darcis,Roger Federer,R,R,M,20150903,US Open,R64,19:00:00,Arthur Ashe,Hard,Jake Garner,5,0,Edo
 20150903-M-US_Open-R64-Bernard_Tomic-Lleyton_Hewitt,Bernard Tomic,Lleyton Hewitt,R,R,M,20150903,US Open,R64,,,Hard,,3,1,Amy
-20150902-M-US_Open-R64-Rafael_Nadal-Diego_Sebastian_Schwartzman,Rafael Nadal,Diego Sebastian Schwartzman,L,R,M,20150902,US Open,R64,,Ashe,Hard,,3,1,jeffsackmann
 20150902-M-US_Open-R64-Fernando_Verdasco-Milos_Raonic,Fernando Verdasco,Milos Raonic,L,R,M,20150902,US Open,R64,12:20pm,Grandstand,Hard,,5,1,@CanuckKicker
 20150901-M-US_Open-R128-Roger_Federer-Leonardo_Mayer,Roger Federer,Leonardo Mayer,R,R,M,20150901,US Open,R128,14:30:00,Arthur Ashe,Hard,Eva Asderaki,5,0,Edo
 20150831-M-US_Open-R128-Tim_Smyczek-Milos_Raonic,Tim Smyczek,Milos Raonic,R,R,M,20150831,US Open,R128,2pm,Court 17,Hard,,5,1,@CanuckKicker
 20150829-M-Winston_Salem-F-Pierre_Hugues_Herbert-Kevin_Anderson,Pierre Hugues Herbert,Kevin Anderson,R,R,M,20150829,Winston Salem,F,,,Hard,,3,1,Edged
-20150827-M-Winston_Salem-QF-Malek_Jaziri-Thomaz_Bellucci,Malek Jaziri,Thomaz Bellucci,R,L,M,20150827,Winston Salem,QF,,Center,Hard,,3,1,jeffsackmann
 20150824-M-Manerbio_CH-R32-Antonio_Veic-Andrey_Kuznetsov,Antonio Veic,Andrey Kuznetsov,R,R,M,20150824,Manerbio CH,R32,,Center,Hard,,3,1,Isaac
-20150823-M-Cincinnati-F-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20150823,Cincinnati,F,1:00 PM,Center,Hard,Mohamed Lahyani,3,1,Isaac
+20150823-M-Cincinnati_Masters-F-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20150823,Cincinnati Masters,F,1:00 PM,Center,Hard,Mohamed Lahyani,3,1,Isaac
+20150822-M-Cincinnati_Masters-SF-Andy_Murray-Roger_Federer,Andy Murray,Roger Federer,R,R,M,20150822,Cincinnati Masters,SF,,Center,Hard,Fergus Murphy,3,1,FedFan
+20150822-M-Cincinnati_Masters-QF-Roger_Federer-Feliciano_Lopez,Roger Federer,Feliciano Lopez,R,L,M,20150822,Cincinnati Masters,QF,19:00:00,Centre,Hard,Mohamed Lahyani,3,0,Edo
 20150822-M-Cincinnati-SF-Novak_Djokovic-Alexandr_Dolgopolov,Novak Djokovic,Alexandr Dolgopolov,R,R,M,20150822,Cincinnati,SF,,Center,Hard,Carlos Bernardes,3,1,Isaac
-20150822-M-Cincinnati-SF-Andy_Murray-Roger_Federer,Andy Murray,Roger Federer,R,R,M,20150822,Cincinnati,SF,,Center,Hard,Fergus Murphy,3,1,FedFan
-20150822-M-Cincinnati-QF-Roger_Federer-Feliciano_Lopez,Roger Federer,Feliciano Lopez,R,L,M,20150822,Cincinnati,QF,19:00:00,Centre,Hard,Mohamed Lahyani,3,0,Edo
-20150817-M-Cincinnati-R64-Viktor_Troicki-Mardy_Fish,Viktor Troicki,Mardy Fish,R,R,M,20150817,Cincinnati,R64,11:00 AM,Center,Hard,Mohamed Lahyani,3,1,jeffsackmann
 20150816-M-Canada_Masters-F-Andy_Murray-Novak_Djokovic,Andy Murray,Novak Djokovic,R,R,M,20150816,Canada Masters,F,3:15 PM,,Hard,,3,1,Lowell
 20150815-M-Canada_Masters-SF-Andy_Murray-Kei_Nishikori,Andy Murray,Kei Nishikori,R,R,M,20150815,Canada Masters,SF,8:15 PM,Stadium,Hard,,3,1,Lowell
-20150814-M-Canada_Masters-QF-Novak_Djokovic-Ernests_Gulbis,Novak Djokovic,Ernests Gulbis,R,R,M,20150814,Canada Masters,QF,,,Hard,Ali Nili,3,1,jeffsackmann
 20150813-M-Canada_Masters-R16-Novak_Djokovic-Jack_Sock,Novak Djokovic,Jack Sock,R,R,M,20150813,Canada Masters,R16,12:40 PM,Stadium,Hard,,3,1,Lowell
-20150811-M-Canada_Masters-R32-Novak_Djokovic-Thomaz_Bellucci,Novak Djokovic,Thomaz Bellucci,R,L,M,20150811,Canada Masters,R32,,Center,Hard,,3,1,jeffsackmann
 20150810-M-Prague_CH-Q3-Rogerio_Dutra_Silva-Juan_Carlos_Saez,Rogerio Dutra Silva,Juan Carlos Saez,R,R,M,20150810,Prague CH,Q3,,Court 1,Clay,,3,1,Isaac
 20150806-M-Washington-R32-Alexandr_Dolgopolov-Ivo_Karlovic,Alexandr Dolgopolov,Ivo Karlovic,R,R,M,20150806,Washington,R32,12:05 AM,,Hard,Blaze Trifunovski,3,1,ChapelHeel66
-20150806-M-Washington-R16-Teymuraz_Gabashvili-Ricardas_Berankis,Teymuraz Gabashvili,Ricardas Berankis,R,R,M,20150806,Washington,R16,,1,Hard,Manuel Messina,3,1,jeffsackmann
 20150806-M-Washington-R16-Steve_Johnson-Grigor_Dimitrov,Steve Johnson,Grigor Dimitrov,R,R,M,20150806,Washington,R16,8:05 PM,,Hard,Mohammed Fitouhi,3,1,ChapelHeel66
 20150805-M-Washington-R32-Steve_Johnson-Bernard_Tomic,Steve Johnson,Bernard Tomic,R,R,M,20150805,Washington,R32,5:45 PM,Grandstand,Hard,,3,1,ChapelHeel66
-20150805-M-Washington-R32-Grigor_Dimitrov-Guido_Pella,Grigor Dimitrov,Guido Pella,R,L,M,20150805,Washington,R32,,Grandstand,Hard,Blaze Trifunovski,3,1,jeffsackmann
-20150804-M-Washington-R32-Vasek_Pospisil-Donald_Young,Vasek Pospisil,Donald Young,R,L,M,20150804,Washington,R32,,,Hard,Manuel Messina,3,1,jeffsackmann
-20150731-M-Gstaad-QF-Pablo_Andujar-Thomaz_Bellucci,Pablo Andujar,Thomaz Bellucci,R,L,M,20150731,Gstaad,QF,,,Clay,,3,1,jeffsackmann
-20150728-M-Bogota-QF-Malek_Jaziri-Adrian_Mannarino,Malek Jaziri,Adrian Mannarino,R,L,M,20150728,Bogota,QF,,,Hard,,3,1,jeffsackmann
 20150726-M-Bogota-F-Bernard_Tomic-Adrian_Mannarino,Bernard Tomic,Adrian Mannarino,R,L,M,20150726,Bogota,F,,,Hard,Mohamed Lahyani,3,1,Amy
 20150726-M-Bastad-F-Tommy_Robredo-Benoit_Paire,Tommy Robredo,Benoit Paire,R,R,M,20150726,Bastad,F,2:10 PM,,Clay,Cedric Mourier,3,1,ChapelHeel66
 20150725-M-Bogota-SF-Michael_Berrer-Bernard_Tomic,Michael Berrer,Bernard Tomic,L,R,M,20150725,Bogota,SF,,,Hard,,3,1,Amy
-20150724-M-Bastad-QF-Alexander_Zverev-Thomaz_Bellucci,Alexander Zverev,Thomaz Bellucci,R,L,M,20150724,Bastad,QF,,,Clay,,3,1,jeffsackmann
-20150723-M-Umag-R16-Aljaz_Bedene-Borna_Coric,Aljaz Bedene,Borna Coric,R,R,M,20150723,Umag,R16,,,Clay,,3,1,jeffsackmann
-20150723-M-Bastad-R16-Pablo_Cuevas-Federico_Delbonis,Pablo Cuevas,Federico Delbonis,R,L,M,20150723,Bastad,R16,,,Clay,,3,1,jeffsackmann
-20150723-M-Bastad-R16-Albert_Ramos-Tommy_Robredo,Albert Ramos,Tommy Robredo,L,R,M,20150723,Bastad,R16,,,Clay,Cedric Mourier,3,1,jeffsackmann
-20150721-M-Umag-R32-Jiri_Vesely-Fabio_Fognini,Jiri Vesely,Fabio Fognini,L,R,M,20150721,Umag,R32,,,Clay,,3,1,jeffsackmann
-20150721-M-Bastad-R32-Denis_Istomin-Diego_Sebastian_Schwartzman,Denis Istomin,Diego Sebastian Schwartzman,R,R,M,20150721,Bastad,R32,,,Clay,Arnaud Gabas,3,1,jeffsackmann
 20150712-M-Wimbledon-F-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20150712,Wimbledon,F,14:00:00,Centre,Grass,Ali Nili,5,0,Edo
 20150710-M-Wimbledon-SF-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20150710,Wimbledon,SF,16:00:00,Centre,Grass,Mohamed Lahyani,5,0,Edo
 20150710-M-Wimbledon-SF-Novak_Djokovic-Richard_Gasquet,Novak Djokovic,Richard Gasquet,R,R,M,20150710,Wimbledon,SF,13:00:00,Centre,Grass,Jake Garner,5,0,Edo
@@ -509,62 +663,44 @@ match_id,Player 1,Player 2,Pl 1 hand,Pl 2 hand,Gender,Date,Tournament,Round,Time
 20150630-M-Wimbledon-R128-Roger_Federer-Damir_Dzumhur,Roger Federer,Damir Dzumhur,R,R,M,20150630,Wimbledon,R128,14:00:00,Centre,Grass,Jake Garner,5,0,Edo
 20150626-M-Nottingham-SF-Sam_Querrey-Alexandr_Dolgopolov,Sam Querrey,Alexandr Dolgopolov,R,R,M,20150626,Nottingham,SF,13:30:00,Centre,Grass,,3,1,Edo
 20150625-M-Nottingham-QF-Denis_Istomin-Leonardo_Mayer,Denis Istomin,Leonardo Mayer,R,R,M,20150625,Nottingham,QF,1:45 PM,,Grass,Renaud Lichtenstein,3,1,ChapelHeel66
-20150625-M-Milan_CH-R16-Gianluca_Naso-Laslo_Djere,Gianluca Naso,Laslo Djere,R,R,M,20150625,Milan CH,R16,,,Clay,,3,1,jeffsackmann
 20150624-M-Nottingham-R16-Sam_Querrey-Pablo_Cuevas,Sam Querrey,Pablo Cuevas,R,R,M,20150624,Nottingham,R16,1:40 PM,,Grass,Richard Haigh,3,1,ChapelHeel66
 20150624-M-Nottingham-R16-Marcos_Baghdatis-Alexander_Zverev,Marcos Baghdatis,Alexander Zverev,R,R,M,20150624,Nottingham,R16,,,Grass,,3,1,1HandBH
 20150621-M-Queens_Club-F-Andy_Murray-Kevin_Anderson,Andy Murray,Kevin Anderson,R,R,M,20150621,Queens Club,F,,,Grass,,3,1,chrisG
-20150621-M-Halle-F-Andreas_Seppi-Roger_Federer,Andreas Seppi,Roger Federer,R,R,M,20150621,Halle,F,2:00 PM,Stadion,Grass,Cédric Mourier,3,1,Edo
+20150621-M-Halle-F-Andreas_Seppi-Roger_Federer,Andreas Seppi,Roger Federer,R,R,M,20150621,Halle,F,2:00 PM,Stadion,Grass,CÃ©dric Mourier,3,1,Edo
 20150620-M-Halle-SF-Roger_Federer-Ivo_Karlovic,Roger Federer,Ivo Karlovic,R,R,M,20150620,Halle,SF,3:00 PM,Stadion,Grass,Manuel Messina,3,1,Edo
-20150619-M-Queens_Club-QF-Kevin_Anderson-Gilles_Simon,Kevin Anderson,Gilles Simon,R,R,M,20150619,Queens Club,QF,,Centre,Grass,James Keothavong,3,1,jeffsackmann
-20150619-M-Queens_Club-QF-John_Isner-Viktor_Troicki,John Isner,Viktor Troicki,R,R,M,20150619,Queens Club,QF,,Centre,Grass,James Keothavong,3,1,jeffsackmann
-20150619-M-Halle-QF-Tomas_Berdych-Ivo_Karlovic,Tomas Berdych,Ivo Karlovic,R,R,M,20150619,Halle,QF,,,Grass,,3,1,jeffsackmann
 20150618-M-Fergana_CH-R16-Ti_Chen-Laurynas_Grigelis,Ti Chen,Laurynas Grigelis,R,R,M,20150618,Fergana CH,R16,,Center Court,Hard,,3,1,Isaac
 20150617-M-Queens_Club-R16-Thanasi_Kokkinakis-Gilles_Simon,Thanasi Kokkinakis,Gilles Simon,R,R,M,20150617,Queens Club,R16,,,Grass,James Keothavong,3,1,pvtennis
-20150617-M-Queens_Club-R16-Stanislas_Wawrinka-Kevin_Anderson,Stanislas Wawrinka,Kevin Anderson,R,R,M,20150617,Queens Club,R16,,Centre,Grass,Gerry Armstrong,3,1,jeffsackmann
 20150615-M-Ilkley_CH-SF-Matthew_Ebden-Ivan_Dodig,Matthew Ebden,Ivan Dodig,R,R,M,20150615,Ilkley CH,SF,,,Grass,,3,1,Isaac
 20150615-M-Ilkey_CH-R32-Yuki_Bhambri-Cameron_Norrie,Yuki Bhambri,Cameron Norrie,R,L,M,20150615,Ilkey CH,R32,,,Grass,,3,1,Isaac
 20150615-M-Halle-R32-Andreas_Haider_Maurer-Dustin_Brown,Andreas Haider Maurer,Dustin Brown,R,R,M,20150615,Halle,R32,2:00 PM,Centre,Grass,,3,1,Edo
 20150613-M-s_Hertogenbosch-SF-Gilles_Muller-David_Goffin,Gilles Muller,David Goffin,L,R,M,20150613,s Hertogenbosch,SF,,,Grass,Mohamed El Jennati,3,1,pvtennis
-20150613-M-s_Hertogenbosch-F-Nicolas_Mahut-David_Goffin,Nicolas Mahut,David Goffin,R,R,M,20150613,s Hertogenbosch,F,,Center,Grass,,3,1,jeffsackmann
-20150612-M-s_Hertogenbosch-SF-Nicolas_Mahut-Robin_Haase,Nicolas Mahut,Robin Haase,R,R,M,20150612,s Hertogenbosch,SF,,,Grass,Roland Herfel,3,1,jeffsackmann
-20150612-M-Surbiton_CH-SF-Brydan_Klein-Denis_Kudla,Brydan Klein,Denis Kudla,R,R,M,20150612,Surbiton CH,SF,,,Grass,,3,1,jeffsackmann
 20150611-M-s_Hertogenbosch-R16-Roberto_Bautista_Agut-Nicolas_Mahut,Roberto Bautista Agut,Nicolas Mahut,R,R,M,20150611,s Hertogenbosch,R16,,,Grass,,3,1,Stephen
 20150611-M-s_Hertogenbosch-R16-Jurgen_Melzer-David_Goffin,Jurgen Melzer,David Goffin,L,R,M,20150611,s Hertogenbosch,R16,,Centre,Grass,Cedric Mourier,3,1,Edo
 20150611-M-Stuttgart-R16-Bernard_Tomic-Tommy_Haas,Bernard Tomic,Tommy Haas,R,R,M,20150611,Stuttgart,R16,,,Grass,Adel Nour,3,1,Amy
-20150610-M-s Hertogenbosch-R16-Vasek_Pospisil-Gilles_Muller,Vasek Pospisil,Gilles Muller,R,L,M,20150610,s Hertogenbosch,R16,,,Grass,Roland Herfel,3,1,jeffsackmann
 20150610-M-Stuttgart-R16-Feliciano_Lopez-Samuel_Groth,Feliciano Lopez,Samuel Groth,L,R,M,20150610,Stuttgart,R16,,,Grass,,3,1,Jenn
-20150610-M-Stuttgart-R16-Andreas_Seppi-Mischa_Zverev,Andreas Seppi,Mischa Zverev,R,L,M,20150610,Stuttgart,R16,,,Grass,Manuel Messina,3,1,jeffsackmann
 20150609-M-Stuttgart-R32-Jan_Lennard_Struff-Bernard_Tomic,Jan Lennard Struff,Bernard Tomic,R,R,M,20150609,Stuttgart,R32,,,Grass,Adel Nour,3,1,Amy
+20150609-M-Stuttgart-R32-Dustin_Brown-Jerzy_Janowicz,Dustin Brown,Jerzy Janowicz,R,R,M,20150609,Stuttgart,R32,16:55,Centre,Grass,Manuel Messina,3,1,MaGav
 20150608-M-Stuttgart-R16-Andreas_Haider_Maurer-Gael_Monfils,Andreas Haider Maurer,Gael Monfils,R,R,M,20150608,Stuttgart,R16,,,Grass,,3,1,Isaac
 20150608-M-Stuttgart-Q3-Dustin_Brown-Michael_Berrer,Dustin Brown,Michael Berrer,R,L,M,20150608,Stuttgart,Q3,,,Grass,,3,1,Isaac
 20150607-M-Roland_Garros-F-Stanislas_Wawrinka-Novak_Djokovic,Stanislas Wawrinka,Novak Djokovic,R,R,M,20150607,Roland Garros,F,3:00 PM,Philippe Chatrier,Clay,Damien Dumusois,5,0,Edo
+20150605-M-Roland_Garros-SF-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20150605,Roland Garros,SF,5.30pm,Philippe Chatrier,Clay,Pascal Maria,5,0,Edo
 20150603-M-Roland_Garros-QF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20150603,Roland Garros,QF,,,Clay,,5,0,Amy
 20150531-M-Roland_Garros-R16-Roger_Federer-Gael_Monfils,Roger Federer,Gael Monfils,R,R,M,20150531,Roland Garros,R16,19.20.00,Philippe Chatrier,Clay,Carlos Bernardes,5,0,Edo
 20150530-M-Roland_Garros-R32-Nick_Kyrgios-Andy_Murray,Nick Kyrgios,Andy Murray,R,R,M,20150530,Roland Garros,R32,11:10 AM,Suzanne Lenglen,Clay,Damien Dumusois,5,0,ChapelHeel66
 20150529-M-Roland_Garros-R32-Damir_Dzumhur-Roger_Federer,Damir Dzumhur,Roger Federer,R,R,M,20150529,Roland Garros,R32,2:00 PM,Philippe Chatrier,Clay,,5,0,Edo
-20150528-M-Vicenza_CH-R16-Guido_Pella-Federico_Gaio,Guido Pella,Federico Gaio,L,R,M,20150528,Vicenza CH,R16,,,Clay,,3,1,jeffsackmann
 20150528-M-Roland_Garros-R64-Jeremy_Chardy-John_Isner,Jeremy Chardy,John Isner,R,R,M,20150528,Roland Garros,R64,4:40 PM,Court 1 (The Bullring),Clay,Carlos Ramos,5,1,ChapelHeel66
 20150526-M-Roland_Garros-R128-Richard_Gasquet-Germain_Gigounon,Richard Gasquet,Germain Gigounon,R,R,M,20150526,Roland Garros,R128,2:40 PM,Court Suzanne Lenglen,Clay,Gianluca Moscarella,5,0,ChapelHeel66
 20150524-M-Roland_Garros-R128-Paul_Henri_Mathieu-Kei_Nishikori,Paul Henri Mathieu,Kei Nishikori,R,R,M,20150524,Roland Garros,R128,2:50 PM,Suzanne Lenglen,Clay,Jake Garner,5,0,Edo
-20150524-M-Roland_Garros-R128-Nicolas_Mahut-Kimmer_Coppejans,Nicolas Mahut,Kimmer Coppejans,R,R,M,20150524,Roland Garros,R128,,2,Clay,,5,0,jeffsackmann
 20150524-M-Nice-F-Leonardo_Mayer-Dominic_Thiem,Leonardo Mayer,Dominic Thiem,R,R,M,20150524,Nice,F,3:00 PM,Central,Clay,,3,1,Edo
 20150522-M-Scheveningen-R32-Aleksandr_Nedovyesov-Andrey_Golubev,Aleksandr Nedovyesov,Andrey Golubev,R,R,M,20150522,Scheveningen,R32,15:09,,Clay,,3,1,Bramre
-20150522-M-Nice-SF-Leonardo_Mayer-Borna_Coric,Leonardo Mayer,Borna Coric,R,R,M,20150522,Nice,SF,,,Clay,,3,1,jeffsackmann
-20150522-M-Geneva-F-Joao_Sousa-Thomaz_Bellucci,Joao Sousa,Thomaz Bellucci,R,L,M,20150522,Geneva,F,,,Clay,Roland Herfel,3,1,jeffsackmann
 20150521-M-Nice-QF-Leonardo_Mayer-Juan_Monaco,Leonardo Mayer,Juan Monaco,R,R,M,20150521,Nice,QF,,,Clay,,3,1,Jenn
-20150520-M-Geneva-R16-Adrian_Mannarino-Pablo_Andujar,Adrian Mannarino,Pablo Andujar,L,R,M,20150520,Geneva,R16,,,Clay,,3,1,jeffsackmann
-20150520-M-Geneva-QF-Albert_Ramos-Thomaz_Bellucci,Albert Ramos,Thomaz Bellucci,L,L,M,20150520,Geneva,QF,,,Clay,,3,1,jeffsackmann
-20150519-M-Geneva-R16-Lukas_Rosol-Stanislas_Wawrinka,Lukas Rosol,Stanislas Wawrinka,R,R,M,20150519,Geneva,R16,,,Clay,,3,1,jeffsackmann
-20150517-M-Geneva-R32-Thomaz_Bellucci-Marcos_Baghdatis,Thomaz Bellucci,Marcos Baghdatis,L,R,M,20150517,Geneva,R32,,,Clay,Roland Herfel,3,1,jeffsackmann
+20150517-M-Rome_Masters-F-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20150517,Rome Masters,F,,Centre,Clay,Damian Steiner,3,1,Aaron Chiu
 20150515-M-Rome_Masters-QF-Roger_Federer-Tomas_Berdych,Roger Federer,Tomas Berdych,R,R,M,20150515,Rome Masters,QF,2:00 PM,Centre,Clay,Fergus Murphy,3,1,Edo
 20150515-M-Rome_Masters-QF-Novak_Djokovic-Kei_Nishikori,Novak Djokovic,Kei Nishikori,R,R,M,20150515,Rome Masters,QF,,Centrale,Clay,,3,1,jk
 20150514-M-Rome_Masters-R16-Roger_Federer-Kevin_Anderson,Roger Federer,Kevin Anderson,R,R,M,20150514,Rome Masters,R16,,Centrale,Clay,Carlos Bernardes,3,1,FedFan
 20150514-M-Rome_Masters-R16-John_Isner-Rafael_Nadal,John Isner,Rafael Nadal,R,L,M,20150514,Rome Masters,R16,,Centrale,Clay,Mohamed Lahyani,3,1,Martin
 20150513-M-Rome_Masters-R32-Jeremy_Chardy-Andy_Murray,Jeremy Chardy,Andy Murray,R,R,M,20150513,Rome Masters,R32,12:00 PM,Centrale,Clay,Carlos Bernardes,3,1,DavidAurora
-20150512-M-Rome_Masters-R64-Nick_Kyrgios-Feliciano_Lopez,Nick Kyrgios,Feliciano Lopez,R,L,M,20150512,Rome Masters,R64,,,Clay,Damien Dumusois,3,1,jeffsackmann
 20150512-M-Rome_Masters-R64-Marin_Cilic-Guillermo_Garcia_Lopez,Marin Cilic,Guillermo Garcia Lopez,R,R,M,20150512,Rome Masters,R64,11:00 AM,Grandstand,Clay,Gianluca Moscarella,3,1,DavidAurora
-20150512-M-Rome_Masters-R64-Andrea_Arnaboldi-David_Goffin,Andrea Arnaboldi,David Goffin,L,R,M,20150512,Rome Masters,R64,,,Clay,,3,1,jeffsackmann
-20150512-M-Rome_Masters-R32-Matteo_Donati-Tomas_Berdych,Matteo Donati,Tomas Berdych,R,R,M,20150512,Rome Masters,R32,,,Clay,,3,1,jeffsackmann
 20150511-M-Rome_Masters-R64-Steve_Johnson-Fabio_Fognini,Steve Johnson,Fabio Fognini,R,R,M,20150511,Rome Masters,R64,7:30 PM,Centrale,Clay,,3,1,DavidAurora
 20150511-M-Rome_Masters-R64-Jack_Sock-Gilles_Simon,Jack Sock,Gilles Simon,R,R,M,20150511,Rome Masters,R64,11:00 AM,Grandstand,Clay,Carlos Bernardes,3,1,DavidAurora
 20150509-M-Madrid_Masters-SF-Kei_Nishikori-Andy_Murray,Kei Nishikori,Andy Murray,R,R,M,20150509,Madrid Masters,SF,8:00 PM,Manolo Santana,Clay,,3,1,Edo
@@ -573,868 +709,1108 @@ match_id,Player 1,Player 2,Pl 1 hand,Pl 2 hand,Gender,Date,Tournament,Round,Time
 20150507-M-Madrid_Masters-R16-John_Isner-Nick_Kyrgios,John Isner,Nick Kyrgios,R,R,M,20150507,Madrid Masters,R16,3:00 PM,Stadium 3,Clay,Carlos Bernardes,3,1,Edo
 20150507-M-Madrid_Masters-R16-Grigor_Dimitrov-Stanislas_Wawrinka,Grigor Dimitrov,Stanislas Wawrinka,R,R,M,20150507,Madrid Masters,R16,1:00 PM,Arantxa Sanchez-Vicario,Clay,,3,1,Edo
 20150506-M-Madrid_Masters-R32-Leonardo_Mayer-Feliciano_Lopez,Leonardo Mayer,Feliciano Lopez,R,L,M,20150506,Madrid Masters,R32,,ASV,Clay,,3,1,Jenn
-20150505-M-Madrid_Masters-R64-Roberto_Bautista_Agut-Marius_Copil,Roberto Bautista Agut,Marius Copil,R,R,M,20150505,Madrid Masters,R64,,ASV,Clay,Carlos Bernardes,3,1,jeffsackmann
-20150505-M-Madrid_Masters-R64-Fernando_Verdasco-Guillermo_Garcia_Lopez,Fernando Verdasco,Guillermo Garcia Lopez,L,R,M,20150505,Madrid Masters,R64,3:15 PM,Centre,Clay,,3,1,DavidAurora
-20150503-M-Istanbul-F-Roger_Federer-Pablo_Cuevas,Roger Federer,Pablo Cuevas,R,R,M,20150503,Istanbul,F,4:00 PM,Centre,Clay,,3,1,Edo
-20150503-M-Estoril-F-Richard_Gasquet-Nick_Kyrgios,Richard Gasquet,Nick Kyrgios,R,R,M,20150503,Estoril,F,,,Clay,,3,1,Isaac
-20150502-M-Munich-QF-Philipp_Kohlschreiber-David_Goffin,Philipp Kohlschreiber,David Goffin,R,R,M,20150502,Munich,QF,,,Clay,James Keothavong,3,1,pvtennis
-20150502-M-Munich-QF-Andy_Murray-Lukas_Rosol,Andy Murray,Lukas Rosol,R,R,M,20150502,Munich,QF,10:00 AM,Centre,Clay,Cedric Mourier,3,1,Edo
-20150502-M-Istanbul-SF-Roger_Federer-Diego_Sebastian_Schwartzman,Roger Federer,Diego Sebastian Schwartzman,R,R,M,20150502,Istanbul,SF,3:00 PM,Centre,Clay,Mohamed Lahyani,3,1,Edo
-20150502-M-Istanbul-SF-Grigor_Dimitrov-Pablo_Cuevas,Grigor Dimitrov,Pablo Cuevas,R,R,M,20150502,Istanbul,SF,5:00 PM,Centre,Clay,R. Lichtenste,3,1,Edo
-20150501-M-Estoril-QF-Richard_Gasquet-Nicolas_Almagro,Richard Gasquet,Nicolas Almagro,R,R,M,20150501,Estoril,QF,2:45 PM,,Clay,Adel Nour,3,1,ChapelHeel66
-20150430-M-Munich-R16-Fabio_Fognini-Dominic_Thiem,Fabio Fognini,Dominic Thiem,R,R,M,20150430,Munich,R16,3:45 PM,Centre,Clay,,3,1,DavidAurora
-20150430-M-Istanbul-R16-Denis_Istomin-Thomaz_Bellucci,Denis Istomin,Thomaz Bellucci,R,L,M,20150430,Istanbul,R16,14:30 PM,Centre,Clay,,3,1,DavidAurora
-20150429-M-Istanbul-R16-Diego_Sebastian_Schwartzman-Jurgen_Melzer,Diego Sebastian Schwartzman,Jurgen Melzer,R,L,M,20150429,Istanbul,R16,,,Clay,,3,1,CEM
-20150426-M-Bucharest-F-Guillermo_Garcia_Lopez-Jiri_Vesely,Guillermo Garcia Lopez,Jiri Vesely,R,L,M,20150426,Bucharest,F,2:30 PM,Centre,Clay,Damien Dumusois,3,1,David Aurora
-20150425-M-Bucharest-SF-Jiri_Vesely-Daniel_Gimeno_Traver,Jiri Vesely,Daniel Gimeno Traver,L,R,M,20150425,Bucharest,SF,1:00 PM,Centre,Clay,,3,1,DavidAurora
-20150424-M-Bucharest-QF-Lukas_Rosol-Guillermo_Garcia_Lopez,Lukas Rosol,Guillermo Garcia Lopez,R,R,M,20150424,Bucharest,QF,11:50 AM,Central,Clay,Damien Dumusois,3,1,ChapelHeel66
-20150424-M-Barcelona-QF-Roberto_Bautista_Agut-Kei_Nishikori,Roberto Bautista Agut,Kei Nishikori,R,R,M,20150424,Barcelona,QF,12:30 PM,Centre,Clay,Carlos Bernardes,3,1,DavidAurora
-20150423-M-Barcelona-R16-Kei_Nishikori-Santiago_Giraldo,Kei Nishikori,Santiago Giraldo,R,R,M,20150423,Barcelona,R16,11:00 AM,Centre,Clay,Ali Nili,3,1,DavidAurora
-20150421-M-Barcelona-R64-Fernando_Verdasco-Andrey_Rublev,Fernando Verdasco,Andrey Rublev,L,R,M,20150421,Barcelona,R64,1:30 PM,Centre,Clay,Mohamed Lahyani,3,1,DavidAurora
-20150420-M-Barcelona-R64-Pablo_Carreno_Busta-Teymuraz_Gabashvili,Pablo Carreno Busta,Teymuraz Gabashvili,R,R,M,20150420,Barcelona,R64,5:30 PM,Centre,Clay,Ali Nili,3,1,DavidAurora
-20150418-M-Monte_Carlo_Masters-SF-Tomas_Berdych-Gael_Monfils,Tomas Berdych,Gael Monfils,R,R,M,20150418,Monte Carlo Masters,SF,1:00 PM,Centre,Clay,Carlos Bernardes,3,1,DavidAurora
-20150418-M-Monte_Carlo_Masters-SF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20150418,Monte Carlo Masters,SF,3.40PM,Centre,Clay,Cédric Mourier,3,0,Edo
-20150417-M-Monte_Carlo_Masters-QF-Milos_Raonic-Tomas_Berdych,Milos Raonic,Tomas Berdych,R,R,M,20150417,Monte Carlo Masters,QF,10:30 AM,Centre,Clay,Manuel Messina,3,1,DavidAurora
-20150417-M-Monte_Carlo_Masters-QF-Grigor_Dimitrov-Gael_Monfils,Grigor Dimitrov,Gael Monfils,R,R,M,20150417,Monte Carlo Masters,QF,12:00 PM,Centre,Clay,Gianluca Moscarella,3,1,DavidAurora
-20150417-M-Monte_Carlo_Masters-QF-David_Ferrer-Rafael_Nadal,David Ferrer,Rafael Nadal,R,L,M,20150417,Monte Carlo Masters,QF,2:40 PM,Centre,Clay,Damien Dumusois,3,1,DavidAurora
-20150416-M-Monte_Carlo_Masters-R16-Tomas_Berdych-Roberto_Bautista_Agut,Tomas Berdych,Roberto Bautista Agut,R,R,M,20150416,Monte Carlo Masters,R16,,Court des Princes,Clay,,3,1,jeffsackmann
-20150416-M-Monte_Carlo_Masters-R16-Roger_Federer-Gael_Monfils,Roger Federer,Gael Monfils,R,R,M,20150416,Monte Carlo Masters,R16,,Central,Clay,Manuel Messina,3,1,FedFan
-20150415-M-Monte_Carlo_Masters-R32-Stanislas_Wawrinka-Juan_Monaco,Stanislas Wawrinka,Juan Monaco,R,R,M,20150415,Monte Carlo Masters,R32,11:00 AM,Central,Clay,,3,1,jeffsackmann
-20150415-M-Monte_Carlo_Masters-R32-Jo_Wilfried_Tsonga-David_Goffin,Jo Wilfried Tsonga,David Goffin,R,R,M,20150415,Monte Carlo Masters,R32,,Central,Clay,Carlos Bernardes,3,1,pvtennis
-20150414-M-Monte_Carlo_Masters-R64-Tommy_Robredo-Andreas_Seppi,Tommy Robredo,Andreas Seppi,R,R,M,20150414,Monte Carlo Masters,R64,12:30 PM,,Court des Princes,Damien Dumusois,3,1,DavidAurora
-20150414-M-Monte_Carlo_Masters-R64-Dominic_Thiem-Lucas_Pouille,Dominic Thiem,Lucas Pouille,R,R,M,20150414,Monte Carlo Masters,R64,10:30 AM,,Clay,,3,1,DavidAurora
-20150413-M-Monte_Carlo_Masters-R64-Mikhail_Kukushkin-Philipp_Kohlschreiber,Mikhail Kukushkin,Philipp Kohlschreiber,R,R,M,20150413,Monte Carlo Masters,R64,11:00 AM,Court Des Princes,Clay,,3,1,dropshot
-20150413-M-Monte_Carlo_Masters-R64-Borna_Coric-Alexandr_Dolgopolov,Borna Coric,Alexandr Dolgopolov,R,R,M,20150413,Monte Carlo Masters,R64,12:00 PM,Centre,Clay,Carlos Bernardes,3,1,DavidAurora
-20150411-M-Napoli_CH-SF-Daniel_Munoz_De_La_Nava-Thomas_Fabbiano,Daniel Munoz De La Nava,Thomas Fabbiano,L,R,M,20150411,Napoli CH,SF,,,Clay,,3,1,jeffsackmann
-20150410-M-Houston-QF-Sam_Querrey-Feliciano_Lopez,Sam Querrey,Feliciano Lopez,R,L,M,20150410,Houston,QF,,,Clay,,3,1,jeffsackmann
-20150410-M-Casablanca-QF-Nicolas_Almagro-Martin_Klizan,Nicolas Almagro,Martin Klizan,R,L,M,20150410,Casablanca,QF,,,Clay,Roland Herfel,3,1,DavidAurora
-20150409-M-Casablanca-R16-Daniel_Gimeno_Traver-Mikhail_Kukushkin,Daniel Gimeno Traver,Mikhail Kukushkin,R,R,M,20150409,Casablanca,R16,3:00 PM,,Clay,Mohamed El Jennati,3,1,DavidAurora
-20150408-M-Casablanca-R16-Carlos_Berlocq-Nicolas_Almagro,Carlos Berlocq,Nicolas Almagro,R,R,M,20150408,Casablanca,R16,1:00 PM,,Clay,,3,1,DavidAurora
-20150407-M-Casablanca-R32-Robin_Haase-Lamine_Ouahab,Robin Haase,Lamine Ouahab,R,R,M,20150407,Casablanca,R32,,Centre,Clay,Adel Nour,3,1,jeffsackmann
-20150407-M-Casablanca-R32-Nicolas_Almagro-Taro_Daniel,Nicolas Almagro,Taro Daniel,R,R,M,20150407,Casablanca,R32,,,Clay,Roland Herfel,3,1,DavidAurora
-20150406-M-Casablanca-R32-Carlos_Berlocq-Pablo_Carreno_Busta,Carlos Berlocq,Pablo Carreno Busta,R,R,M,20150406,Casablanca,R32,11:00 AM,,Clay,Adel Nour,3,1,DavidAurora
-20150405-M-Miami_Masters-F-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20150405,Miami Masters,F,,Center,Hard,Damien Dumusois,3,1,1HandBH
-20150403-M-Raanana_CH-R16-Blaz_Rola-Konstantin_Kravchuk,Blaz Rola,Konstantin Kravchuk,L,R,M,20150403,Raanana CH,R16,,Center,Hard,,3,1,jeffsackmann
-20150401-M-Miami_Masters-QF-Dominic_Thiem-Andy_Murray,Dominic Thiem,Andy Murray,R,R,M,20150401,Miami Masters,QF,,Stadium,Hard,,3,1,chrisG
-20150331-M-San_Luis_Potosi_CH-R32-Giovanni_Lapentti-Chase_Buchanan,Giovanni Lapentti,Chase Buchanan,R,R,M,20150331,San Luis Potosi CH,R32,,,Clay,,3,1,Amy
-20150330-M-Miami_Masters-R32-Viktor_Troicki-Kei_Nishikori,Viktor Troicki,Kei Nishikori,R,R,M,20150330,Miami Masters,R32,,,Hard,,3,1,Amy
-20150330-M-Miami_Masters-R32-Jerzy_Janowicz-David_Goffin,Jerzy Janowicz,David Goffin,R,R,M,20150330,Miami Masters,R32,,,Hard,,3,1,jeffsackmann
-20150329-M-Miami_Masters-R32-Leonardo_Mayer-Kevin_Anderson,Leonardo Mayer,Kevin Anderson,R,R,M,20150329,Miami Masters,R32,,1,Hard,,3,1,Jenn
-20150328-M-Miami_Masters-R64-Tim_Smyczek-Jo_Wilfried_Tsonga,Tim Smyczek,Jo Wilfried Tsonga,R,R,M,20150328,Miami Masters,R64,,Stadium,Hard,,3,1,pvtennis
-20150328-M-Miami_Masters-R64-Mikhail_Youzhny-Kei_Nishikori,Mikhail Youzhny,Kei Nishikori,R,R,M,20150328,Miami Masters,R64,,Grandstand,Hard,,3,0,GETJr
-20150325-M-Miami_Masters-R64-Vasek_Pospisil-Juan_Martin_Del_Potro,Vasek Pospisil,Juan Martin Del Potro,R,R,M,20150325,Miami Masters,R64,,,Hard,,3,1,Amy
-20150325-M-Miami_Masters-R128-Diego_Sebastian_Schwartzman-Dominic_Thiem,Diego Sebastian Schwartzman,Dominic Thiem,R,R,M,20150325,Miami Masters,R128,,Grandstand,Hard,,3,1,pablo
-20150321-M-Irving_CH-SF-Gilles_Muller-Tim_Smyczek,Gilles Muller,Tim Smyczek,L,R,M,20150321,Irving CH,SF,,,Hard,,3,1,jeffsackmann
-20150321-M-Indian_Wells_Masters-SF-Milos_Raonic-Roger_Federer,Milos Raonic,Roger Federer,R,R,M,20150321,Indian Wells Masters,SF,,,Hard,,3,1,Edged
-20150321-M-Indian_Wells_Masters-QF-Milos_Raonic-Rafael_Nadal,Milos Raonic,Rafael Nadal,R,L,M,20150321,Indian Wells Masters,QF,,,Hard,,3,1,Edged
-20150320-M-Indian_Wells_Masters-QF-Tomas_Berdych-Roger_Federer,Tomas Berdych,Roger Federer,R,R,M,20150320,Indian Wells Masters,QF,,,Hard,Fergus Murphy,3,1,Amy
-20150318-M-Shenzhen_CH-R16-Marton_Fucsovics-Tristan_Lamasine,Marton Fucsovics,Tristan Lamasine,R,R,M,20150318,Shenzhen CH,R16,,,Hard,,3,1,jeffsackmann
-20150318-M-Indian_Wells_Masters-R16-Milos_Raonic-Tommy_Robredo,Milos Raonic,Tommy Robredo,R,R,M,20150318,Indian Wells Masters,R16,,,Hard,,3,1,Edged
-20150318-M-Indian_Wells_Masters-R16-Feliciano_Lopez-Kei_Nishikori,Feliciano Lopez,Kei Nishikori,L,R,M,20150318,Indian Wells Masters,R16,,Stadium 1,Hard,,3,1,jeffsackmann
-20150318-M-Indian_Wells_Masters-QF-Andy_Murray-Feliciano_Lopez,Andy Murray,Feliciano Lopez,R,L,M,20150318,Indian Wells Masters,QF,,Stadium 1,Hard,Mo,3,1,jeffsackmann
-20150318-M-Indian_Wells-R16-Roger_Federer-Jack_Sock,Roger Federer,Jack Sock,R,R,M,20150318,Indian Wells,R16,,,Hard,,3,1,Amy
-20150316-M-Indian_Wells_Masters-R32-Novak_Djokovic-Albert_Ramos,Novak Djokovic,Albert Ramos,R,L,M,20150316,Indian Wells Masters,R32,,Stadium 1,Hard,Carlos Bernardes,3,1,jeffsackmann
-20150316-M-Indian_Wells_Masters-R32-Feliciano_Lopez-Pablo_Cuevas,Feliciano Lopez,Pablo Cuevas,L,R,M,20150316,Indian Wells Masters,R32,,Stadium 2,Hard,Mo,3,1,Jenn
-20150316-M-Indian_Wells_Masters-R32-Ernests_Gulbis-Adrian_Mannarino,Ernests Gulbis,Adrian Mannarino,R,L,M,20150316,Indian Wells Masters,R32,,,Hard,Ali Nili,3,1,jeffsackmann
-20150316-M-Indian_Wells_Masters-R32-David_Ferrer-Bernard_Tomic,David Ferrer,Bernard Tomic,R,R,M,20150316,Indian Wells Masters,R32,,,Hard,Adel Nour,3,1,Amy
-20150315-M-Indian_Wells_Masters-R64-Diego_Sebastian_Schwartzman-Roger_Federer,Diego Sebastian Schwartzman,Roger Federer,R,R,M,20150315,Indian Wells Masters,R64,,Stadium 1,Hard,,3,1,FedFan
-20150314-M-Indian_Wells_Masters-R64-Donald_Young-Jeremy_Chardy,Donald Young,Jeremy Chardy,L,R,M,20150314,Indian Wells Masters,R64,,,Hard,Fergus Murphy,3,1,jeffsackmann
-20150313-M-Santiago_CH-QF-Jordi_Samper_Montana-Ruben_Ramirez_Hidalgo,Jordi Samper Montana,Ruben Ramirez Hidalgo,R,R,M,20150313,Santiago CH,QF,,,Clay,,3,1,jeffsackmann
-20150313-M-Indian_Wells_Masters-R128-Sam_Querrey-Sergiy_Stakhovsky,Sam Querrey,Sergiy Stakhovsky,R,R,M,20150313,Indian Wells Masters,R128,,Stadium 1,Hard,,3,1,Isaac
-20150313-M-Indian_Wells_Masters-R128-Diego_Sebastian_Schwartzman-Jerzy_Janowicz,Diego Sebastian Schwartzman,Jerzy Janowicz,R,R,M,20150313,Indian Wells Masters,R128,,Stadium 3,Hard,Ali Nili,3,1,jeffsackmann
-20150313-M-Indian_Wells_Masters-R128-Denis_Kudla-Nick_Kyrgios,Denis Kudla,Nick Kyrgios,R,R,M,20150313,Indian Wells Masters,R128,,Stadium 1,Hard,,3,1,jeffsackmann
-20150312-M-Indian_Wells_Masters-R128-Tim_Smyczek-Benjamin_Becker,Tim Smyczek,Benjamin Becker,R,R,M,20150312,Indian Wells Masters,R128,,Stadium 1,Hard,Cedric Mourier,3,1,jeffsackmann
-20150312-M-Indian_Wells_Masters-R128-Andreas_Haider_Maurer-Borna_Coric,Andreas Haider Maurer,Borna Coric,R,R,M,20150312,Indian Wells Masters,R128,,Stadium 3,Hard,,3,1,chrisG
-20150303-M-Quimper_CH-R32-Jurgen_Zopp-Maxime_Authom,Jurgen Zopp,Maxime Authom,R,R,M,20150303,Quimper CH,R32,,,Hard,,3,1,jeffsackmann
-20150228-M-Dubai-F-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20150228,Dubai,F,,,Hard,Mohamed Lahyani,3,1,FedFan
-20150227-M-Dubai-SF-Roger_Federer-Borna_Coric,Roger Federer,Borna Coric,R,R,M,20150227,Dubai,SF,,,Hard,Kader Nouni,3,1,FedFan
-20150227-M-Acapulco-SF-Kevin_Anderson-Kei_Nishikori,Kevin Anderson,Kei Nishikori,R,R,M,20150227,Acapulco,SF,,,Hard,,3,1,jeffsackmann
-20150226-M-Dubai-QF-Novak_Djokovic-Marsel_Ilhan,Novak Djokovic,Marsel Ilhan,R,R,M,20150226,Dubai,QF,,Centre,Hard,Kader Nouni,3,1,Salvo
-20150226-M-Dubai-QF-Andy_Murray-Borna_Coric,Andy Murray,Borna Coric,R,R,M,20150226,Dubai,QF,,,Hard,,3,1,chrisG
-20150226-M-Acapulco-QF-Viktor_Troicki-Kevin_Anderson,Viktor Troicki,Kevin Anderson,R,R,M,20150226,Acapulco,QF,,,Hard,,3,1,jeffsackmann
-20150225-M-Dubai-R16-Fernando_Verdasco-Roger_Federer,Fernando Verdasco,Roger Federer,L,R,M,20150225,Dubai,R16,,,Hard,Kader Nouni,3,1,jeffsackmann
-20150223-M-Dubai-R32-Joao_Sousa-James_Mcgee,Joao Sousa,James Mcgee,R,R,M,20150223,Dubai,R32,,,Hard,Kader Nouni,3,1,jeffsackmann
-20150223-M-Buenos_Aires-QF-Rafael_Nadal-Federico_Delbonis,Rafael Nadal,Federico Delbonis,L,L,M,20150223,Buenos Aires,QF,,Center,Clay,,3,1,Isaac
-20150221-M-Marseille-SF-Sergiy_Stakhovsky-Gilles_Simon,Sergiy Stakhovsky,Gilles Simon,R,R,M,20150221,Marseille,SF,,,Hard,James Keothavong,3,1,pvtennis
-20150221-M-Marseille-SF-Roberto_Bautista_Agut-Gael_Monfils,Roberto Bautista Agut,Gael Monfils,R,R,M,20150221,Marseille,SF,,,Hard,,3,1,pvtennis
-20150220-M-Delray_Beach-QF-Steve_Johnson-Ivo_Karlovic,Steve Johnson,Ivo Karlovic,R,R,M,20150220,Delray Beach,QF,8:10 PM,,Hard,Pascal Maria,3,1,ChapelHeel66
-20150220-M-Delray_Beach-QF-Adrian_Mannarino-Yen_Hsun_Lu,Adrian Mannarino,Yen Hsun Lu,L,R,M,20150220,Delray Beach,QF,,Center,Hard,,3,1,jeffsackmann
-20150219-M-Rio_De_Janeiro-R16-Rafael_Nadal-Pablo_Carreno_Busta,Rafael Nadal,Pablo Carreno Busta,L,R,M,20150219,Rio De Janeiro,R16,,Center Court,Clay,Adel Nour,3,1,Isaac
-20150218-M-Delray_Beach-R32-Steve_Johnson-Andrey_Rublev,Steve Johnson,Andrey Rublev,R,R,M,20150218,Delray Beach,R32,,,Hard,,3,1,jeffsackmann
-20150218-M-Delray_Beach-R16-Thanasi_Kokkinakis-Ivo_Karlovic,Thanasi Kokkinakis,Ivo Karlovic,R,R,M,20150218,Delray Beach,R16,12:45,,Hard,,3,1,ChapelHeel66
-20150217-M-Rio_de_Janeiro-R32-Thomaz_Bellucci-Rafael_Nadal,Thomaz Bellucci,Rafael Nadal,L,L,M,20150217,Rio de Janeiro,R32,,Center Court,Clay,,3,1,Isaac
-20150217-M-Marseille-R32-Alexander_Zverev-Gael_Monfils,Alexander Zverev,Gael Monfils,R,R,M,20150217,Marseille,R32,,,Hard,,3,1,pvtennis
-20150215-M-Sao_Paulo-F-Luca_Vanni-Pablo_Cuevas,Luca Vanni,Pablo Cuevas,R,R,M,20150215,Sao Paulo,F,,,Clay,,3,1,jeffsackmann
-20150215-M-Rotterdam-F-Stanislas_Wawrinka-Tomas_Berdych,Stanislas Wawrinka,Tomas Berdych,R,R,M,20150215,Rotterdam,F,,Center court,Hard,Gerry Armstrong,3,1,Isaac
-20150215-M-Launceston_CH-F-Hyeon_Chung-Bjorn_Fratangelo,Hyeon Chung,Bjorn Fratangelo,R,R,M,20150215,Launceston CH,F,,,Hard,,3,1,jeffsackmann
-20150214-M-Sao_Paulo-SF-Santiago_Giraldo-Pablo_Cuevas,Santiago Giraldo,Pablo Cuevas,R,R,M,20150214,Sao Paulo,SF,,,Clay,,3,1,jeffsackmann
-20150213-M-Sao_Paulo-QF-Santiago_Giraldo-Fabio_Fognini,Santiago Giraldo,Fabio Fognini,R,R,M,20150213,Sao Paulo,QF,,,Clay,,3,1,Jenn
-20150213-M-Sao_Paulo-QF-Nicolas_Almagro-Pablo_Cuevas,Nicolas Almagro,Pablo Cuevas,R,R,M,20150213,Sao Paulo,QF,,,Clay,,3,1,jeffsackmann
-20150212-M-Rotterdam-R16-Milos_Raonic-Simone_Bolelli,Milos Raonic,Simone Bolelli,R,R,M,20150212,Rotterdam,R16,,Center court,Hard,Cedric Mourier,3,1,Isaac
-20150212-M-Rotterdam-R16-Jeremy_Chardy-Gilles_Simon,Jeremy Chardy,Gilles Simon,R,R,M,20150212,Rotterdam,R16,,,Hard,,3,1,jeffsackmann
-20150211-M-Rotterdam-R16-Sergiy_Stakhovsky-Dominic_Thiem,Sergiy Stakhovsky,Dominic Thiem,R,R,M,20150211,Rotterdam,R16,,,Hard,,3,1,jeffsackmann
-20150211-M-Rotterdam-R16-Grigor_Dimitrov-Gilles_Muller,Grigor Dimitrov,Gilles Muller,R,L,M,20150211,Rotterdam,R16,,,Hard,Cedric Mourier,3,1,jeffsackmann
-20150210-M-Rotterdam-R32-Vasek_Pospisil-Philipp_Kohlschreiber,Vasek Pospisil,Philipp Kohlschreiber,R,R,M,20150210,Rotterdam,R32,,,Hard,,3,1,jeffsackmann
-20150210-M-Rotterdam-R32-Andrey_Kuznetsov-Milos_Raonic,Andrey Kuznetsov,Milos Raonic,R,R,M,20150210,Rotterdam,R32,,Center Court,Hard,,3,1,Isaac
-20150210-M-Bergamo_CH-R32-Benoit_Paire-Jan_Mertl,Benoit Paire,Jan Mertl,R,R,M,20150210,Bergamo CH,R32,,Center,Hard,,3,1,jeffsackmann
-20150209-M-Rotterdam-R32-Roberto_Bautista_Agut-Alexander_Zverev,Roberto Bautista Agut,Alexander Zverev,R,R,M,20150209,Rotterdam,R32,,,Hard,,3,1,jeffsackmann
-20150209-M-Rotterdam-R32-Grigor_Dimitrov-Paul_Henri_Mathieu,Grigor Dimitrov,Paul Henri Mathieu,R,R,M,20150209,Rotterdam,R32,,Center Court,Hard,,3,1,Isaac
-20150208-M-Zagreb-F-Andreas_Seppi-Guillermo_Garcia_Lopez,Andreas Seppi,Guillermo Garcia Lopez,R,R,M,20150208,Zagreb,F,,Center court,Hard,,3,1,Isaac
-20150208-M-Quito-F-Feliciano_Lopez-Victor_Estrella,Feliciano Lopez,Victor Estrella,L,R,M,20150208,Quito,F,,,Hard,,3,1,jeffsackmann
-20150208-M-Montpellier-F-Richard_Gasquet-Jerzy_Janowicz,Richard Gasquet,Jerzy Janowicz,R,R,M,20150208,Montpellier,F,,Centre Court,Indoor Hard,Manuel Messina,3,1,Isaac
-20150207-M-Zagreb-SF-Marcos_Baghdatis-Guillermo_Garcia_Lopez,Marcos Baghdatis,Guillermo Garcia Lopez,R,R,M,20150207,Zagreb,SF,,Center,Hard,,3,1,jeffsackmann
-20150207-M-Montpellier-SF-Richard_Gasquet-Gael_Monfils,Richard Gasquet,Gael Monfils,R,R,M,20150207,Montpellier,SF,,,Hard,,3,1,jeffsackmann
-20150207-M-Glasgow_CH-SF-David_Guez-Ruben_Bemelmans,David Guez,Ruben Bemelmans,R,L,M,20150207,Glasgow CH,SF,,,Hard,,3,1,jeffsackmann
-20150206-M-Montpellier-QF-Joao_Sousa-Philipp_Kohlschreiber,Joao Sousa,Philipp Kohlschreiber,R,R,M,20150206,Montpellier,QF,3:40 PM,,Hard,Arnaud Gabas,3,1,ChapelHeel66
-20150206-M-Montpellier-QF-Gilles_Simon-Jerzy_Janowicz,Gilles Simon,Jerzy Janowicz,R,R,M,20150206,Montpellier,QF,,,Hard,,3,1,jeffsackmann
-20150205-M-Zagreb-R16-Ivan_Dodig-Marcel_Granollers,Ivan Dodig,Marcel Granollers,R,R,M,20150205,Zagreb,R16,11:15 AM,,Hard,Ahmed Abdel Azim,3,1,ChapelHeel66
-20150203-M-Montpellier-R32-Nikoloz_Basilashvili-Benoit_Paire,Nikoloz Basilashvili,Benoit Paire,R,R,M,20150203,Montpellier,R32,,Center,Hard,,3,1,jeffsackmann
-20150203-M-Glasgow_CH-R32-Niels_Desein-Tim_Puetz,Niels Desein,Tim Puetz,R,R,M,20150203,Glasgow CH,R32,,,Hard,,3,1,jeffsackmann
-20150202-M-Quito-Q3-Gerald_Melzer-Roberto_Carballes_Baena,Gerald Melzer,Roberto Carballes Baena,L,R,M,20150202,Quito,Q3,,,Clay,,3,1,jeffsackmann
-20150201-M-Australian_Open-F-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20150201,Australian Open,F,,Rod Laver,Hard,,5,0,Lowell
-20150131-M-Hong_Kong_CH-SF-Kyle_Edmund-Yoshihito_Nishioka,Kyle Edmund,Yoshihito Nishioka,R,L,M,20150131,Hong Kong CH,SF,,,Hard,,3,1,jeffsackmann
-20150130-M-Australian_Open-SF-Novak_Djokovic-Stanislas_Wawrinka,Novak Djokovic,Stanislas Wawrinka,R,R,M,20150130,Australian Open,SF,,Rod Laver Arena,Hard,,5,0,Isaac
-20150127-M-Australian_Open-QF-Tomas_Berdych-Rafael_Nadal,Tomas Berdych,Rafael Nadal,R,L,M,20150127,Australian Open,QF,,Rod Laver Arena,Hard,Mohamed Lahyani,5,0,Bobby
-20150127-M-Australian_Open-QF-Stanislas_Wawrinka_-Kei_Nishikori,Stanislas Wawrinka ,Kei Nishikori,R,R,M,20150127,Australian Open,QF,,Rod Laver Arena,Hard,,5,0,Isaac
-20150126-M-Bucaramanga_CH-R32-Arthur_De_Greef-Victor_Estrella,Arthur De Greef,Victor Estrella,R,R,M,20150126,Bucaramanga CH,R32,,,Clay,,3,1,jeffsackmann
-20150125-M-Australian_Open-R16-Bernard_Tomic-Tomas_Berdych,Bernard Tomic,Tomas Berdych,R,R,M,20150125,Australian Open,R16,,Margaret Court Arena,Hard Court,,5,0,Bobby
-20150123-M-Australian_Open-R32-Fernando_Verdasco-Novak_Djokovic,Fernando Verdasco,Novak Djokovic,L,R,M,20150123,Australian Open,R32,,Rod Laver Arena,Hard,,5,0,Isaac
-20150117-M-Auckland-F-Jiri_Vesely-Adrian_Mannarino,Jiri Vesely,Adrian Mannarino,L,L,M,20150117,Auckland,F,,,Hard,Gerry Armstrong,3,1,jeffsackmann
-20150116-M-Auckland-SF-Kevin_Anderson-Jiri_Vesely,Kevin Anderson,Jiri Vesely,R,L,M,20150116,Auckland,SF,,,Hard,Paula Vieira Souza,3,1,jeffsackmann
-20150114-M-Sydney-QF-Gilles_Muller-Bernard_Tomic,Gilles Muller,Bernard Tomic,L,R,M,20150114,Sydney,QF,,Centre,Hard,Fergus Murphy,3,1,jeffsackmann
-20150114-M-Auckland-R16-Ernests_Gulbis-Jiri_Vesely,Ernests Gulbis,Jiri Vesely,R,L,M,20150114,Auckland,R16,,,Hard,,3,1,jeffsackmann
-20150111-M-Chennai-F-Stanislas_Wawrinka-Aljaz_Bedene,Stanislas Wawrinka,Aljaz Bedene,R,R,M,20150111,Chennai,F,,,Hard,,3,1,jeffsackmann
-20150109-M-Brisbane-QF-Bernard_Tomic-Kei_Nishikori,Bernard Tomic,Kei Nishikori,R,R,M,20150109,Brisbane,QF,,Pat Rafter Arena (Centre),,,3,1,qthetennisfan
-20150106-M-Doha-R32-Novak_Djokovic-Dusan_Lajovic,Novak Djokovic,Dusan Lajovic,R,R,M,20150106,Doha,R32,,,Hard,Carlos Bernardes,3,1,MBLAIR
-20150106-M-Doha-R16-Tomas_Berdych-Blaz_Kavcic,Tomas Berdych,Blaz Kavcic,R,R,M,20150106,Doha,R16,,,Hard,Carlos Bernardes,3,1,MBLAIR
-20150105-M-Doha-R32-Rafael_Nadal-Michael_Berrer,Rafael Nadal,Michael Berrer,L,L,M,20150105,Doha,R32,,Centre,Hard,,3,1,Isaac
-20141123-M-Davis_Cup_World_Group_F-RR-Richard_Gasquet-Roger_Federer,Richard Gasquet,Roger Federer,R,R,M,20141123,Davis Cup World Group F,RR,14:00:00,Lille,Clay,James Keothavong,5,0,Edo
-20141117-M-Lima_CH-F-Jason_Kubler-Guido_Pella,Jason Kubler,Guido Pella,R,L,M,20141117,Lima CH,F,,,Clay,,3,1,Amy
-20141115-M-London-SF-Roger_Federer-Stanislas_Wawrinka,Roger Federer,Stanislas Wawrinka,R,R,M,20141115,London,SF,,,Hard,Cedric Mourier,3,1,jeffsackmann
-20141114-M-Tour_Finals-RR-Tomas_Berdych-Novak_Djokovic,Tomas Berdych,Novak Djokovic,R,R,M,20141114,Tour Finals,RR,,,Hard,,3,1,Amy
-20141114-M-London-RR-Stanislas_Wawrinka-Marin_Cilic,Stanislas Wawrinka,Marin Cilic,R,R,M,20141114,London,RR,,,Hard,Damien Steiner,3,1,jeffsackmann
-20141113-M-London-RR-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20141113,London,RR,,,Hard,Mohamed Lahyani,3,1,jeffsackmann
-20141112-M-London-RR-Marin_Cilic-Tomas_Berdych,Marin Cilic,Tomas Berdych,R,R,M,20141112,London,RR,,,Hard,Carlos Bernardes,3,1,jeffsackmann
-20141111-M-London-RR-Andy_Murray-Milos_Raonic,Andy Murray,Milos Raonic,R,R,M,20141111,London,RR,,,Hard,Damian Steiner,3,1,jeffsackmann
-20141111-M-Champaign_CH-R32-Jared_Donaldson-Alex_Kuznetsov,Jared Donaldson,Alex Kuznetsov,R,R,M,20141111,Champaign CH,R32,,Court 1,Hard,,3,1,Amy
-20141110-M-London-RR-Marin_Cilic-Novak_Djokovic,Marin Cilic,Novak Djokovic,R,R,M,20141110,London,RR,,,Hard,Damien Steiner,3,1,jeffsackmann
-20141109-M-London-RR-Roger_Federer-Milos_Raonic,Roger Federer,Milos Raonic,R,R,M,20141109,London,RR,,,Hard,Carlos Bernardes,3,1,jeffsackmann
-20141109-M-London-RR-Kei_Nishikori-Andy_Murray,Kei Nishikori,Andy Murray,R,R,M,20141109,London,RR,,,Hard,Cedric Mourier,3,1,jeffsackmann
-20141108-M-Mouilleron_CH-QF-Marsel_Ilhan-Borna_Coric,Marsel Ilhan,Borna Coric,R,R,M,20141108,Mouilleron CH,QF,,,Hard,,3,1,jeffsackmann
-20141104-M-Knoxville_CH-R32-Jared_Donaldson-Daniel_Nguyen,Jared Donaldson,Daniel Nguyen,R,R,M,20141104,Knoxville CH,R32,,Center,Hard,,3,1,Amy
-20141103-M-Charlottesville_CH-F-Liam_Broady-James_Duckworth,Liam Broady,James Duckworth,L,R,M,20141103,Charlottesville CH,F,,,Hard,,3,1,jeffsackmann
-20141101-M-Paris_Masters-F-Novak_Djokovic-Milos_Raonic,Novak Djokovic,Milos Raonic,R,R,M,20141101,Paris Masters,F,,,Hard,Cedric Mourier,3,1,jeffsackmann
-20141101-M-Geneva_CH-SF-Radu_Albot-Marcos_Baghdatis,Radu Albot,Marcos Baghdatis,R,R,M,20141101,Geneva CH,SF,,,Hard,,3,1,jeffsackmann
-20141030-M-Paris_Masters-R16-Novak_Djokovic-Gael_Monfils,Novak Djokovic,Gael Monfils,R,R,M,20141030,Paris Masters,R16,,Central,Hard,Ali Nili,3,1,jeffsackmann
-20141030-M-Paris_Masters-R16-Jo_Wilfried_Tsonga-Kei_Nishikori,Jo Wilfried Tsonga,Kei Nishikori,R,R,M,20141030,Paris Masters,R16,,Central,Hard,Carlos Bernardes,3,1,jeffsackmann
-20141029-M-Paris_Masters-R32-Stanislas_Wawrinka-Dominic_Thiem,Stanislas Wawrinka,Dominic Thiem,R,R,M,20141029,Paris Masters,R32,,Center,Hard,,3,1,jeffsackmann
-20141029-M-Paris_Masters-R32-Lucas_Pouille-Fabio_Fognini,Lucas Pouille,Fabio Fognini,R,R,M,20141029,Paris Masters,R32,,1,Hard,Carlos Bernardes,3,1,jeffsackmann
-20141028-M-Paris_Masters-R64-Vasek_Pospisil-Tommy_Robredo,Vasek Pospisil,Tommy Robredo,R,R,M,20141028,Paris Masters,R64,,1,Hard,Cedric Mourier,3,1,jeffsackmann
-20141027-M-Paris_Masters-R64-Pierre_Hugues_Herbert-Adrian_Mannarino,Pierre Hugues Herbert,Adrian Mannarino,R,L,M,20141027,Paris Masters,R64,,1,Hard,Roland Herfel,3,1,jeffsackmann
-20141026-M-Basel-F-David_Goffin-Roger_Federer,David Goffin,Roger Federer,R,R,M,20141026,Basel,F,,,Hard,Mohamed Lahyani,3,1,jeffsackmann
-20141025-M-Valencia-SF-David_Ferrer-Andy_Murray,David Ferrer,Andy Murray,R,R,M,20141025,Valencia,SF,,Agora,Hard,,3,1,jeffsackmann
-20141024-M-Basel-QF-Grigor_Dimitrov-Roger_Federer,Grigor Dimitrov,Roger Federer,R,R,M,20141024,Basel,QF,,,Hard,Mohamed Lahyani,3,1,jeffsackmann
-20141022-M-Toyota_CH-SF-Yuichi_Sugita-Go_Soeda,Yuichi Sugita,Go Soeda,R,R,M,20141022,Toyota CH,SF,,,Carpet,,3,1,jeffsackmann
-20141022-M-Basel-R32-Ernests_Gulbis-Borna_Coric,Ernests Gulbis,Borna Coric,R,R,M,20141022,Basel,R32,,,Hard,Mohamed El Jennati,3,1,jeffsackmann
-20141021-M-Valencia-R32-Norbert_Gombos-Feliciano_Lopez,Norbert Gombos,Feliciano Lopez,R,L,M,20141021,Valencia,R32,,Agora,Hard,Ali Nili,3,1,jeffsackmann
-20141020-M-Valencia-R32-Stefan_Kozlov-Martin_Klizan,Stefan Kozlov,Martin Klizan,R,L,M,20141020,Valencia,R32,,Agora,Hard,Ali Nili,3,1,jeffsackmann
-20141020-M-Basel-R32-Dominic_Thiem-David_Goffin,Dominic Thiem,David Goffin,R,R,M,20141020,Basel,R32,,,Hard,,3,1,jeffsackmann
-20141019-M-Moscow-F-Roberto_Bautista_Agut-Marin_Cilic,Roberto Bautista Agut,Marin Cilic,R,R,M,20141019,Moscow,F,,,Hard,Roland Herfel,3,1,jeffsackmann
-20141018-M-Vienna-SF-Viktor_Troicki-Andy_Murray,Viktor Troicki,Andy Murray,R,R,M,20141018,Vienna,SF,,,Hard,,3,1,jeffsackmann
-20141018-M-Stockholm-SF-Tomas_Berdych-Matthias_Bachinger,Tomas Berdych,Matthias Bachinger,R,R,M,20141018,Stockholm,SF,,,Hard,,3,1,jeffsackmann
-20141016-M-Moscow-R16-Milos_Raonic-Ricardas_Berankis,Milos Raonic,Ricardas Berankis,R,R,M,20141016,Moscow,R16,,,Hard,,3,1,jeffsackmann
-20141014-M-Stockholm-R32-Donald_Young-Leonardo_Mayer,Donald Young,Leonardo Mayer,L,R,M,20141014,Stockholm,R32,,,Hard,,3,1,jeffsackmann
-20141012-M-Guayaquil_CH-R16-Jose_Hernandez-Diego_Sebastian_Schwartzman,Jose Hernandez,Diego Sebastian Schwartzman,R,R,M,20141012,Guayaquil CH,R16,,Center,Clay,,3,1,jeffsackmann
-20141011-M-Shanghai_Masters-F-Roger_Federer-Gilles_Simon,Roger Federer,Gilles Simon,R,R,M,20141011,Shanghai Masters,F,,,Hard,Ali Nili,3,1,jeffsackmann
-20141010-M-Shanghai_Masters-SF-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20141010,Shanghai Masters,SF,,,Hard,,3,1,jeffsackmann
-20141006-M-Ortisei_CH-R16-Austin_Krajicek-Nikoloz_Basilashvili,Austin Krajicek,Nikoloz Basilashvili,L,R,M,20141006,Ortisei CH,R16,,1,Hard,,3,1,jeffsackmann
-20141005-M-Beijing-F-Tomas_Berdych-Novak_Djokovic,Tomas Berdych,Novak Djokovic,R,R,M,20141005,Beijing,F,,,Hard,Carlos Bernardes,3,1,jeffsackmann
-20140930-M-Tokyo-R32-Stanislas_Wawrinka-Tatsuma_Ito,Stanislas Wawrinka,Tatsuma Ito,R,R,M,20140930,Tokyo,R32,,,Hard,Cedric Mourier,3,1,jeffsackmann
-20140929-M-Sacramento_CH-R16-Jared_Donaldson-Luca_Vanni,Jared Donaldson,Luca Vanni,R,R,M,20140929,Sacramento CH,R16,,,Hard,,3,1,Amy
-20140928-M-Shenzhen-F-Andy_Murray-Tommy_Robredo,Andy Murray,Tommy Robredo,R,R,M,20140928,Shenzhen,F,,Centre,Hard,Lahyani Mohamed,3,1,1HandBH
-20140927-M-Shenzhen-SF-Tommy_Robredo-Santiago_Giraldo,Tommy Robredo,Santiago Giraldo,R,R,M,20140927,Shenzhen,SF,,,Hard,Fergus Murphy,3,1,jeffsackmann
-20140926-M-Shenzhen-QF-Viktor_Troicki-Santiago_Giraldo,Viktor Troicki,Santiago Giraldo,R,R,M,20140926,Shenzhen,QF,,,Hard,Eva Asderaki,3,1,jeffsackmann
-20140924-M-Napa_CH-R16-Alex_Bolt-Dennis_Novikov,Alex Bolt,Dennis Novikov,L,R,M,20140924,Napa CH,R16,,,Hard,,3,1,jeffsackmann
-20140922-M-Shenzhen-R16-Somdev_Devvarman-Andy_Murray,Somdev Devvarman,Andy Murray,R,R,M,20140922,Shenzhen,R16,,,Hard,,3,1,Amy
-20140921-M-Campinas_CH-F-Andre_Ghem-Diego_Sebastian_Schwartzman,Andre Ghem,Diego Sebastian Schwartzman,R,R,M,20140921,Campinas CH,F,,,Clay,,3,1,jeffsackmann
-20140920-M-Meknes_CH-SF-Matteo_Viola-Kimmer_Coppejans,Matteo Viola,Kimmer Coppejans,R,R,M,20140920,Meknes CH,SF,,,Clay,,3,1,jeffsackmann
-20140918-M-Metz-R16-Jo_Wilfried_Tsonga-Gilles_Muller,Jo Wilfried Tsonga,Gilles Muller,R,L,M,20140918,Metz,R16,,,Hard,,3,1,jeffsackmann
-20140915-M-USA_F25-SF-Tennys_Sandgren-Jarmere_Jenkins,Tennys Sandgren,Jarmere Jenkins,R,R,M,20140915,USA F25,SF,,,Hard,,3,1,Isaac
-20140914-M-Davis_Cup_World_Group_SF-RR-Roger_Federer-Fabio_Fognini,Roger Federer,Fabio Fognini,R,R,M,20140914,Davis Cup World Group SF,RR,15:00:00,Geneva,Hard,Pascal Maria,5,0,Edo
-20140908-M-US_Open-F-Marin_Cilic-Kei_Nishikori,Marin Cilic,Kei Nishikori,R,R,M,20140908,US Open,F,,Ashe,Hard,,5,1,jeffsackmann
-20140908-M-USA_F24-QF-Jean_Yves_Aubone-Ty_Trombetta,Jean Yves Aubone,Ty Trombetta,R,R,M,20140908,USA F24,QF,,,Hard,,3,1,Isaac
-20140906-M-US_Open-SF-Marin_Cilic-Roger_Federer,Marin Cilic,Roger Federer,R,R,M,20140906,US Open,SF,,Ashe,Hard,,3,1,jeffsackmann
-20140906-M-St_Remy_CH-QF-Vincent_Millot-Denys_Molchanov,Vincent Millot,Denys Molchanov,L,R,M,20140906,St Remy CH,QF,,,Hard,,3,1,jeffsackmann
-20140902-M-Shanghai_CH-R32-John_Millman-Ze_Zhang,John Millman,Ze Zhang,R,R,M,20140902,Shanghai CH,R32,Day,Stadium,Hard,,3,1,d
-20140810-M-Canada_Masters-F-Jo_Wilfried_Tsonga-Roger_Federer,Jo Wilfried Tsonga,Roger Federer,R,R,M,20140810,Canada Masters,F,,,Hard,,3,1,Bobby
-20140807-M-Canada_Masters-R16-Novak_Djokovic-Jo_Wilfried_Tsonga,Novak Djokovic,Jo Wilfried Tsonga,R,R,M,20140807,Canada Masters,R16,,Centre,Hard,,3,1,Amy
-20140805-M-Canada_Masters-R64-Donald_Young-Frank_Dancevic,Donald Young,Frank Dancevic,L,R,M,20140805,Canada Masters,R64,,Grandstand,Hard,Richard Haigh,3,1,jeffsackmann
-20140805-M-Canada_Masters-R32-Peter_Polansky-Roger_Federer,Peter Polansky,Roger Federer,R,R,M,20140805,Canada Masters,R32,,Centre,Hard,,3,1,Amy
-20140804-M-Canada_Masters-R64-Peter_Polansky-Jerzy_Janowicz,Peter Polansky,Jerzy Janowicz,R,R,M,20140804,Canada Masters,R64,,,Hard,Mohamed Lahyani,3,1,jeffsackmann
-20140803-M-Washington-F-Vasek_Pospisil-Milos_Raonic,Vasek Pospisil,Milos Raonic,R,R,M,20140803,Washington,F,,Center,Hard,Fergus Murphy,3,1,jeffsackmann
-20140802-M-Washington-SF-Richard_Gasquet-Vasek_Pospisil,Richard Gasquet,Vasek Pospisil,R,R,M,20140802,Washington,SF,,Center,Hard,,3,1,jeffsackmann
-20140802-M-Segovia_CH-SF-Alexander_Kudryavtsev-Adrian_Menendez_Maceiras,Alexander Kudryavtsev,Adrian Menendez Maceiras,R,R,M,20140802,Segovia CH,SF,,,Hard,,3,1,jeffsackmann
-20140730-M-Kitzbuhel-R16-Dominic_Thiem-Jiri_Vesely,Dominic Thiem,Jiri Vesely,R,L,M,20140730,Kitzbuhel,R16,,Center,Clay,,3,1,jeffsackmann
-20140729-M-Washington-R64-Sam_Querrey-Michael_Russell,Sam Querrey,Michael Russell,R,R,M,20140729,Washington,R64,,Center,Hard,,3,1,jeffsackmann
-20140728-M-Washington-R64-Francis_Tiafoe-Evgeny_Donskoy,Francis Tiafoe,Evgeny Donskoy,R,R,M,20140728,Washington,R64,,Center,Hard,,3,1,jeffsackmann
-20140727-M-Umag-SF-Marin_Cilic-Tommy_Robredo,Marin Cilic,Tommy Robredo,R,R,M,20140727,Umag,SF,,,Clay,,3,1,jeffsackmann
-20140727-M-Atlanta-F-John_Isner-Dudi_Sela,John Isner,Dudi Sela,R,R,M,20140727,Atlanta,F,,,Hard,,3,1,Bobby
-20140725-M-Gstaad-QF-Viktor_Troicki-Fernando_Verdasco,Viktor Troicki,Fernando Verdasco,R,L,M,20140725,Gstaad,QF,,,Clay,Damien Dumusois,3,1,jeffsackmann
-20140725-M-Atlanta-QF-John_Isner-Marinko_Matosevic,John Isner,Marinko Matosevic,R,R,M,20140725,Atlanta,QF,,,Hard,,3,1,Bobby
-20140721-M-Umag-R32-Ante_Pavic-Horacio_Zeballos,Ante Pavic,Horacio Zeballos,R,L,M,20140721,Umag,R32,,,Clay,,3,1,Amy
-20140720-M-Bogota-F-Bernard_Tomic-Ivo_Karlovic,Bernard Tomic,Ivo Karlovic,R,R,M,20140720,Bogota,F,,,Hard,,3,1,Amy
-20140719-M-Poznan_CH-SF-Adam_Pavlasek-David_Goffin,Adam Pavlasek,David Goffin,R,R,M,20140719,Poznan CH,SF,,,Clay,,3,1,jeffsackmann
-20140719-M-Bogota-SF-Bernard_Tomic-Victor_Estrella,Bernard Tomic,Victor Estrella,R,R,M,20140719,Bogota,SF,,,Hard,,3,1,Amy
-20140715-M-Poznan_CH-R32-Andreas_Haider_Maurer-Christian_Garin,Andreas Haider Maurer,Christian Garin,R,R,M,20140715,Poznan CH,R32,,,Clay,,3,1,jeffsackmann
-20140714-M-Hamburg-R64-Jan_Lennard_Struff-Filip_Krajinovic,Jan Lennard Struff,Filip Krajinovic,R,R,M,20140714,Hamburg,R64,,,Clay,Cedric Mourier,3,1,jeffsackmann
-20140714-M-Bogota-QF-Jimmy_Wang-Ivo_Karlovic,Jimmy Wang,Ivo Karlovic,R,R,M,20140714,Bogota,QF,,,Hard,,3,1,Amy
-20140713-M-Scheveningen_CH-F-David_Goffin-Andreas_Beck,David Goffin,Andreas Beck,R,L,M,20140713,Scheveningen CH,F,,,Clay,,3,1,jeffsackmann
-20140713-M-Portoroz_CH-F-Gilles_Muller-Blaz_Kavcic,Gilles Muller,Blaz Kavcic,L,R,M,20140713,Portoroz CH,F,,,Hard,,3,1,jeffsackmann
-20140711-M-Bastad-QF-Renzo_Olivo-Pablo_Cuevas,Renzo Olivo,Pablo Cuevas,R,R,M,20140711,Bastad,QF,11:00 AM,,Clay,Felix Torralba,3,1,jeffsackmann
-20140711-M-Bastad-QF-Fernando_Verdasco-Pablo_Carreno_Busta,Fernando Verdasco,Pablo Carreno Busta,L,R,M,20140711,Bastad,QF,,,Clay,Carlos Bernardes,3,1,jeffsackmann
-20140710-M-Stuttgart-R32-Jan_Lennard_Struff-Philipp_Kohlschreiber,Jan Lennard Struff,Philipp Kohlschreiber,R,R,M,20140710,Stuttgart,R32,5:10 PM,,Clay,Damian Steiner,3,1,ChapelHeel66
-20140710-M-Newport-QF-Samuel_Groth-Nicolas_Mahut,Samuel Groth,Nicolas Mahut,R,R,M,20140710,Newport,QF,,,Grass,Fergus Murphy,3,1,jeffsackmann
-20140710-M-Bastad-R16-Victor_Hanescu-David_Ferrer,Victor Hanescu,David Ferrer,R,R,M,20140710,Bastad,R16,,,Clay,Carlos Bernardes,3,1,jeffsackmann
-20140709-M-Stuttgart-R32-Alexander_Zverev-Lukas_Rosol,Alexander Zverev,Lukas Rosol,R,R,M,20140709,Stuttgart,R32,6:30 PM,,Clay,Damian Steiner,3,1,jeffsackmann
-20140709-M-Bastad-R16-Joao_Sousa-Elias_Ymer,Joao Sousa,Elias Ymer,R,R,M,20140709,Bastad,R16,,,Clay,Felix Torralba,3,1,jeffsackmann
-20140706-M-Wimbledon-F-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20140706,Wimbledon,F,14:09,Centre Court,Grass,James Keothavong,5,0,1HandBH
-20140704-M-Winnetka_CH-QF-John_Patrick_Smith-Illya_Marchenko,John Patrick Smith,Illya Marchenko,L,R,M,20140704,Winnetka CH,QF,,,Hard,,3,1,jeffsackmann
-20140704-M-Wimbledon-SF-Milos_Raonic-Roger_Federer,Milos Raonic,Roger Federer,R,R,M,20140704,Wimbledon,SF,,Centre,Grass,,5,0,Isaac
-20140701-M-Wimbledon-R16-Nick_Kyrgios-Rafael_Nadal,Nick Kyrgios,Rafael Nadal,R ,L,M,20140701,Wimbledon,R16,4:00 PM,Centre,Grass,Carlos Bernardes,5,0,DebLDecker
-20140630-M-Winnetka_CH-F-Farrukh_Dustov-Denis_Kudla,Farrukh Dustov,Denis Kudla,R,R,M,20140630,Winnetka CH,F,,,Hard,,3,1,Amy
-20140628-M-Wimbledon-R32-Mikhail_Kukushkin-Rafael_Nadal,Mikhail Kukushkin,Rafael Nadal,R ,L,M,20140628,Wimbledon,R32,1:00 PM,Centre,Grass,Pascal Maria,5,0,DebLDecker
-20140628-M-Padova_CH-SF-Nikola_Cacic-Maximo_Gonzalez,Nikola Cacic,Maximo Gonzalez,R,R,M,20140628,Padova CH,SF,Day,Central,Clay,,3,1,d
-20140627-M-Wimbledon-R32-Grigor_Dimitrov-Alexandr_Dolgopolov,Grigor Dimitrov,Alexandr Dolgopolov,R,R,M,20140627,Wimbledon,R32,,No. 1 Court,Grass,,5,0,1HandBH
-20140626-M-Wimbledon-R64-Rafael_Nadal-Lukas_Rosol,Rafael Nadal,Lukas Rosol,L,R ,M,20140626,Wimbledon,R64,1:00 PM,Centre,Grass,James Keothavong,5,0,DebLDecker
-20140625-M-Wimbledon-R64-Tomas_Berdych-Bernard_Tomic,Tomas Berdych,Bernard Tomic,R,R,M,20140625,Wimbledon,R64,,Court 1,Grass,,5,0,Bobby
-20140624-M-Wimbledon-R128-Kenny_De_Schepper-Kei_Nishikori,Kenny De Schepper,Kei Nishikori,L,R,M,20140624,Wimbledon,R128,,,Grass,Ali Nili,5,0,jeffsackmann
-20140616-M-Eastbourne-R32-Ivo_Karlovic-Jeremy_Chardy,Ivo Karlovic,Jeremy Chardy,R,R,M,20140616,Eastbourne,R32,,,Grass,,3,1,qthetennisfan
-20140614-M-Queens_Club-SF-Stanislas_Wawrinka-Grigor_Dimitrov,Stanislas Wawrinka,Grigor Dimitrov,R,R,M,20140614,Queens Club,SF,,,Grass,,3,1,Eric J
-20140613-M-Halle-QF-Kei_Nishikori-Steve_Johnson,Kei Nishikori,Steve Johnson,R,R,M,20140613,Halle,QF,,Stadium,Grass,Roland Herfel,3,1,jeffsackmann
-20140612-M-Halle-R16-Dustin_Brown-Rafael_Nadal,Dustin Brown,Rafael Nadal,R ,L,M,20140612,Halle,R16,5:30 PM,Stadium,Grass,Carlos Bernardes,3,1,DebLDecker
-20140611-M-Halle-R16-Robin_Haase-Alejandro_Falla,Robin Haase,Alejandro Falla,R,L,M,20140611,Halle,R16,,Stadium,Grass,Carlos Bernardes,3,1,jeffsackmann
-20140611-M-Caltanissetta_CH-R16-Marco_Cecchinato-Facundo_Bagnis,Marco Cecchinato,Facundo Bagnis,R,L,M,20140611,Caltanissetta CH,R16,,,Clay,,3,1,jeffsackmann
-20140610-M-Halle-R32-Dustin_Brown-Andrey_Kuznetsov,Dustin Brown,Andrey Kuznetsov,R,R,M,20140610,Halle,R32,,,Grass,Carlos Bernardes,3,1,jeffsackmann
-20140609-M-Queens_Club-R32-Grigor_Dimitrov-James_Ward,Grigor Dimitrov,James Ward,R,R,M,20140609,Queen's Club,R32,,,Grass,,3,1,Isaac
-20140609-M-Queens_Club-R32-Blaz_Rola-James_Ward,Blaz Rola,James Ward,L,R,M,20140609,Queen's Club,R32,,Centre,Grass,,3,1,jeffsackmann
-20140609-M-Prague_CH-R32-Steven_Diez-Renzo_Olivo,Steven Diez,Renzo Olivo,R,R,M,20140609,Prague CH,R32,Day,Court 1,Clay,,3,1,d
-20140608-M-Roland_Garros-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R ,L,M,20140608,Roland Garros,F,3:00 PM,Philippe Chatrier,Clay,Pascal Maria,5,0,DebLDecker
-20140606-M-Roland_Garros-SF-Rafael_Nadal-Andy_Murray,Rafael Nadal,Andy Murray,L,R ,M,20140606,Roland Garros,SF,4:00 PM,Philippe Chatrier,Clay,Damien Dumusois,5,0,DebLDecker
-20140604-M-Roland_Garros-QF-David_Ferrer-Rafael_Nadal,David Ferrer,Rafael Nadal,R ,L,M,20140604,Roland Garros,QF,6:45 PM,Suzanne Lenglen,Clay,James Keothavong,5,0,DebLDecker
-20140601-M-Roland_Garros-R16-Rafael_Nadal-Dusan_Lajovic,Rafael Nadal,Dusan Lajovic,L,R,M,20140601,Roland Garros,R16,13:30 PM,Philippe Chatrier,Clay,Pierre Bacchi,5,0,DebLDecker
-20140531-M-Roland_Garros-R32-Leonardo_Mayer-Rafael_Nadal,Leonardo Mayer,Rafael Nadal,R ,L,M,20140531,Roland Garros,R32,3:45 PM,Philippe Chartrier,Clay,Pascal Maria,5,0,DebLDecker
-20140530-M-Vicenza_CH-QF-Yoshihito_Nishioka-Andrej_Martin,Yoshihito Nishioka,Andrej Martin,L,R,M,20140530,Vicenza CH,QF,,,Clay,,3,1,jeffsackmann
-20140529-M-Roland_Garros-R64-Rafael_Nadal-Dominic_Thiem,Rafael Nadal,Dominic Thiem,L,R ,M,20140529,Roland Garros,R64,1:00 PM,Philippe Chatrier,Clay,Carlos Bernardes,5,0,DebLDecker
-20140528-M-Roland_Garros-R64-Roger_Federer-Diego_Sebastian_Schwartzman,Roger Federer,Diego Sebastian Schwartzman,R,R,M,20140528,Roland Garros,R64,,Lenglen,Clay,,5,0,jeffsackmann
-20140528-M-Roland_Garros-R64-Guillermo_Garcia_Lopez-Adrian_Mannarino,Guillermo Garcia Lopez,Adrian Mannarino,R,L,M,20140528,Roland Garros,R64,,,Clay,Alison Hughes,3,1,jeffsackmann
-20140526-M-Roland_Garros-R128-Robby_Ginepri-Rafael_Nadal,Robby Ginepri,Rafael Nadal,R ,L,M,20140526,Roland Garros,R128,5:30 PM,Suzanne Lenglen,Clay,Pierre Bacchi,5,0,DebLDecker
-20140524-M-Nice-F-Ernests_Gulbis-Federico_Delbonis,Ernests Gulbis,Federico Delbonis,R,L,M,20140524,Nice,F,,Centre,Clay,,3,1,James
-20140520-M-Dusseldorf-R32-Nikolay_Davydenko-Dudi_Sela,Nikolay Davydenko,Dudi Sela,R,R,M,20140520,Dusseldorf,R32,,,Clay,Damian Steiner,3,1,jeffsackmann
-20140519-M-Dusseldorf-R32-Dustin_Brown-Yen_Hsun_Lu,Dustin Brown,Yen Hsun Lu,R,R,M,20140519,Dusseldorf,R32,,,Clay,Fergus Murphy,3,1,jeffsackmann
-20140518-M-Rome_Masters-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R ,L,M,20140518,Rome Masters,F,4:00 PM,Centrale,Clay,Carlos Bernardes,3,1,DebLDecker
-20140517-M-Rome_Masters-SF-Grigor_Dimitrov-Rafael_Nadal,Grigor Dimitrov,Rafael Nadal,R ,L,M,20140517,Rome Masters,SF,8:00 PM,Centrale,Clay,Mohamed El Jennati,3,1,DebLDecker
-20140516-M-Rome_Masters-QF-Andy_Murray-Rafael_Nadal,Andy Murray,Rafael Nadal,R ,L,M,20140516,Rome Masters,QF,9:00 PM,Centrale,Clay,Mohamed Lahyani,3,1,DebLDecker
-20140515-M-Rome_Masters-R16-Mikhail_Youzhny-Rafael_Nadal,Mikhail Youzhny,Rafael Nadal,R ,L,M,20140515,Rome Masters,R16,4:30 PM,Centrale,Clay,Mohamed Al Jennati,3,1,DebLDecker
-20140515-M-Busan_CH-R16-Amir_Weintraub-Daniel_Smethurst,Amir Weintraub,Daniel Smethurst,R,R,M,20140515,Busan CH,R16,Day,Court 1,Hard,,3,1,d
-20140514-M-Rome_Masters-R32-Roger_Federer-Jeremy_Chardy,Roger Federer,Jeremy Chardy,R,R,M,20140514,Rome Masters,R32,,Centre,Clay,,3,1,qthetennisfan
-20140514-M-Rome_Masters-R32-Gilles_Simon-Rafael_Nadal,Gilles Simon,Rafael Nadal,R ,L,M,20140514,Rome Masters,R32,7:15 PM,Centrale,Clay,Damian Steiner,3,1,DebLDecker
-20140514-M-Rome_Masters-R32-Ernests_Gulbis-Stephane_Robert,Ernests Gulbis,Stephane Robert,R,R,M,20140514,Rome Masters,R32,,,Clay,Mohamed El Jennati,3,1,jeffsackmann
-20140512-M-Rome_Masters-R64-Pere_Riba-Paolo_Lorenzi,Pere Riba,Paolo Lorenzi,R,R,M,20140512,Rome Masters,R64,,Pietrangeli,Clay,,3,1,jeffsackmann
-20140511-M-Madrid_Masters-F-Rafael_Nadal-Kei_Nishikori,Rafael Nadal,Kei Nishikori,L,R ,M,20140511,Madrid Masters,F,7:15 PM,Manolo Santana,Clay,Damien Dumusois,3,1,DebLDecker
-20140510-M-Madrid_Masters-SF-Roberto_Bautista_Agut-Rafael_Nadal,Roberto Bautista Agut,Rafael Nadal,R ,L,M,20140510,Madrid Masters,SF,4:00 PM,Manolo Santana,Clay,Carlos Bernardes,3,1,DebLDecker
-20140509-M-Rome_CH-QF-Mate_Delic-Julian_Reister,Mate Delic,Julian Reister,R,R,M,20140509,Rome CH,QF,Day,Court 1,Clay,,3,1,d
-20140509-M-Madrid_Masters-QF-Tomas_Berdych-Rafael_Nadal,Tomas Berdych,Rafael Nadal,R ,L,M,20140509,Madrid Masters,QF,3:30 PM,Manolo Santana,Clay,Mohamed Lahyani,3,1,DebLDecker
-20140508-M-Madrid_Masters-R16-Jarkko_Nieminen-Rafael_Nadal,Jarkko Nieminen,Rafael Nadal,L,L,M,20140508,Madrid Masters,R16,3:30 PM,Manolo Santana,Clay,Damien Dumusois,3,1,DebLDecker
-20140507-M-Madrid_Masters-R32-Rafael_Nadal-Juan_Monaco,Rafael Nadal,Juan Monaco,L,R ,M,20140507,Madrid Masters,R32,3:15 PM,Manolo Santana,Clay,Carlos Bernardes,3,1,DebLDecker
-20140507-M-Madrid_Masters-R32-Paul_Henri_Mathieu-Marin_Cilic,Paul Henri Mathieu,Marin Cilic,R,R,M,20140507,Madrid Masters,R32,,Stadium 3,Clay,James Keothavong,3,1,jeffsackmann
-20140506-M-Madrid_Masters-R64-Nicolas_Almagro-Andrey_Golubev,Nicolas Almagro,Andrey Golubev,R,R,M,20140506,Madrid Masters,R64,,,Clay,Fergus Murphy,3,1,jeffsackmann
-20140503-M-Munich-SF-Tommy_Haas-Martin_Klizan,Tommy Haas,Martin Klizan,R,L,M,20140503,Munich,SF,,,Clay,Felix Torralba,3,1,jeffsackmann
-20140503-M-Munich-SF-Jan_Lennard_Struff-Fabio_Fognini,Jan Lennard Struff,Fabio Fognini,R,R,M,20140503,Munich,SF,,,Clay,,3,1,jeffsackmann
-20140502-M-Tunis_CH-SF-Mate_Delic-Simone_Bolelli,Mate Delic,Simone Bolelli,R,R,M,20140502,Tunis CH,SF,,,Clay,,3,1,jeffsackmann
-20140429-M-Cali_CH-R32-Mathias_Bourgue-Gonzalo_Lama,Mathias Bourgue,Gonzalo Lama,R,R,M,20140429,Cali CH,R32,Day,Court 1,Clay,,3,1,d
-20140427-M-Barcelona-F-Santiago_Giraldo-Kei_Nishikori,Santiago Giraldo,Kei Nishikori,R,R,M,20140427,Barcelona,F,16:00,,Clay,Mohamed Lahyani,3,1,jeffsackmann
-20140425-M-Barcelona-QF-Nicolas_Almagro-Rafael_Nadal,Nicolas Almagro,Rafael Nadal,R ,L,M,20140425,Barcelona,QF,3:30 PM,Pista Central,Clay,Mohamed Lahyani,3,1,DebLDecker
-20140424-M-Barcelona-R16-Ivan_Dodig-Rafael_Nadal,Ivan Dodig,Rafael Nadal,R ,L,M,20140424,Barcelona,R16,7:30 PM,Pista Central,Clay,Mohamed El Jennati,3,1,DebLDecker
-20140423-M-Barcelona-R32-Albert_Ramos-Rafael_Nadal,Albert Ramos,Rafael Nadal,L,L,M,20140423,Barcelona,R32,3:30 PM,Pista Central,Clay,Magdi Somat,3,1,DebLDecker
-20140418-M-Monte_Carlo_Masters-QF-David_Ferrer-Rafael_Nadal,David Ferrer,Rafael Nadal,R ,L,M,20140418,Monte Carlo Masters,QF,12:30 PM,Central,Clay,Carlos Bernardes,3,1,DebLDecker
-20140417-M-Monte_Carlo_Masters-R16-Andreas_Seppi-Rafael_Nadal,Andreas Seppi,Rafael Nadal,R ,L,M,20140417,Monte Carlo Masters,R16,2:00 PM,Central,Clay,Cedric Mourier,3,1,DebLDecker
-20140416-M-Monte_Carlo_Masters-R32-Rafael_Nadal-Teymuraz_Gabashvili,Rafael Nadal,Teymuraz Gabashvili,L,R ,M,20140416,Monte Carlo Masters,R32,2:00 PM,Central,Clay,Pascal Maria,3,1,DebLDecker
-20140415-M-San_Luis_Potosi_CH-R32-Paolo_Lorenzi-Mauricio_Echazu,Paolo Lorenzi,Mauricio Echazu,R,R,M,20140415,San Luis Potosi CH,R32,Afternoon,Central,Clay,,3,1,d
-20140414-M-Sao_Paulo_CH-R32-Horacio_Zeballos-Ricardo_Hocevar,Horacio Zeballos,Ricardo Hocevar,L,R,M,20140414,Sao Paulo CH,R32,Night,Quadra Central,Clay,,3,1,d
-20140409-M-Itajai-R32-Mohamed_Safwat-Eduardo_Russi,Mohamed Safwat,Eduardo Russi,R,R,M,20140409,Itajai,R32,Morning,Centre,Clay,,3,1,d
-20140330-M-Miami_Masters-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R ,L,M,20140330,Miami Masters,F,2:30 PM,Stadium,Hard,Mohamed Lahyani,3,1,DebLDecker
-20140327-M-Miami_Masters-QF-Milos_Raonic-Rafael_Nadal,Milos Raonic,Rafael Nadal,R ,L,M,20140327,Miami Masters,QF,7:00 PM,Stadium,Hard,Cedric Mourier,3,1,DebLDecker
-20140326-M-Miami_Masters-QF-Roger_Federer-Kei_Nishikori,Roger Federer,Kei Nishikori,R,R,M,20140326,Miami Masters,QF,21:30,Stadium,Hard,Mohamed Lahyani,3,1,jeffsackmann
-20140325-M-Miami_Masters-R16-Jo_Wilfried_Tsonga-Andy_Murray,Jo Wilfried Tsonga,Andy Murray,R,R,M,20140325,Miami Masters,R16,15:30,Stadium,Hard,Mohamed Lahyani,3,1,jeffsackmann
-20140325-M-Miami_Masters-R16-Fabio_Fognini-Rafael_Nadal,Fabio Fognini,Rafael Nadal,R ,L,M,20140325,Miami Masters,R16,9:30 PM,Stadium,Hard,Damian Steiner,3,1,DebLDecker
-20140324-M-Miami_Masters-R32-Dusan_Lajovic-Alexandr_Dolgopolov,Dusan Lajovic,Alexandr Dolgopolov,R,R,M,20140324,Miami Masters,R32,12:30,Grandstand,Hard,Fergus Murphy,3,1,jeffsackmann
-20140324-M-Miami_Masters-R32-Denis_Istomin-Rafael_Nadal,Denis Istomin,Rafael Nadal,R ,L,M,20140324,Miami Masters,R32,6:15 PM,Stadium,Hard,Carlos Bernardes,3,1,DebLDecker
-20140323-M-Miami_Masters-R32-Roger_Federer-Thiemo_De_Bakker,Roger Federer,Thiemo De Bakker,R,R,M,20140323,Miami Masters,R32,14:45,Center,Hard,Mohamed Lahyani,3,1,jeffsackmann
-20140322-M-Miami_Masters-R64-Lleyton_Hewitt-Rafael_Nadal,Lleyton Hewitt,Rafael Nadal,R,L ,M,20140322,Miami Masters,R64,10:30 PM,Stadium,Hard,Gerry Armstrong,3,1,DebLDecker
-20140322-M-Miami_Masters-R64-Donald_Young-John_Isner,Donald Young,John Isner,L,R,M,20140322,Miami Masters,R64,16:45,Center,Hard,Mohamed Lahyani,3,1,jeffsackmann
-20140321-M-Miami_Masters-R64-Adrian_Mannarino-Jo_Wilfried_Tsonga,Adrian Mannarino,Jo Wilfried Tsonga,L,R,M,20140321,Miami Masters,R64,20:30,Grandstand,Hard,Gerry Armstrong,3,1,jeffsackmann
-20140320-M-Miami_Masters-R128-Pablo_Carreno_Busta-Joao_Sousa,Pablo Carreno Busta,Joao Sousa,R,R,M,20140320,Miami Masters,R128,18:00,Court 1,Hard,Fergus Murphy,3,1,jeffsackmann
-20140319-M-Miami_Masters-R128-Lukasz_Kubot-Matthew_Ebden,Lukasz Kubot,Matthew Ebden,R,R,M,20140319,Miami Masters,R128,11:00,Grandstand,Hard,Cedric Mourier,3,1,jeffsackmann
-20140317-M-Rimouski_CH-R32-Izak_Van_Der_Merwe-Daniel_Cox,Izak Van Der Merwe,Daniel Cox,R,R,M,20140317,Rimouski CH,R32,,Centre,Indoor Hard,,3,1,d
-20140316-M-Indian_Wells_Masters-F-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20140316,Indian Wells Masters,F,14:00,Stadium 1,Hard,Ali Nili,3,1,jeffsackmann
-20140315-M-Indian_Wells_Masters-SF-John_Isner-Novak_Djokovic,John Isner,Novak Djokovic,R,R,M,20140315,Indian Wells Masters,SF,13:45,Stadium 1,Hard,Carlos Bernardes,3,1,jeffsackmann
-20140312-M-Indian_Wells_Masters-R16-Tommy_Haas-Roger_Federer,Tommy Haas,Roger Federer,R,R,M,20140312,Indian Wells Masters,R16,,Stadium 1,Hard,Felix Torralba,3,1,jeffsackmann
-20140311-M-Indian_Wells_Masters-R32-Mikhail_Kukushkin-Feliciano_Lopez,Mikhail Kukushkin,Feliciano Lopez,R,L,M,20140311,Indian Wells Masters,R32,,Stadium 2,Hard,Ali Nili,3,1,jeffsackmann
-20140311-M-Indian_Wells_Masters-R32-Julien_Benneteau-Dominic_Thiem,Julien Benneteau,Dominic Thiem,R,R,M,20140311,Indian Wells Masters,R32,,,Hard,Fergus Murphy,3,1,jeffsackmann
-20140310-M-Indian_Wells_Masters-R32-Jiri_Vesely-Andy_Murray,Jiri Vesely,Andy Murray,L,R,M,20140310,Indian Wells Masters,R32,,,Hard,Mohamed Lahyani,3,1,jeffsackmann
-20140310-M-Indian_Wells_Masters-R32-Alexandr_Dolgopolov-Rafael_Nadal,Alexandr Dolgopolov,Rafael Nadal,R ,L,M,20140310,Indian Wells Masters,R32,5:55 PM,Center,Hard,Mohamed Lahyani,3,1,DebLDecker
-20140308-M-Indian_Wells_Masters-R64-Stanislas_Wawrinka-Ivo_Karlovic,Stanislas Wawrinka,Ivo Karlovic,R,R,M,20140308,Indian Wells Masters,R64,,,Hard,Felix Torralba,3,1,jeffsackmann
-20140308-M-Indian_Wells_Masters-R64-Radek_Stepanek-Rafael_Nadal,Radek Stepanek,Rafael Nadal,R ,L,M,20140308,Indian Wells Masters,R64,7:15 PM,Center,Hard,Magdi Somat,3,1,DebLDecker
-20140301-M-Dubai-F-Tomas_Berdych-Roger_Federer,Tomas Berdych,Roger Federer,R,R,M,20140301,Dubai,F,,,Hard,Mohamed Lahyani,3,1,jeffsackmann
-20140228-M-Dubai-SF-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20140228,Dubai,SF,,Centre,Hard,Mohamed el Jennati,3,1,Sagar Manohar
-20140224-M-Cherbourg_CH-Q3-Rudy_Coco-Taro_Daniel,Rudy Coco,Taro Daniel,L,R,M,20140224,Cherbourg CH,Q3,Morning,Central,Indoor Hard,,3,1,d
-20140223-M-Rio_de_Janeiro-F-Rafael_Nadal-Alexandr_Dolgopolov,Rafael Nadal,Alexandr Dolgopolov,L,R ,M,20140223,Rio de Janeiro,F,5:00 PM,Center,Clay,Damien Dumusois,3,1,DebLDecker
-20140222-M-Rio_de_Janeiro-SF-Rafael_Nadal-Pablo_Andujar,Rafael Nadal,Pablo Andujar,L,R ,M,20140222,Rio de Janeiro,SF,7:00 PM,Center,Clay ,Mohamed Fitouhi,3,1,DebLDecker
-20140221-M-Rio_de_Janeiro-QF-Rafael_Nadal-Joao_Sousa,Rafael Nadal,Joao Sousa,L,R ,M,20140221,Rio de Janeiro,QF,21:30,Center,Clay,Damien Dumusois,3,1,DebLDecker
-20140220-M-Rio_de_Janeiro-R16-Albert_Montanes-Rafael_Nadal,Albert Montanes,Rafael Nadal,R,L,M,20140220,Rio de Janeiro,R16,08: PM,Center,Clay,Magdi Somat,3,1,DebLDecker
-20140218-M-Rio_de_Janeiro-R32-Rafael_Nadal-Daniel_Gimeno_Traver,Rafael Nadal,Daniel Gimeno Traver,L,R ,M,20140218,Rio de Janeiro,R32,20:20,Center,Clay,Adel Nour,3,1,DebLDecker
-20140210-M-Rotterdam-R32-Tomas_Berdych-Andreas_Seppi,Tomas Berdych,Andreas Seppi,R,R,M,20140210,Rotterdam,R32,,,Hard,,3,1,Isaac
-20140210-M-Memphis-R32-Nick_Kyrgios-Tim_Smyczek,Nick Kyrgios,Tim Smyczek,R,R,M,20140210,Memphis,R32,8:00PM,Centre,Indoor Hard,,3,1,FSOT
-20140201-M-Burnie_CH-F-Hiroki_Moriya-Matt_Reid,Hiroki Moriya,Matt Reid,R,R,M,20140201,Burnie CH,F,,Centre,Hard,,3,1,FSOT
-20140126-M-Australian_Open-F-Stanislas_Wawrinka-Rafael_Nadal,Stanislas Wawrinka,Rafael Nadal,R ,L,M,20140126,Australian Open,F,7:30,Rod Laver,Hard,Carlos Ramos,5,0,DebLDecker
-20140124-M-Maui_CH-QF-Takanyi_Garanganga-Tsung_Hua_Yang,Takanyi Garanganga,Tsung Hua Yang,R,R,M,20140124,Maui CH,QF,,Stadium,Hard,Keith Crossland,3,1,jeffsackmann
-20140124-M-Australian_Open-SF-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20140124,Australian Open,SF,8:00 PM,RLA,Hard,Jake Garner,5,0,jeffsackmann
-20140122-M-Australian_Open-QF-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20140122,Australian Open,QF,,Rod Laver Arena,Hard,,5,1,Isaac
-20140122-M-Australian_Open-QF-Novak_Djokovic-Stanislas_Wawrinka_,Novak Djokovic,Stanislas Wawrinka ,R,R,M,20140122,Australian Open,QF,,,Hard,,5,0,Isaac
-20140122-M-Australian_Open-QF-Grigor_Dimitrov-Rafael_Nadal,Grigor Dimitrov,Rafael Nadal,R ,L,M,20140122,Australian Open,QF,3:00 PM,Rod Laver,Hard,Carlos Bernardes,5,0,DebLDecker
-20140120-M-Australian_Open-R16-Roger_Federer-Jo_Wilfried_Tsonga,Roger Federer,Jo Wilfried Tsonga,R,R,M,20140120,Australian Open,R16,,,Hard,,3,1,jeffsackmann
-20140120-M-Australian_Open-R16-Kei_Nishikori-Rafael_Nadal,Kei Nishikori,Rafael Nadal,R ,L,M,20140120,Australian Open,R16,3:45,Rod Laver,Hard,Eva Asderaki,5,0,DebLDecker
-20140118-M-Australian_Open-R32-Gael_Monfils-Rafael_Nadal,Gael Monfils,Rafael Nadal,R,L,M,20140118,Australian Open,R32,9:30 PM,Rod Laver,Hard,Jake Garner,5,0,DebLDecker
-20140117-M-Australian_Open-R32-Tomas_Berdych-Damir_Dzumhur,Tomas Berdych,Damir Dzumhur,R,R,M,20140117,Australian Open,R32,,,Hard,Eva Asderaki,5,0,jeffsackmann
-20140116-M-Australian_Open-R64-Thanasi_Kokkinakis-Rafael_Nadal,Thanasi Kokkinakis,Rafael Nadal,R,L,M,20140116,Australian Open,R64,5:15 PM,Rod Laver,Hard,Gerry Armstrong,5,0,DebLDecker
-20140114-M-Australian_Open-R128-Nick_Kyrgios-Benjamin_Becker,Nick Kyrgios,Benjamin Becker,R,R,M,20140114,Australian Open,R128,,Show Court 3,Hard,,5,0,jeffsackmann
-20140113-M-Australian_Open-R128-Bernard_Tomic-Rafael_Nadal,Bernard Tomic,Rafael Nadal,R ,L,M,20140113,Australian Open,R128,8:40 PM,Rod Laver Arena,Hard,James Keothavong,5,0,DebLDecker
-20140111-M-Sydney-F-Bernard_Tomic-Juan_Martin_Del_Potro,Bernard Tomic,Juan Martin Del Potro,R,R,M,20140111,Sydney,F,,,Hard,,3,1,Backstop5
-20140110-M-Auckland-SF-David_Ferrer-Yen_Hsun_Lu,David Ferrer,Yen Hsun Lu,R,R,M,20140110,Auckland,SF,,,Hard,Dimitar Trifunovski,3,1,jeffsackmann
-20140109-M-Sydney-QF-Marinko_Matosevic-Sergiy_Stakhovsky,Marinko Matosevic,Sergiy Stakhovsky,R,R,M,20140109,Sydney,QF,,,Hard,,3,1,FSOT
-20140109-M-Sydney-QF-Juan_Martin_Del_Potro-Radek_Stepanek,Juan Martin Del Potro,Radek Stepanek,R,R,M,20140109,Sydney,QF,11:40,Centre,Hard,Tony Nimmons,3,1,1HandBH
-20140109-M-Auckland-QF-Roberto_Bautista_Agut-Jack_Sock,Roberto Bautista Agut,Jack Sock,R,R,M,20140109,Auckland,QF,,Centre,Hard,Paula Vieira,3,1,FSOT
-20140108-M-Auckland-R16-Tommy_Haas-Jack_Sock,Tommy Haas,Jack Sock,R,R,M,20140108,Auckland,R16,,,Hard,Damien Dumusois,3,1,jeffsackmann
-20140107-M-Auckland-R32-Michal_Przysiezny-Benoit_Paire,Michal Przysiezny,Benoit Paire,R,R,M,20140107,Auckland,R32,3:00PM,Centre,Hard,,3,1,FSOT
-20140107-M-Auckland-R32-Jose_Rubin_Statham-Lukas_Lacko,Jose Rubin Statham,Lukas Lacko,R,R,M,20140107,Auckland,R32,12:00PM,Centre,Hard,Paula Vieira,3,1,FSOT
-20140106-M-Sydney-R32-Matthew_Ebden-Julien_Benneteau,Matthew Ebden,Julien Benneteau,R,R,M,20140106,Sydney,R32,,,Hard,,3,1,Isaac
-20140106-M-Sydney-R32-Bernard_Tomic-Marcel_Granollers,Bernard Tomic,Marcel Granollers,R,R,M,20140106,Sydney,R32,,,Hard,,3,1,Isaac
-20140105-M-Sao_Paulo_CH-F-Alejandro_Gonzalez-Joao_Souza,Alejandro Gonzalez,Joao Souza,R,R,M,20140105,Sao Paulo CH,F,11:00AM,C,Hard,,3,1,FSOT
-20140105-M-Brisbane-F-Roger_Federer-Lleyton_Hewitt,Roger Federer,Lleyton Hewitt,R,R,M,20140105,Brisbane,F,,,Hard,Mohamed Lahyani,3,1,jeffsackmann
-20140104-M-Doha-F-Rafael_Nadal-Gael_Monfils,Rafael Nadal,Gael Monfils,L,R,M,20140104,Doha,F,6:00 PM,,Hard,Manuel Messina,3,1,DebLDecker
-20140104-M-Chennai-SF-Edouard_Roger_Vasselin-Marcel_Granollers,Edouard Roger Vasselin,Marcel Granollers,R,R,M,20140104,Chennai,SF,5:00PM,Centre,Hard,Christophe Damaske,3,1,FSOT
-20140104-M-Brisbane-SF-Lleyton_Hewitt-Kei_Nishikori,Lleyton Hewitt,Kei Nishikori,R,R,M,20140104,Brisbane,SF,,,Hard,,3,1,jeffsackmann
-20140103-M-Sao_Paulo_CH-QF-Gastao_Elias-Facundo_Arguello,Gastao Elias,Facundo Arguello,R,R,M,20140103,Sao Paulo CH,QF,,Centre,Hard,,3,1,JJ
-20140103-M-Doha-SF-Peter_Gojowczyk-Rafael_Nadal,Peter Gojowczyk,Rafael Nadal,R ,L,M,20140103,Doha,SF,6:25,Centre,Hard,Cedric Mourier,3,1,DebLDecker
-20140103-M-Chennai-QF-Aljaz_Bedene-Stanislas_Wawrinka,Aljaz Bedene,Stanislas Wawrinka,R,R,M,20140103,Chennai,QF,5:00pm,One,Hard,Christophe Damaske,3,1,FSOT
-20140102-M-Doha-QF-Ernests_Gulbis-Rafael_Nadal,Ernests Gulbis,Rafael Nadal,R ,L,M,20140102,Doha,QF,8:10 PM,Centre,Hard,Cedric Mourier,3,1,DebLDecker
-20140102-M-Brisbane-R16-Lleyton_Hewitt-Feliciano_Lopez,Lleyton Hewitt,Feliciano Lopez,R,L,M,20140102,Brisbane,R16,,Centre,Hard,Lahyani Mohamed,3,1,1HandBH
-20140102-M-Brisbane-QF-Roger_Federer-Marinko_Matosevic,Roger Federer,Marinko Matosevic,R,R,M,20140102,Brisbane,QF,,,Hard,,3,1,Isaac
-20140101-M-Doha-R16-Rafael_Nadal-Tobias_Kamke,Rafael Nadal,Tobias Kamke,L,R ,M,20140101,Doha,R16,5:50 PM,Centre,Hard,Manuel Messina,3,1,DebLDecker
-20140101-M-Brisbane-R16-Matthew_Ebden-Kei_Nishikori,Matthew Ebden,Kei Nishikori,R,R,M,20140101,Brisbane,R16,,,Hard,,3,1,Briton Park
-20140101-M-Brisbane-R16-Marin_Cilic-Grigor_Dimitrov,Marin Cilic,Grigor Dimitrov,R,R,M,20140101,Brisbane,R16,,,Hard,Mohamed Lahyani,3,1,dropshot
-20140101-M-Brisbane-R16-Jarkko_Nieminen-Roger_Federer,Jarkko Nieminen,Roger Federer,L,R,M,20140101,Brisbane,R16,,,Hard,,3,1,Briton
-20131231-M-Doha-R32-Rafael_Nadal-Lukas_Rosol,Rafael Nadal,Lukas Rosol,L ,R,M,20131231,Doha,R32,6:00 PM,Centre,Hard,Cedric Mourier,3,1,DebLDecker
-20131230-M-Brisbane-R32-Grigor_Dimitrov-Robin_Haase,Grigor Dimitrov,Robin Haase,R,R,M,20131230,Brisbane,R32,,,Hard,,3,1,EricJ
-20131117-M-CH_Tour_Finals-F-Alejandro_Gonzalez-Filippo_Volandri,Alejandro Gonzalez,Filippo Volandri,R,R,M,20131117,CH Tour Finals,F,,,Clay,,3,1,jeffsackmann
-20131116-M-CH_Tour_Finals-SF-Teymuraz_Gabashvili-Filippo_Volandri,Teymuraz Gabashvili,Filippo Volandri,R,R,M,20131116,CH Tour Finals,SF,,,,,3,1,jeffsackmann
-20131114-M-CH_Tour_Finals-RR-Teymuraz_Gabashvili-Aleksandr_Nedovyesov,Teymuraz Gabashvili,Aleksandr Nedovyesov,R,R,M,20131114,CH Tour Finals,RR,,,Clay,,3,1,jeffsackmann
-20131114-M-CH_Tour_Finals-RR-Alejandro_Gonzalez-Jesse_Huta_Galung,Alejandro Gonzalez,Jesse Huta Galung,R,R,M,20131114,CH Tour Finals,RR,,,Clay,,3,1,jeffsackmann
-20131113-M-CH_Tour_Finals-RR-Guilherme_Clezar-Aleksandr_Nedovyesov,Guilherme Clezar,Aleksandr Nedovyesov,R,R,M,20131113,CH Tour Finals,RR,,,Clay,,3,1,jeffsackmann
-20131112-M-Champaign_CH-R32-Tennys_Sandgren-Filip_Peliwo,Tennys Sandgren,Filip Peliwo,R,R,M,2013 11 12,Champaign CH,R32,8:20 PM CST,1,Indoor hard,,3,1,jeffsackmann
-20131112-M-Champaign_CH-R32-Marcos_Giron-Rajeev_Ram,Marcos Giron,Rajeev Ram,R,R,M,20131112,Champaign CH,R32,7pm CT,,Indoor hard,,3,1,jeffsackmann
-20131111-M-Tour_Finals-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20131111,Tour Finals,F,,,Indoor hard,Mo,3,1,jeffsackmann
-20131110-M-Tour_Finals-SF-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20131110,Tour Finals,SF,,,Indoor hard,,3,1,jeffsackmann
-20131110-M-Tour_Finals-SF-Novak_Djokovic-Stanislas_Wawrinka,Novak Djokovic,Stanislas Wawrinka,R,R,M,20131110,Tour Finals,SF,,,Indoor hard,,3,1,jeffsackmann
-20131109-M-Tour_Finals-RR-Roger_Federer-Juan_Martin_Del_Potro,Roger Federer,Juan Martin Del Potro,R,R,M,20131109,Tour Finals,RR,,,Hard,,3,1,jeffsackmann
-20131108-M-Tour_Finals-RR-Stanislas_Wawrinka-David_Ferrer,Stanislas Wawrinka,David Ferrer,R,R,M,20131108,Tour Finals,RR,,,Indoor hard,,3,1,jeffsackmann
-20131107-M-Tour_Finals-RR-Richard_Gasquet-Roger_Federer,Richard Gasquet,Roger Federer,R,R,M,20131107,Tour Finals,RR,,,Indoor hard,Damien Steiner,3,1,jeffsackmann
-20131107-M-Tour_Finals-RR-Novak_Djokovic-Juan_Martin_Del_Potro,Novak Djokovic,Juan Martin Del Potro,R,R,M,20131107,Tour Finals,RR,,,Indoor hard,Mo,3,1,jeffsackmann
-20131106-M-Tour_Finals-RR-David_Ferrer-Tomas_Berdych,David Ferrer,Tomas Berdych,R,R,M,20131106,Tour Finals,RR,,,Indoor hard,,3,1,jeffsackmann
-20131104-M-Tour_Finals-RR-Richard_Gasquet-Novak_Djokovic,Richard Gasquet,Novak Djokovic,R,R,M,20131104,Tour Finals,RR,,,Hard,,3,1,Isaac
-20131104-M-Tour_Finals-RR-Richard_Gasquet-Juan_Martin_Del_Potro,Richard Gasquet,Juan Martin Del Potro,R,R,M,20131104,Tour Finals,RR,,,Indoor Hard,,3,1,jeffsackmann
-20131103-M-Paris_Masters-F-Novak_Djokovic-David_Ferrer,Novak Djokovic,David Ferrer,R,R,M,20131103,Paris Masters,F,3:00pm,Centre,Hard Indoor,Damien Dumusois,3,1,Backstop5
-20131102-M-Paris_Masters-SF-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20131102,Paris Masters,SF,,,Hard,,3,1,Isaac
-20131102-M-Paris_Masters-SF-David_Ferrer-Rafael_Nadal,David Ferrer,Rafael Nadal,R,L,M,20131102,Paris Masters,SF,,,Hard,,3,1,Isaac
-20131101-M-Paris_Masters-QF-Roger_Federer-Juan_Martin_Del_Potro,Roger Federer,Juan Martin del Potro,R,R,M,20131101,Paris Masters,QF,,,Hard,,3,1,Amy
-20131101-M-Paris_Masters-QF-Novak_Djokovic-Stanislas_Wawrinka,Novak Djokovic,Stanislas Wawrinka,R,R,M,20131101,Paris Masters,QF,,,Hard,,3,1,Isaac
-20131031-M-Paris_Masters-R16-John_Isner-Novak_Djokovic,John Isner,Novak Djokovic,R,R,M,20131031,Paris Masters,R16,,,Hard,,3,1,Isaac
-20131030-M-Paris_Masters-R32-David_Ferrer-Lukas_Rosol,David Ferrer,Lukas Rosol,R,R,M,20131030,Paris Masters,R32,,,Indoor Hard,Mohamed El Jennati,3,1,jeffsackmann
-20131028-M-Paris_Masters-QF-Richard_Gasquet-Rafael_Nadal,Richard Gasquet,Rafael Nadal,R,L,M,20131028,Paris Masters,QF,,,Hard,,3,1,Isaac
-20131027-M-Basel-F-Juan_Martin_Del_Potro-Roger_Federer,Juan Martin Del Potro,Roger Federer,R,R,M,20131027,Basel,F,2:30 PM,Center,Indoor Hard,,3,1,Vaibhav Shevade
-20131025-M-Basel-QF-Grigor_Dimitrov-Roger_Federer,Grigor Dimitrov,Roger Federer,R,R,M,20131025,Basel,QF,,,Hard,,3,1,Amy
-20131013-M-Shanghai_Masters-F-Novak_Djokovic-Juan_Martin_Del_Potro,Novak Djokovic,Juan Martin del Potro,R,R,M,20131013,Shanghai Masters,F,,Stadium,Hard,Damien Dumusois,3,1,Backstop5
-20131012-M-Shanghai_Masters-SF-Rafael_Nadal-Juan_Martin_Del_Potro,Rafael Nadal,Juan Martin del Potro,L,R,M,20131012,Shanghai Masters,SF,,,Hard,,3,1,Amy
-20131012-M-Shanghai_Masters-SF-Novak_Djokovic-Jo_Wilfried_Tsonga,Novak Djokovic,Jo Wilfried Tsonga,R,R,M,20131012,Shanghai Masters,SF,,,Hard,,3,1,jeffsackmann
-20131011-M-Shanghai_Masters-QF-Nicolas_Almagro-Juan_Martin_Del_Potro,Nicolas Almagro,Juan Martin del Potro,R,R,M,20131011,Shanghai Masters,QF,,,Hard,,3,1,Amy
-20131010-M-Shanghai_Masters-R16-Roger_Federer-Gael_Monfils,Roger Federer,Gael Monfils,R,R,M,20131010,Shanghai Masters,R16,16:30:00,Center,Hard,,3,1,Joey Hanf
-20131008-M-Shanghai_Masters-R64-Vasek_Pospisil-Richard_Gasquet,Vasek Pospisil,Richard Gasquet,R,R,M,20131008,Shanghai Masters,R64,,,Hard,Ali Nili,3,1,jeffsackmann
-20131007-M-Shanghai_Masters-R64-Gilles_Simon-Benoit_Paire,Gilles Simon,Benoit Paire,R,R,M,20131007,Shanghai Masters,R64,,,Hard,,3,1,jeffsackmann
-20131007-M-Shanghai_Masters-R32-Roger_Federer-Andreas_Seppi,Roger Federer,Andreas Seppi,R,R,M,20131007,Shanghai Masters,R32,,,Hard,Mohamed Lahyani,3,1,Isaac
-20131007-M-Shanghai_Masters-R32-Rafael_Nadal-Alexandr_Dolgopolov,Rafael Nadal,Alexandr Dolgopolov,L,R,M,20131007,Shanghai Masters,R32,,Stadium,Hard,,3,1,Isaac
-20131007-M-Shanghai_Masters-R32-Marcel_Granollers-Novak_Djokovic,Marcel Granollers,Novak Djokovic,R,R,M,20131007,Shanghai Masters,R32,,,Hard,,3,1,Isaac
-20131006-M-Tokyo-F-Juan_Martin_Del_Potro-Milos_Raonic,Juan Martin Del Potro,Milos Raonic,R,R,M,20131006,Tokyo,F,,,Hard,,3,1,Amy
-20131005-M-Tokyo-SF-Nicolas_Almagro-Juan_Martin_Del_Potro,Nicolas Almagro,Juan Martin Del Potro,R,R,M,20131005,Tokyo,SF,,,Hard,,3,1,Amy
-20131005-M-Beijing-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20131005,Beijing,F,,,Hard,,3,1,Isaac
-20131004-M-Beijing-QF-Fabio_Fognini-Rafael_Nadal,Fabio Fognini,Rafael Nadal,R,L,M,20131004,Beijing,QF,,,Hard,,3,1,jeffsackmann
-20130929-M-Kuala_Lumpur-F-Julien_Benneteau-Joao_Sousa,Julien Benneteau,Joao Sousa,R,R,M,20130929,Kuala Lumpur,F,,,Indoor Hard,Mohammed Lahyani,3,1,jeffsackmann
-20130927-M-Bangkok-QF-Feliciano_Lopez-Milos_Raonic,Feliciano Lopez,Milos Raonic,L,R,M,20130927,Bangkok,QF,,,Indoor Hard,,3,1,jeffsackmann
-20130921-M-Metz-SF-Jo_Wilfried_Tsonga-Florian_Mayer,Jo Wilfried Tsonga,Florian Mayer,R,R,M,20130921,Metz,SF,,Centre,Hard,Manuel Messina,3,1,ChapelHeel66
-20130913-M-Davis_Cup_World_Group_PO-RR-Sergiy_Stakhovsky-Rafael_Nadal,Sergiy Stakhovsky,Rafael Nadal,R,L,M,20130913,Davis Cup World Group PO,RR,,Estadio Manolo Santana,Clay,Emmanuel Joseph,5,0,Salvo
-20130909-M-US_Open-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20130909,US Open,F,5:00 PM EST,Ashe,Hard,Jake Garner,5,1,jeffsackmann
-20130907-M-US_Open-SF-Richard_Gasquet-Rafael_Nadal,Richard Gasquet,Rafael Nadal,R,L,M,20130907,US Open,SF,5:00 PM EST,Ashe,Hard,Eva Asderaki,5,1,jeffsackmann
-20130907-M-US_Open-SF-Novak_Djokovic-Stanislas_Wawrinka,Novak Djokovic,Stanislas Wawrinka,R,R,M,20130907,US Open,SF,12:00 PM EST,Ashe,Hard,,5,1,jeffsackmann
-20130905-M-US_Open-QF-Stanislas_Wawrinka-Andy_Murray,Stanislas Wawrinka,Andy Murray,R,R,M,20130905,US Open,QF,2:30 PM EST,Ashe,Hard,Carlos Ramos,5,1,jeffsackmann
-20130904-M-US_Open-QF-Richard_Gasquet-David_Ferrer,Richard Gasquet,David Ferrer,R,R,M,20130904,US Open,QF,12:00 pm EST,Ashe,Hard,,5,1,jeffsackmann
-20130903-M-US_Open-R16-Denis_Istomin-Andy_Murray,Denis Istomin,Andy Murray,R,R,M,20130903,US Open,R16,8:30 PM EST,Ashe,Hard,,5,1,jeffsackmann
-20130901-M-US_Open-R32-Tomas_Berdych-Julien_Benneteau,Tomas Berdych,Julien Benneteau,R,R,M,20130901,US Open,R32,12:20 pm EST,Grandstand,Hard,,3,1,jeffsackmann
-20130830-M-US_Open-R64-Kevin_Anderson-Marcos_Baghdatis,Kevin Anderson,Marcos Baghdatis,R,R,M,20130830,US Open,R64,,17,Hard,,3,1,jeffsackmann
-20130828-M-US_Open-R128-Lleyton_Hewitt-Brian_Baker,Lleyton Hewitt,Brian Baker,R,R,M,20130828,US Open,R128,7pm EST,Grandstand,hard,,3,1,jeffsackmann
-20130827-M-US_Open-R128-Roger_Federer-Grega_Zemlja,Roger Federer,Grega Zemlja,R,R,M,20130827,US Open,R128,3:30 EST,Ashe,Hard,Anthony Nimmons,3,1,jeffsackmann
-20130818-M-Cincinnati_Masters-F-John_Isner-Rafael_Nadal,John Isner,Rafael Nadal,R,L,M,20130818,Cincinnati Masters,F,,,Hard,Fergus Murphy,3,1,jeffsackmann
-20130813-M-Canada_Masters-QF-Novak_Djokovic-Richard_Gasquet,Novak Djokovic,Richard Gasquet,R,R,M,20130813,Canada Masters,QF,,,Hard,,3,1,Isaac
-20130811-M-Canada_Masters-F-Milos_Raonic-Rafael_Nadal,Milos Raonic,Rafael Nadal,R,L,M,20130811,Canada Masters,F,,Court Central,Hard,,3,1,Isaac
-20130810-M-Aptos_CH-SF-Bradley_Klahn-Evgeny_Donskoy,Bradley Klahn,Evgeny Donskoy,L,R,M,20130810,Aptos CH,SF,,,Hard,,3,1,jeffsackmann
-20130808-M-Canada_Masters-R16-Ernests_Gulbis-Andy_Murray,Ernests Gulbis,Andy Murray,R,R,M,20130808,Canada Masters,R16,,,Hard,,3,1,qthetennisfan
-20130807-M-Canada_Masters-R32-Marcel_Granollers-Andy_Murray,Marcel Granollers,Andy Murray,R,R,M,20130807,Canada Masters,R32,,,Hard,,3,1,jeffsackmann
-20130806-M-Canada_Masters-R64-Vasek_Pospisil-John_Isner,Vasek Pospisil,John Isner,R,R,M,20130806,Canada Masters,R64,,Court Central,Hard,,3,1,@CanuckKicker
-20130805-M-Canada_Masters-R64-Peter_Polansky-Kei_Nishikori,Peter Polansky,Kei Nishikori,R,R,M,20130805,Canada Masters,R64,,Court Central,Hard,Damian Steiner,3,1,@CanuckKicker
-20130729-M-Washington-R16-Bernard_Tomic-Juan_Martin_Del_Potro,Bernard Tomic,Juan Martin Del Potro,R,R,M,20130729,Washington,R16,,,Hard,,3,1,Amy
-20130728-M-Atlanta-F-Kevin_Anderson-John_Isner,Kevin Anderson,John Isner,R,R,M,20130728,Atlanta,F,,Center,Hard,,3,1,1HandBH
-20130724-M-Lexington_CH-R16-James_Ward-Mitchell_Krueger,James Ward,Mitchell Krueger,R,R,M,20130724,Lexington CH,R16,,Stadium 1,Hard,,3,1,Joey Hanf
-20130720-M-Hamburg-SF-Federico_Delbonis-Roger_Federer,Federico Delbonis,Roger Federer,L,R,M,20130720,Hamburg,SF,,,Clay,,3,1,jeffsackmann
-20130714-M-Newport-F-Nicolas_Mahut-Lleyton_Hewitt,Nicolas Mahut,Lleyton Hewitt,R,R,M,20130714,Newport,F,,,Grass,,3,1,jeffsackmann
-20130714-M-Bastad-F-Carlos_Berlocq-Fernando_Verdasco,Carlos Berlocq,Fernando Verdasco,R,L,M,20130714,Bastad,F,,,Clay,Mohamed El Jennati,3,1,jeffsackmann
-20130707-M-Wimbledon-F-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20130707,Wimbledon,F,2:00 PM,Centre,Grass,Mohamed Lahyani,5,0,Verity or @vab14
-20130703-M-Wimbledon-QF-David_Ferrer-Juan_Martin_Del_Potro,David Ferrer,Juan Martin Del Potro,R,R,M,20130703,Wimbledon,QF,,,Grass,,5,0,Amy
-20130622-M-s_Hertogenbosch-F-Nicolas_Mahut-Stanislas_Wawrinka,Nicolas Mahut,Stanislas Wawrinka,R,R,M,20130622,s Hertogenbosch,F,,,Grass,,3,1,jeffsackmann
-20130616-M-Halle-F-Mikhail_Youzhny-Roger_Federer,Mikhail Youzhny,Roger Federer,R,R,M,20130616,Halle,F,,,Grass,Roland Herfel,3,1,jeffsackmann
-20130614-M-Halle-QF-Roger_Federer-Mischa_Zverev,Roger Federer,Mischa Zverev,R,L,M,20130614,Halle,QF,,Centre,Grass,,3,1,Daya
-20130612-M-Halle-R16-Gael_Monfils-Jan_Hernych,Gael Monfils,Jan Hernych,R,R,M,20130612,Halle,R16,8:30 AM,,Grass,Roland Herfel,3,1,ChapelHeel66
-20130609-M-Roland_Garros-F-David_Ferrer-Rafael_Nadal,David Ferrer,Rafael Nadal,R,L,M,20130609,Roland Garros,F,,,Clay,Cedric Mourier,5,0,Amy
-20130607-M-Roland_Garros-SF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20130607,Roland Garros,SF,,,Clay,,5,0,Amy
-20130524-M-Dusseldorf-SF-Jarkko_Nieminen-Igor_Sijsling,Jarkko Nieminen,Igor Sijsling,L,R,M,20130524,Dusseldorf,SF,,,Clay,,3,1,jeffsackmann
-20130518-M-Rome_Masters-SF-Roger_Federer-Benoit_Paire,Roger Federer,Benoit Paire,R,R,M,20130518,Rome Masters,SF,8:00 PM,Centrale,Clay,Mohamed El Jennati,3,1,Edo
-20130517-M-Rome_Masters-SF-Tomas_Berdych-Rafael_Nadal,Tomas Berdych,Rafael Nadal,R,L,M,20130517,Rome Masters,SF,,,Clay,,3,1,Isaac
-20130516-M-Rome_Masters-QF-Roger_Federer-Jerzy_Janowicz,Roger Federer,Jerzy Janowicz,R,R,M,20130516,Rome Masters,QF,,,Clay,Carlos Bernardes,3,1,jeffsackmann
-20130514-M-Rome_Masters-R32-Juan_Martin_Del_Potro-Andrey_Kuznetsov,Juan Martin Del Potro,Andrey Kuznetsov,R,R,M,20130514,Rome Masters,R32,,,Clay,,3,1,Amy
-20130512-M-Rome_Masters-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20130512,Rome Masters,F,,Campo Centrale,Clay,Carlos Bernardes,3,1,Isaac
-20130512-M-Madrid_Masters-F-Stanislas_Wawrinka-Rafael_Nadal,Stanislas Wawrinka,Rafael Nadal,R ,L,M,20130512,Madrid Masters,F,,Manolo Santana,Clay,,3,1,Backstop5
-20130509-M-Madrid_Masters-R16-Grigor_Dimitrov-Stanislas_Wawrinka,Grigor Dimitrov,Stanislas Wawrinka,R,R,M,20130509,Madrid Masters,R16,21:16,Arantxa Sanchez Vicario,Clay,Damien Dumosois,3,1,1HandBH
-20130508-M-Madrid_Masters-R16-Roger_Federer-Kei_Nishikori,Roger Federer,Kei Nishikori,R,R,M,20130508,Madrid Masters,R16,,,Clay,Damian Steiner,3,1,jeffsackmann
-20130507-M-Madrid_Masters-R32-Jo_Wilfried_Tsonga-Robin_Haase,Jo Wilfried Tsonga,Robin Haase,R,R,M,20130507,Madrid Masters,R32,,,Clay,Damian Steiner,3,1,jeffsackmann
-20130504-M-Munich-SF-Tommy_Haas-Ivan_Dodig,Tommy Haas,Ivan Dodig,R,R,M,20130504,Munich,SF,,,Clay,Felix Torralba,3,1,jeffsackmann
-20130501-M-Munich-R16-Dmitry_Tursunov-Alexandr_Dolgopolov,Dmitry Tursunov,Alexandr Dolgopolov,R,R,M,20130501,Munich,R16,,,Clay,Mohamed Lahyani,3,1,jeffsackmann
-20130426-M-Barcelona-QF-Tomas_Berdych-Tommy_Robredo,Tomas Berdych,Tommy Robredo,R,R,M,20130426,Barcelona,QF,,,Clay,,3,1,jeffsackmann
-20130419-M-Monte_Carlo_Masters-SF-Novak_Djokovic-Fabio_Fognini,Novak Djokovic,Fabio Fognini,R,R,M,20130419,Monte Carlo Masters,SF,,,Clay,,3,1,Isaac
-20130419-M-Monte_Carlo_Masters-QF-Richard_Gasquet-Fabio_Fognini,Richard Gasquet,Fabio Fognini,R,R,M,20130419,Monte Carlo Masters,QF,,Centre,Clay,Fergus Murphy,3,1,Dead Net Cord
-20130417-M-Monte_Carlo_Masters-R32-Nicolas_Almagro-Jurgen_Melzer,Nicolas Almagro,Jurgen Melzer,R,L,M,20130417,Monte Carlo Masters,R32,,Court des Princes,Clay,Mohammed Lahyani,3,1,jeffsackmann
-20130417-M-Monte_Carlo_Masters-R16-Andy_Murray-Stanislas_Wawrinka,Andy Murray,Stanislas Wawrinka,R,R,M,20130417,Monte Carlo Masters,R16,,,Clay,,3,1,Isaac
-20130414-M-Monte_Carlo_Masters-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20130414,Monte Carlo Masters,F,,Court Centrale,Clay,Mohamed Lahyani,3,1,Isaac
-20130327-M-Miami_Masters-R16-Novak_Djokovic-Tommy_Haas,Novak Djokovic,Tommy Haas,R,R,M,20130327,Miami Masters,R16,,,Hard,,3,1,Amy
-20130325-M-Miami_Masters-R32-Grigor_Dimitrov-Andy_Murray,Grigor Dimitrov,Andy Murray,R,R,M,20130325,Miami Masters,R32,,,Hard,Fergus Murphy,3,1,jeffsackmann
-20130323-M-Miami_Masters-R64-Bernard_Tomic-Andy_Murray,Bernard Tomic,Andy Murray,R,R,M,20130323,Miami Masters,R64,,,Hard,,3,1,Amy
-20130317-M-Indian_Wells_Masters-F-Rafael_Nadal-Juan_Martin_Del_Potro,Rafael Nadal,Juan Martin Del Potro,L,R,M,20130317,Indian Wells Masters,F,,Centre,Hard,Steve Ulrich,3,1,Salvo
-20130314-M-Indian_Wells-R16-Tommy_Haas-Juan_Martin_Del_Potro,Tommy Haas,Juan Martin Del Potro,R,R,M,20130314,Indian Wells,R16,,,Hard,,3,1,Amy
-20130312-M-Indian_Wells-R32-Ernests_Gulbis-Andreas_Seppi,Ernests Gulbis,Andreas Seppi,R,R,M,20130312,Indian Wells,R32,,,Hard,,3,1,jeffsackmann
-20130307-M-Indian_Wells_Masters-R32-Richard_Gasquet-Jerzy_Janowicz,Richard Gasquet,Jerzy Janowicz,R,R,M,20130307,Indian Wells Masters,R32,,,Hard,,3,1,Isaac
-20130303-M-Delray_Beach-F-Ernests_Gulbis-Edouard_Roger_Vasselin,Ernests Gulbis,Edouard Roger Vasselin,R,R,M,20130303,Delray Beach,F,,,Hard,Fergus Murphy,3,1,jeffsackmann
-20130302-M-Dubai-F-Novak_Djokovic-Tomas_Berdych,Novak Djokovic,Tomas Berdych,R,R,M,20130302,Dubai,F,7:15PM,Centre,Hard,,3,1,cameron10
-20130225-M-Dubai-R32-Roger_Federer-Malek_Jaziri,Roger Federer,Malek Jaziri,R,R,M,20130225,Dubai,R32,,,Hard,Alison Lang,3,1,jeffsackmann
-20130225-M-Acapulco-F-David_Ferrer-Rafael_Nadal,David Ferrer,Rafael Nadal,R,L,M,20130225,Acapulco,F,,,Clay,,3,1,Isaac
-20130210-M-Vina_del_Mar-F-Horacio_Zeballos-Rafael_Nadal,Horacio Zeballos,Rafael Nadal,L,L,M,20130210,Vina del Mar,F,,,Clay,Carlos Bernardes,3,1,jeffsackmann
-20130127-M-Australian_Open-F-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20130127,Australian Open,F,,,Hard,,5,0,Amy
-20130125-M-Australian_Open-SF-Roger_Federer-Andy_Murray_,Roger Federer,Andy Murray ,R,R,M,20130125,Australian Open,SF,,Rod Laver Arena,Hard,,5,0,Isaac
-20130125-M-Australian_Open-SF-David_Ferrer-Novak_Djokovic,David Ferrer,Novak Djokovic,R,R,M,20130125,Australian Open,SF,,,Hard,,3,1,Isaac
-20130121-M-Australian_Open-R16-Roger_Federer-Milos_Raonic,Roger Federer,Milos Raonic,R,R,M,20130121,Australian Open,R16,9PM,Center,Hard,Pascal Maria,5,1,jeffsackmann
-20130120-M-Australian_Open-R16-Novak_Djokovic-Stanislas_Wawrinka,Novak Djokovic,Stanislas Wawrinka,R,R,M,20130120,Australian Open,R16,20:38,Rod Laver Arena,Hard,,5,0,1HandBH
-20130117-M-Davis_Cup_World_Group_F-RR-Novak_Djokovic-Tomas_Berdych,Novak Djokovic,Tomas Berdych,R,R,M,20130117,Davis Cup World Group F,RR,14:00:00,Belgrade Arena,Hard,Eric Molina,5,0,Edo
-20130112-M-Sydney-F-Bernard_Tomic-Kevin_Anderson,Bernard Tomic,Kevin Anderson,R,R,M,20130112,Sydney,F,,,Hard,,3,1,Advanced Baseline
-20130109-M-Sydney-R16-Bernard_Tomic-Florian_Mayer,Bernard Tomic,Florian Mayer,R,R,M,20130109,Sydney,R16,,,Hard,Gerry Armstrong,3,1,Amy
-20130108-M-Sydney-R32-Bernard_Tomic-Marinko_Matosevic,Bernard Tomic,Marinko Matosevic,R,R,M,20130108,Sydney,R32,,,Hard,,3,1,Amy
-20130105-M-Brisbane-SF-Kei_Nishikori-Andy_Murray,Kei Nishikori,Andy Murray,R,R,M,20130105,Brisbane,SF,,,Hard,,3,0,Briton
-20130102-M-Brisbane-R16-Jarkko_Nieminen-Alexandr_Dolgopolov,Jarkko Nieminen,Alexandr Dolgopolov,L,R,M,20130102,Brisbane,R16,,Centre,Hard,,3,1,1HandBH
-20130101-M-Brisbane-R32-Benjamin_Mitchell-Marcos_Baghdatis,Benjamin Mitchell,Marcos Baghdatis,R,R,M,20130101,Brisbane,R32,,,Hard,Gianluca Moscarella,3,1,jeffsackmann
-20121112-M-Tour_Finals-F-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20121112,Tour Finals,F,15:19,O2 arena,Indoor Hard,Lars Graff,3,1,Sagar Manohar
-20121102-M-Paris_Masters-QF-Janko_Tipsarevic-Jerzy_Janowicz,Janko Tipsarevic,Jerzy Janowicz,R,R,M,20121102,Paris Masters,QF,,,Indoor Hard,Mohamed Lahyani,3,1,jeffsackmann
-20121102-M-Paris_Masters-QF-David_Ferrer-Jo_Wilfried_Tsonga,David Ferrer,Jo Wilfried Tsonga,R,R,M,20121102,Paris Masters,QF,7:40PM,Centre,Hard,,3,1,cameron10
-20121031-M-Paris_Masters-R32-Sam_Querrey-Novak_Djokovic,Sam Querrey,Novak Djokovic,R,R,M,20121031,Paris Masters,R32,,,Indoor hard,Cedric Mourier,3,1,jeffsackmann
-20121029-M-Paris_Masters-R16-Michael_Llodra-Juan_Martin_Del_Potro,Michael Llodra,Juan Martin Del Potro,L,R,M,20121029,Paris Masters,R16,,,Hard,,3,1,Isaac
-20121029-M-Paris_Masters-F-David_Ferrer-Jerzy_Janowicz,David Ferrer,Jerzy Janowicz,R,R,M,20121029,Paris Masters,F,,Centre,Hard,,3,1,Isaac
-20121012-M-Shanghai_Masters-SF-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20121012,Shanghai Masters,SF,,,Hard,,3,1,Isaac
-20121011-M-Shanghai_Masters-R16-Alexandr_Dolgopolov-Andy_Murray,Alexandr Dolgopolov,Andy Murray,R,R,M,20121011,Shanghai Masters,R16,,Stadium,Hard,Cedric Mourier,3,1,Mark G
-20121011-M-Shanghai_Masters-QF-Marin_Cilic-Roger_Federer,Marin Cilic,Roger Federer,R,R,M,20121011,Shanghai Masters,QF,,,Hard,,3,1,Isaac
-20121008-M-Shanghai_Masters-R32-Novak_Djokovic-Grigor_Dimitrov,Novak Djokovic,Grigor Dimitrov,R,R,M,20121008,Shanghai Masters,R32,,,Hard,,3,1,Isaac
-20120909-M-US_Open-F-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20120909,US Open,F,,Arthur Ashe,Hard,,5,1,Amy
-20120904-M-US_Open-QF-Novak_Djokovic-Juan_Martin_Del_Potro,Novak Djokovic,Juan Martin Del Potro,R,R,M,20120904,US Open,QF,,,Hard,,5,1,Isaac
-20120829-M-US_Open-R64-Ivan_Dodig-Andy_Murray,Ivan Dodig,Andy Murray,R,R,M,20120829,US Open,R64,,,Hard,Roland Herfel,5,1,Amy
-20120820-M-Finland_F3-SF-Vladimir_Ivanov-Alexander_Vasilenko,Vladimir Ivanov,Alexander Vasilenko,R,R,M,20120820,Finland F3,SF,,,Clay,,3,1,Isaac
-20120820-M-Finland_F3-SF-Markus_Eriksson-Alexandre_Penaud,Markus Eriksson,Alexandre Penaud,R,R,M,20120820,Finland F3,SF,,,Clay,,3,1,Isaac
-20120818-M-Cincinnati_Masters-F-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20120818,Cincinnati Masters,F,,,Hard,,3,1,Amy
-20120817-M-Cincinnati_Masters-SF-Roger_Federer-Stanislas_Wawrinka,Roger Federer,Stanislas Wawrinka,R,R,M,20120817,Cincinnati Masters,SF,,,Hard,,3,1,jeffsackmann
-20120812-M-Finland_F1-F-Milos_Sekulic-Vladimir_Ivanov,Milos Sekulic,Vladimir Ivanov,R,R,M,20120812,Finland F1,F,,,Clay,,3,1,Isaac
-20120812-M-Canada_Masters-F-Novak_Djokovic-Richard_Gasquet,Novak Djokovic,Richard Gasquet,R,R,M,20120812,Canada Masters,F,,,Hard,,3,1,Isaac
-20120806-M-Finland_F1-SF-Andres_Artunedo-Vladimir_Ivanov,Andres Artunedo,Vladimir Ivanov,R,R,M,20120806,Finland F1,SF,,,Clay,,3,1,Isaac
-20120805-M-Olympics-BR-Novak_Djokovic-Juan_Martin_Del_Potro,Novak Djokovic,Juan Martin Del Potro,R,R,M,20120805,Olympics,BR,,1,Grass,Lars Graff,3,0,Salvo
-20120804-M-Olympics-F-Andy_Murray-Roger_Federer,Andy Murray,Roger Federer,R,R,M,20120804,Olympics,F,,,Grass,,3,1,Isaac
-20120803-M-Olympics-SF-Juan_Martin_Del_Potro-Roger_Federer,Juan Martin Del Potro,Roger Federer,R,R,M,20120803,Olympics,SF,,Centre,Grass,,3,0,jeffsackmann
-20120803-M-Olympics-SF-Andy_Murray-Novak_Djokovic,Andy Murray,Novak Djokovic,R,R,M,20120803,Olympics,SF,18:30,Centre,Grass,Jake Garner,3,0,hnjc95
-20120802-M-Olympics-QF-Novak_Djokovic-Jo_Wilfried_Tsonga,Novak Djokovic,Jo Wilfried Tsonga,R,R,M,20120802,Olympics,QF,,Centre,Grass,Enric Molina,3,0,Salvo
-20120802-M-Olympics-QF-Nicolas_Almagro-Andy_Murray,Nicolas Almagro,Andy Murray,R,R,M,20120802,Olympics,QF,,1,Grass,John Blom,3,0,Salvo
-20120802-M-Olympics-QF-John_Isner-Roger_Federer,John Isner,Roger Federer,R,R,M,20120802,Olympics,QF,,Centre,Grass,Carlos Bernardes,3,0,Salvo
-20120801-M-Olympics-R16-Roger_Federer-Denis_Istomin,Roger Federer,Denis Istomin,R,R,M,20120801,Olympics,R16,,1,Grass,Eva Asderaki,3,0,Salvo
-20120801-M-Olympics-R16-Novak_Djokovic-Lleyton_Hewitt,Novak Djokovic,Lleyton Hewitt,R,R,M,20120801,Olympics,R16,,Centre,Grass,,3,0,Albertini
-20120801-M-Olympics-R16-Andy_Murray-Marcos_Baghdatis,Andy Murray,Marcos Baghdatis,R,R,M,20120801,Olympics,R16,,Centre,Grass,Carlos Bernardes,3,0,Salvo
-20120731-M-Olympics-R32-Novak_Djokovic-Andy_Roddick,Novak Djokovic,Andy Roddick,R,R,M,20120731,Olympics,R32,,,Grass,,3,0,EricJ
-20120731-M-Olympics-R32-Jarkko_Nieminen-Andy_Murray,Jarkko Nieminen,Andy Murray,L,R,M,20120731,Olympics,R32,,Centre,Grass,Pascal Maria,3,0,Salvo
-20120730-M-Olympics-R32-Juan_Martin_Del_Potro-Andreas_Seppi,Juan Martin Del Potro,Andreas Seppi,R,R,M,20120730,Olympics,R32,,Centre,Grass,Jake Garner,3,0,Salvo
-20120729-M-Olympics-R64-Novak_Djokovic-Fabio_Fognini,Novak Djokovic,Fabio Fognini,R,R,M,20120729,Olympics,R64,,1,Grass,Pascal Maria,3,0,Salvo
-20120729-M-Olympics-R64-Jo_Wilfried_Tsonga-Thomaz_Bellucci,Jo Wilfried Tsonga,Thomaz Bellucci,R,L,M,20120729,Olympics,R64,,Centre,Grass,Enric Molina,3,0,Salvo
-20120729-M-Olympics-R64-Andy_Murray-Stanislas_Wawrinka,Andy Murray,Stanislas Wawrinka,R,R,M,20120729,Olympics,R64,,Centre,Grass,Lars Graff,3,0,Salvo
-20120728-M-Olympics-R64-Roger_Federer-Alejandro_Falla,Roger Federer,Alejandro Falla,R,L,M,20120728,Olympics,R64,,Centre,Grass,Carlos Bernardes,3,0,Salvo
-20120726-M-Olympics-R64-Tomas_Berdych-Steve_Darcis,Tomas Berdych,Steve Darcis,R,R,M,20120726,Olympics,R64,,,Grass,Eva Asderaki,3,1,jeffsackmann
-20120725-M-Olympics-R32-Roger_Federer-Julien_Benneteau,Roger Federer,Julien Benneteau,R,R,M,20120725,Olympics,R32,,,Grass,,3,1,Isaac
-20120720-M-Hamburg-QF-Jeremy_Chardy-Juan_Monaco,Jeremy Chardy,Juan Monaco,R,R,M,20120720,Hamburg,QF,,,Clay,Ahmed Abdel-Azim,3,1,jeffsackmann
-20120708-M-Wimbledon-F-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20120708,Wimbledon,F,2:00 PM,Centre,Grass,Enric Molina,5,0,Paul
-20120706-M-Wimbledon-SF-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20120706,Wimbledon,SF,,Centre,Grass,,5,0,Geethika
-20120608-M-Roland_Garros-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20120608,Roland Garros,F,,Chatrier,Clay,,5,0,Amy
-20120519-M-Rome_Masters-SF-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20120519,Rome Masters,SF,20:00:00,Centrale,Clay,Damien Dumusois,3,0,Edo
-20120519-M-Rome_Masters-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20120519,Rome Masters,F,,Campo Centrale,Clay,,3,1,Isaac
-20120516-M-Rome_Masters-R32-Roger_Federer-Carlos_Berlocq,Roger Federer,Carlos Berlocq,R,R,M,20120516,Rome Masters,R32,,,Clay,,3,0,Isaac
-20120510-M-Madrid_Masters-QF-David_Ferrer-Roger_Federer,David Ferrer,Roger Federer,R,R,M,20120510,Madrid Masters,QF,,,Clay,,3,1,Isaac
-20120510-M-Madrid-R16-Roger_Federer-Richard_Gasquet,Roger Federer,Richard Gasquet,R,R,M,20120510,Madrid,R16,,,Clay,,3,1,Amy
-20120506-M-Madrid_Masters-F-Tomas_Berdych-Roger_Federer,Tomas Berdych,Roger Federer,R,R,M,20120506,Madrid Masters,F,4:00 PM,Manolo Santana,Clay,Mohamed Layhani,3,1,Edo
-20120505-M-Munich-F-Marin_Cilic-Philipp_Kohlschreiber,Marin Cilic,Philipp Kohlschreiber,R,R,M,20120505,Munich,F,,,Clay,Fergus Murphy,3,1,jeffsackmann
-20120505-M-Belgrade-SF-Benoit_Paire-Pablo_Andujar,Benoit Paire,Pablo Andujar,R,R,M,20120505,Belgrade,SF,,,Clay,Gianluca Moscarella,3,1,jeffsackmann
-20120422-M-Monte_Carlo_Masters-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20120422,Monte Carlo Masters,F,,Campo Centrale,Clay,,3,1,Isaac
-20120415-M-Casablanca-F-Albert_Ramos-Pablo_Andujar,Albert Ramos,Pablo Andujar,L,R,M,20120415,Casablanca,F,,,Clay,,3,1,jeffsackmann
-20120406-M-Davis_Cup_World_Group_QF-RR-Ivo_Karlovic-Juan_Martin_Del_Potro,Ivo Karlovic,Juan Martin Del Potro,R,R,M,20120406,Davis Cup World Group QF,RR,16:15,Parque Roca,Clay,,5,0,1HandBH
-20120327-M-Miami_Masters-QF-David_Ferrer-Novak_Djokovic,David Ferrer,Novak Djokovic,R,R,M,20120327,Miami Masters,QF,,,Hard,,3,1,Isaac
-20120319-M-Indian_Wells_Masters-Final-Roger_Federer-John_Isner,Roger Federer,John Isner,R,R,M,20120319,Indian Wells Masters,Final,7:10PM,Stadium 1,Hard Outdoor,Mohamed Lahyani,3,1,cameron10
-20120316-M-Indian_Wells_Masters-SF-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20120316,Indian Wells Masters,SF,12:17,Centre Court,Hard,Steve Ullrich,3,1,Sagar Manohar
-20120314-M-Indian_Wells_Masters-R16-Roger_Federer-Thomaz_Bellucci,Roger Federer,Thomaz Bellucci,R,L,M,20120314,Indian Wells Masters,R16,5:00 PM,,Hard,Ali Nili,3,1,jeffsackmann
-20120313-M-Indian_Wells_Masters-R32-Ryan_Harrison-Guillermo_Garcia_Lopez,Ryan Harrison,Guillermo Garcia Lopez,R,R,M,20120313,Indian Wells Masters,R32,,,Hard,Roland Herfel,3,1,jeffsackmann
-20120303-M-Dubai-F-Andy_Murray-Roger_Federer,Andy Murray,Roger Federer,R,R,M,20120303,Dubai,F,7:10 PM,Centre,Hard,Mohamed Lahyani,3,1,Chris Devine
-20120301-M-Delray_Beach-R16-Bernard_Tomic-Tim_Smyczek,Bernard Tomic,Tim Smyczek,R,R,M,20120301,Delray Beach,R16,,,Hard,,3,1,jeffsackmann
-20120227-M-Dubai-SF-Andy_Murray-Novak_Djokovic,Andy Murray,Novak Djokovic,R,R,M,20120227,Dubai,SF,,Centre,Hard,,3,1,Isaac
-20120225-M-Buenos_Aires-SF-David_Ferrer-David_Nalbandian,David Ferrer,David Nalbandian,R,R,M,20120225,Buenos Aires,SF,,,Clay,,3,1,Isaac
-20120221-M-Buenos_Aires-R32-Wayne_Odesnik-David_Nalbandian,Wayne Odesnik,David Nalbandian,L,R,M,20120221,Buenos Aires,R32,,,Clay,,3,1,jeffsackmann
-20120219-M-Rotterdam-F-Roger_Federer-Juan_Martin_Del_Potro,Roger Federer,Juan Martin del Potro,R,R,M,20120219,Rotterdam,F,,,Hard,,3,1,Amy
-20120210-M-Davis_Cup_World_Group_R1-RR-Julien_Benneteau-Milos_Raonic,Julien Benneteau,Milos Raonic,R,R,M,20120210,Davis Cup World Group R1,RR,,,Hard,,5,0,@CanuckKicker
-20120129-M-Australian_Open-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20120129,Australian Open,F,,Rod Laver,Hard,,5,0,Amy
-20120127-M-Australian_Open-SF-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20120127,Australian Open,SF,,Rod laver Arena,Hard,,5,0,Isaac
-20120127-M-Australian_Open-SF-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20120127,Australian Open,SF,,Rod Laver Arena,Hard,,5,0,Isaac
-20120125-M-Australian_Open-QF-Andy_Murray-Kei_Nishikori,Andy Murray,Kei Nishikori,R,R,M,20120125,Australian Open,QF,0330 GMT,Rod Laver Arena,Hard,,5,0,Rex
-20120124-M-Australian_Open-QF-David_Ferrer-Novak_Djokovic,David Ferrer,Novak Djokovic,R,R,M,20120124,Australian Open,QF,,Rod Laver Arena,Hard,,5,0,Isaac
-20120122-M-Australian_Open-R16-Novak_Djokovic-Lleyton_Hewitt,Novak Djokovic,Lleyton Hewitt,R,R,M,20120122,Australian Open,R16,,Rod Laver Arena,Hard,,5,0,Isaac
-20120121-M-Australian_Open-R32-Michael_Llodra-Andy_Murray,Michael Llodra,Andy Murray,L,R,M,20120121,Australian Open,R32,19:09,Hisense Arena,Hard,Enric Molina,5,0,1HandBH
-20120108-M-Chennai-F-Milos_Raonic-Janko_Tipsarevic,Milos Raonic,Janko Tipsarevic,R,R,M,20120108,Chennai,F,,Centre,Hard,,3,1,@CanuckKicker
-20111127-M-Tour_Finals-F-Roger_Federer-Jo_Wilfried_Tsonga,Roger Federer,Jo Wilfried Tsonga,R,R,M,20111127,Tour Finals,F,8:00 pm,Centre,Hard,Steve Ullrich,3,1,Edo
-20111125-M-Tour_Finals-SF-David_Ferrer-Roger_Federer,David Ferrer,Roger Federer,R,R,M,20111125,Tour Finals,SF,,Centre,Hard,,3,1,Isaac
-20111122-M-Tour_Finals-RR-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20111122,Tour Finals,RR,,,Hard,Steve Ulrich,3,1,Amy
-20111113-M-Paris_Masters-F-Roger_Federer-Jo_Wilfried_Tsonga,Roger Federer,Jo Wilfried Tsonga,R,R,M,20111113,Paris Masters,F,3:00 PM,Court Central,Hard,Lars Graff,3,1,Edo
-20111111-M-Paris_Masters-QF-Roger_Federer-Juan_Monaco,Roger Federer,Juan Monaco,R,R,M,20111111,Paris Masters,QF,,,Hard,,3,1,Isaac
-20111106-M-Basel-F-Kei_Nishikori-Roger_Federer,Kei Nishikori,Roger Federer,R,R,M,20111106,Basel,F,14:15,Center,Hard,Mohamed El Jennati,3,1,1HandBH
-20111021-M-Stockholm-QF-Grigor_Dimitrov-Milos_Raonic,Grigor Dimitrov,Milos Raonic,R,R,M,20111021,Stockholm,QF,,,Hard,,3,1,Isaac
-20111009-M-Tokyo-F-Rafael_Nadal-Andy_Murray,Rafael Nadal,Andy Murray,L,R,M,20111009,Tokyo,F,,,Hard,,3,1,Isaac
-20111009-M-Shanghai_Masters-R32-David_Ferrer-Milos_Raonic,David Ferrer,Milos Raonic,R,R,M,20111009,Shanghai Masters,R32,,,Hard,,3,1,Isaac
-20111008-M-Tokyo-SF-David_Ferrer-Andy_Murray,David Ferrer,Andy Murray,R,R,M,20111008,Tokyo,SF,,,Hard,,3,1,Isaac
-20110911-M-US_Open-F-Rafael_Nadal_-Novak_Djokovic,Rafael Nadal ,Novak Djokovic,L,R,M,20110911,US Open,F,,Arthur Ashe Stadium,Hard,Carlos Ramos,3,1,Isaac
-20110909-M-US_Open-SF-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20110909,US Open,SF,,,Hard,,5,1,Isaac
-20110821-M-Cincinnati_Masters-F-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20110821,Cincinnati Masters,F,,Center,Hard,Fergus Murphy,3,1,Salvo
-20110815-M-Cincinnati_Masters-R32-Roger_Federer-Juan_Martin_Del_Potro,Roger Federer,Juan Martin Del Potro,R,R,M,20110815,Cincinnati Masters,R32,,,Hard,,3,1,Isaac
-20110717-M-Bastad-F-David_Ferrer-Robin_Soderling,David Ferrer,Robin Soderling,R,R,M,20110717,Bastad,F,,,Clay,,3,1,Amy
-20110703-M-Wimbledon-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20110703,Wimbledon,F,,,Grass,,5,0,Isaac
-20110606-M-Queens_Club-SF-Andy_Murray-Andy_Roddick,Andy Murray,Andy Roddick,R,R,M,20110606,Queens Club,SF,,,Grass,,3,1,Isaac
-20110605-M-Roland_Garros-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20110605,Roland Garros,F,3:00 PM,Philippe Chatrier,Clay,Pascal Maria,5,0,Edo
-20110603-M-Roland_Garros-SF-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20110603,Roland Garros,SF,,Philippe Chatrier,Clay,,5,0,Edged
-20110513-M-Rome_Masters-SF-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20110513,Rome Masters,SF,,,Clay,,3,1,Isaac
-20110508-M-Rome_Masters-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20110508,Rome Masters,F,,Campo Centrale,Clay,,3,1,Isaac
-20110424-M-Barcelona-F-David_Ferrer-Rafael_Nadal,David Ferrer,Rafael Nadal,R,L,M,20110424,Barcelona,F,,,Clay,Mohamed Lahyani,3,1,Isaac
-20110401-M-Miami_Masters-SF-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20110401,Miami Masters,SF,,Stadium,Hard,Steve Ullrich,3,1,Isaac
-20110319-M-Indian_Wells_Masters-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20110319,Indian Wells Masters,F,,,Hard,,3,1,Isaac
-20110316-M-Indian_Wells_Masters-QF-Roger_Federer-Stanislas_Wawrinka,Roger Federer,Stanislas Wawrinka,R,R,M,20110316,Indian Wells Masters,QF,,Stadium 1,Hard,,3,1,Isaac
-20110310-M-Indian_Wells_Masters-QF-Richard_Gasquet-Novak_Djokovic,Richard Gasquet,Novak Djokovic,R,R,M,20110310,Indian Wells Masters,QF,,,Hard,Damian Steiner,3,1,Isaac
-20110221-M-Dubai-F-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20110221,Dubai,F,,,Hard,Mohamed Lahyani,3,1,Isaac
-20110130-M-Australian_Open-F-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20110130,Australian Open,F,,,Hard,,3,1,Isaac
-20110123-M-Australian_Open-R16-Robin_Soderling-Alexandr_Dolgopolov,Robin Soderling,Alexandr Dolgopolov,R,R,M,20110123,Australian Open,R16,,,Hard,,5,1,Isaac
-20110120-M-Australian_Open-R64-Gilles_Simon-Roger_Federer,Gilles Simon,Roger Federer,R,R,M,20110120,Australian Open,R64,,Rod Laver Arena,Hard,,5,0,Isaac
-20110118-M-Australian_Open-R128-David_Nalbandian-Lleyton_Hewitt,David Nalbandian,Lleyton Hewitt,R,R,M,20110118,Australian Open,R128,20:18,Rod Laver Arena,Hard,Pascal Maria,5,0,1HandBH
-20110108-M-Doha-F-Roger_Federer-Nikolay_Davydenko,Roger Federer,Nikolay Davydenko,R,R,M,20110108,Doha,F,6:00 PM,Center,Hard,Mohamed Lahyani,3,1,Edo
-20110106-M-Brisbane-QF-Florian_Mayer-Radek_Stepanek,Florian Mayer,Radek Stepanek,R,R,M,20110106,Brisbane,QF,,Rafter,Hard,,3,1,jeffsackmann
-20110102-M-Brisbane-R16-Robin_Soderling-Michael_Berrer,Robin Soderling,Michael Berrer,R,L,M,20110102,Brisbane,R16,,,Hard,,3,1,Amy
-20101128-M-Tour_Finals-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20101128,Tour Finals,F,18:00:00,Centre,Hard,Mohamed Lahyani,3,1,Edo
-20101126-M-Tour_Finals-SF-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20101126,Tour Finals,SF,,,Hard,,3,1,Isaac
-20101122-M-Tour_Finals-RR-Robin_Soderling-Andy_Murray,Robin Soderling,Andy Murray,R,R,M,20101122,Tour Finals,RR,,,Hard,,3,1,Isaac
-20101121-M-Tour_Finals-RR-Tomas_Berdych-Novak_Djokovic,Tomas Berdych,Novak Djokovic,R,R,M,20101121,Tour Finals,RR,,,Hard,,3,1,Isaac
-20101121-M-Tour_Finals-RR-Novak_Djokovic-Andy_Roddick,Novak Djokovic,Andy Roddick,R,R,M,20101121,Tour Finals,RR,,Centre Court,Hard,,3,1,Isaac
-20101121-M-Tour_Finals-RR-Andy_Roddick-Rafael_Nadal,Andy Roddick,Rafael Nadal,R,L,M,20101121,Tour Finals,RR,,,Hard,,3,1,Isaac
-20101121-M-Tour_Finals-RR-Andy_Murray_-Roger_Federer,Andy Murray ,Roger Federer,R,R,M,20101121,Tour Finals,RR,,Centre Court,Hard,,3,1,Isaac
-20101024-M-Stockholm-F-Roger_Federer-Florian_Mayer,Roger Federer,Florian Mayer,R,R,M,20101024,Stockholm,F,12:15:00 PM,,Hard,Lars Graff,3,1,ChapelHeel66
-20101017-M-Shanghai_Masters-F-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20101017,Shanghai Masters,F,5:00:00 PM,Centre,Hard,Cedric Mourier,3,1,Edo
-20101015-M-Shanghai_Masters-SF-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20101015,Shanghai Masters,SF,,Stadium,Hard,,3,1,Isaac
-20101010-M-Tokyo-F-Rafael_Nadal-Gael_Monfils,Rafael Nadal,Gael Monfils,L,R,M,20101010,Tokyo,F,,,Hard,,3,1,Isaac
-20101010-M-Shanghai_Masters-QF-Robin_Soderling-Roger_Federer,Robin Soderling,Roger Federer,R,R,M,20101010,Shanghai Masters,QF,,,Hard,,3,1,Amy
-20100912-M-US_Open-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20100912,US Open,F,,Arthur Ashe Stadium,Hard,,5,1,Isaac
-20100821-M-Cincinnati_Masters-F-Mardy_Fish-Roger_Federer,Mardy Fish,Roger Federer,R,R,M,20100821,Cincinnati Masters,F,3:00:00 PM,Centre,Hard,Gerry Armstrong,3,1,Edo
-20100704-M-Wimbledon-F-Tomas_Berdych-Rafael_Nadal,Tomas Berdych,Rafael Nadal,R,L,M,20100704,Wimbledon,F,2:00 PM,Centre,Grass,Jake Garner,5,0,Edo
-20100606-M-Roland_Garros-F-Robin_Soderling-Rafael_Nadal,Robin Soderling,Rafael Nadal,R,L,M,20100606,Roland Garros,F,,,Clay,,5,0,Amy
-20100512-M-Madrid_Masters-R16-John_Isner-Rafael_Nadal,John Isner,Rafael Nadal,R,R,M,20100512,Madrid Masters,R16,,,Clay,,3,1,Isaac
-20100509-M-Madrid_Open-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20100509,Madrid Open,F,,Manolo Santana,Clay,,3,1,Isaac
-20100418-M-Monte_Carlo_Masters-F-Fernando_Verdasco-Rafael_Nadal,Fernando Verdasco,Rafael Nadal,L,L,M,20100418,Monte Carlo Masters,F,2:30 PM,Centre,Clay,,3,1,cameron10
-20100415-M-Monte_Carlo_Masters-R16-Rafael_Nadal-Michael_Berrer,Rafael Nadal,Michael Berrer,L,L,M,20100415,Monte Carlo Masters,R16,,,Clay,,3,1,Isaac
-20100321-M-Indian_Wells_Masters-F-Andy_Roddick-Ivan_Ljubicic,Andy Roddick,Ivan Ljubicic,R,R,M,20100321,Indian Wells Masters,F,14:00,Center,Hard,Mohamed Lahyani,3,1,jeffsackmann
-20100131-M-Australian_Open-F-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20100131,Australian Open,F,,Rod Laver,Hard,,5,0,Edged
-20100126-M-Australian_Open-QF-Novak_Djokovic-Jo_Wilfried_Tsonga,Novak Djokovic,Jo Wilfried Tsonga,R,R,M,20100126,Australian Open,QF,,,Hard,,5,0,Isaac
-20100126-M-Australian_Open-QF-Andy_Murray-Rafael_Nadal,Andy Murray,Rafael Nadal,R,L,M,20100126,Australian Open,QF,,Rod Laver Arena,Hard,,5,0,Isaac
-20100108-M-Doha-SF-Roger_Federer-Nikolay_Davydenko,Roger Federer,Nikolay Davydenko,R,R,M,20100108,Doha,SF,,Centre,Hard,,3,1,Isaac
-20091127-M-Tour_Finals-SF-Robin_Soderling-Juan_Martin_Del_Potro,Robin Soderling,Juan Martin Del Potro,R,R,M,20091127,Tour Finals,SF,,,Hard,,3,1,Amy
-20091123-M-Tour_Finals-RR-Robin_Soderling-Rafael_Nadal,Robin Soderling,Rafael Nadal,R,L,M,20091123,Tour Finals,RR,,O2 Arena,Hard,,3,1,Isaac
-20091122-M-Tour_Finals-RR-Robin_Soderling-Nikolay_Davydenko,Robin Soderling,Nikolay Davydenko,R,R,M,20091122,Tour Finals,RR,,,Hard,,3,1,Isaac
-20091122-M-Tour_Finals-RR-Andy_Murray-Roger_Federer,Andy Murray,Roger Federer,R,R,M,20091122,Tour Finals,RR,,Centre Court,Hard,,3,1,Isaac
-20091122-M-London-RR-Robin_Soderling-Novak_Djokovic,Robin Soderling,Novak Djokovic,R,R,M,20091122,London,RR,,,Hard,,3,1,Amy
-20091110-M-Paris_Masters-R32-Marat_Safin-Juan_Martin_Del_Potro,Marat Safin,Juan Martin Del Potro,R,R,M,20091110,Paris Masters,R32,,,Hard,,3,1,Amy
-20091018-M-Shanghai_Masters-F-Rafael_Nadal-Nikolay_Davydenko,Rafael Nadal,Nikolay Davydenko,L,R,M,20091018,Shanghai Masters,F,,,Hard,Steve Ulrich,3,1,jeffsackmann
-20090912-M-US_Open-F-Roger_Federer-Juan_Martin_Del_Potro,Roger Federer,Juan Martin Del Potro,R,R,M,20090912,US Open,F,,,Hard,,5,1,Amy
-20090831-M-US_Open-SF-Juan_Martin_Del_Potro-Rafael_Nadal,Juan Martin Del Potro,Rafael Nadal,R,L,M,20090831,US Open,SF,,,Hard,Steve Ulrich,3,1,Amy
-20090816-M-Cincinnati-F-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20090816,Cincinnati,F,,,Hard,,3,1,Isaac
-20090810-M-Canada_Masters-R32-Fernando_Gonzalez-Milos_Raonic,Fernando Gonzalez,Milos Raonic,R,R,M,20090810,Canada Masters,R32,,,Hard,Ali Nili,3,1,jeffsackmann
-20090705-M-Wimbledon-F-Andy_Roddick-Roger_Federer,Andy Roddick,Roger Federer,R,R,M,20090705,Wimbledon,F,,Centre,Grass,Lars Graff,5,0,Paul
-20090607-M-Roland_Garros-F-Robin_Soderling-Roger_Federer,Robin Soderling,Roger Federer,R,R,M,20090607,Roland Garros,F,15:00:00,Philippe Chatrier,Clay,Pascal Maria,5,0,Edo
-20090605-M-Roland_Garros-SF-Roger_Federer-Juan_Martin_Del_Potro,Roger Federer,Juan Martin Del Potro,R,R,M,20090605,Roland Garros,SF,,Court Philippe Chatrier,Clay,Enric Molina,5,0,marct
-20090531-M-Roland_Garros-R16-Robin_Soderling-Rafael_Nadal,Robin Soderling,Rafael Nadal,R,L,M,20090531,Roland Garros,R16,,,Clay,,5,0,Amy
-20090517-M-Madrid_Masters-F-Rafael_Nadal-Roger_Federer,Rafael Nadal,Roger Federer,L,R,M,20090517,Madrid Masters,F,3:00 PM,Manolo Santana,Clay,Lars Graff,3,1,Edo
-20090503-M-Rome_Masters-SF-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20090503,Rome Masters,SF,14:00:00,Pietrangeli,Clay,Carlos Bernardes,3,1,Edo
-20090405-M-Miami_Masters-F-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20090405,Miami Masters,F,,,Hard,Gerry Armstrong,3,1,Isaac
-20090323-M-Indian_Wells_Masters-F-Rafael_Nadal-Andy_Murray,Rafael Nadal,Andy Murray,L,R,M,20090323,Indian Wells Masters,F,,Stadium 1,Hard,Cedric Mourier,3,1,Salvo
-20090201-M-Australian_Open-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20090201,Australian Open,F,8:30 PM,Centre,Hard,Pascal Maria,5,0,Edo
-20090130-M-Australian_Open-SF-Fernando_Verdasco-Rafael_Nadal,Fernando Verdasco,Rafael Nadal,L,L,M,20090130,Australian Open,SF,,Rod Laver,Hard,,5,0,Edged
-20081026-M-Basel-F-Roger_Federer-David_Nalbandian,Roger Federer,David Nalbandian,R,R,M,20081026,Basel,F,,Centre,Hard,Mohamed Layhani,3,1,Edo
-20080914-M-Bucharest-F-Gilles_Simon-Carlos_Moya,Gilles Simon,Carlos Moya,R,R,M,20080914,Bucharest,F,,,Clay,,3,1,jeffsackmann
-20080908-M-US_Open-F-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20080908,US Open,F,5:00 PM,Ashe,Hard,Carlos Bernardes,5,1,Edo
-20080905-M-US_Open-SF-Rafael_Nadal-Andy_Murray,Rafael Nadal,Andy Murray,L,R,M,20080905,US Open,SF,,Arthur Ashe Stadium,Hard,,5,1,Isaac
-20080817-M-Olympics-F-Rafael_Nadal-Fernando_Gonzalez,Rafael Nadal,Fernando Gonzalez,L,R,M,20080817,Olympics,F,,Diamond Court,Hard,Jake Garner,5,0,Salvo
-20080815-M-Olympics-SF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20080815,Olympics,SF,,Centre,Hard,Carlos Ramos,3,0,Salvo
-20080802-M-Cincinnati_Masters-SF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20080802,Cincinnati Masters,SF,,,Hard,,3,1,Isaac
-20080727-M-Canada_Masters-F-Nicolas_Kiefer-Rafael_Nadal,Nicolas Kiefer,Rafael Nadal,R,L,M,20080727,Canada Masters,F,,,Hard,,3,1,Isaac
-20080706-M-Wimbledon-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20080706,Wimbledon,F,,,Grass,Pascal Maria,5,0,Amy
-20080615-M-Queens_Club-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20080615,Queens Club,F,,Centre,Grass,Steve Ulrich,3,1,Salvo
-20080615-M-Halle-F-Roger_Federer-Philipp_Kohlschreiber,Roger Federer,Philipp Kohlschreiber,R,R,M,20080615,Halle,F,2:00 PM,Stadion,Grass,Carlos Bernardes,3,1,Edo
-20080614-M-Queens_Club-SF-Andy_Roddick-Rafael_Nadal,Andy Roddick,Rafael Nadal,R,L,M,20080614,Queens Club,SF,,Centre,Grass,Mohamed El Jennati,3,1,Salvo
-20080608-M-Roland_Garros-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20080608,Roland Garros,F,2:00 PM,Philippe Chatrier,Clay,Carlos Ramos,5,0,Edo
-20080420-M-Estoril-F-Nikolay_Davydenko-Roger_Federer,Nikolay Davydenko,Roger Federer,R,R,M,20080420,Estoril,F,,Centre,Clay,Carlos Bernardes,3,1,Edo
-20080307-M-Dubai-QF-Igor_Andreev-Novak_Djokovic,Igor Andreev,Novak Djokovic,R,R,M,20080307,Dubai,QF,,,Hard,,3,1,Isaac
-20080127-M-Australian_Open-F-Jo_Wilfried_Tsonga-Novak_Djokovic,Jo Wilfried Tsonga,Novak Djokovic,R,R,M,20080127,Australian Open,F,,Laver,Hard,Carlos Ramos,5,0,jeffsackmann
-20080125-M-Australian_Open-SF-Jo_Wilfried_Tsonga_-Rafael_Nadal,Jo Wilfried Tsonga ,Rafael Nadal,R,L,M,20080125,Australian Open,SF,,,Hard,,5,0,Isaac
-20071118-M-Masters_Cup-F-David_Ferrer-Roger_Federer,David Ferrer,Roger Federer,R,R,M,20071118,Masters Cup,F,,Centre,Hard,Pascal Maria,5,1,Edo
-20071112-M-Masters_Cup-SF-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20071112,Masters Cup,SF,,Centre,Hard,,3,1,Isaac
-20071112-M-Masters_Cup-RR-Novak_Djokovic-Richard_Gasquet,Novak Djokovic,Richard Gasquet,R,R,M,20071112,Masters Cup,RR,,,Hard,,3,1,Isaac
-20071028-M-Paris_Masters-F-Rafael_Nadal-David_Nalbandian,Rafael Nadal,David Nalbandian,L,R,M,20071028,Paris Masters,F,,,Hard,,3,1,Isaac
-20071028-M-Basel-F-Roger_Federer-Jarkko_Nieminen,Roger Federer,Jarkko Nieminen,R,L,M,20071028,Basel,F,,,Hard,,3,1,Isaac
-20071022-M-Basel-R16-Roger_Federer-Juan_Martin_Del_Potro,Roger Federer,Juan Martin Del Potro,R,R,M,20071022,Basel,R16,,,Hard,Mohamed Lahyani,3,1,Amy
-20070909-M-US_Open-F-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20070909,US Open,F,4:00 PM,Ashe,Hard,Jake Garner,5,1,Edo
-20070905-M-US_Open-QF-Roger_Federer-Andy_Roddick,Roger Federer,Andy Roddick,R,R,M,20070905,US Open,QF,19:00:00,Arthur Ashe,Hard,Enric Molina,5,1,Edo
-20070819-M-Cincinnati_Masters-F-Roger_Federer-James_Blake,Roger Federer,James Blake,R,R,M,20070819,Cincinnati Masters,F,3:00:00 PM,Stadium,Hard,Fergus Murphy,3,1,Edo
-20070810-M-Canada_Masters-SF-Roger_Federer-Radek_Stepanek,Roger Federer,Radek Stepanek,R,R,M,20070810,Canada Masters,SF,,,Hard,,3,1,Isaac
-20070805-M-Canada_Masters-F-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20070805,Canada Masters,F,Day Match,Montreal,Hard,Gerry Armstrong,3,1,Edo
-20070708-M-Wimbledon-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20070708,Wimbledon,F,,,Grass,Carlos Ramos,5,0,Amy
-20070610-M-Roland_Garros-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20070610,Roland Garros,F,,Chatrier,Clay,,5,0,Amy
-20070520-M-Hamburg_Masters-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20070520,Hamburg Masters,F,3:00 PM,,Clay,Cedric Mourier,3,1,Edo
-20070314-M-Indian_Wells_Masters-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20070314,Indian Wells Masters,F,,Stadium 1,Hard,Mohamed Lahyani,3,1,Isaac
-20070128-M-Australian_Open-F-Roger_Federer-Fernando_Gonzalez,Roger Federer,Fernando Gonzalez,R,R,M,20070128,Australian Open,F,,Laver,Hard,,5,0,jeffsackmann
-20070123-M-Australian_Open-QF-Rafael_Nadal-Fernando_Gonzalez,Rafael Nadal,Fernando Gonzalez,L,R,M,20070123,Australian Open,QF,,,Hard,,5,0,Isaac
-20061119-M-Masters_Cup-F-Roger_Federer-James_Blake,Roger Federer,James Blake,R,R,M,20061119,Masters Cup,F,,Centre,Hard,Lars Graf,5,1,Edo
-20061113-M-Shanghai-SF-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20061113,Shanghai,SF,,Center,Hard,Mohamed Lahyani,3,1,Isaac
-20061022-M-Madrid_Masters-F-Roger_Federer-Fernando_Gonzalez,Roger Federer,Fernando Gonzalez,R,R,M,20061022,Madrid Masters,F,3:00 PM,Central,Hard,Mohamed Lahyani,5,1,Edo
-20061010-M-Moscow-R32-Marat_Safin-Nicolas_Mahut,Marat Safin,Nicolas Mahut,R,R,M,20061010,Moscow,R32,,,Hard,,3,1,jeffsackmann
-20061008-M-Tokyo-F-Roger_Federer-Tim_Henman,Roger Federer,Tim Henman,R,R,M,20061008,Tokyo,F,2:00:00 PM,Centre,Hard,Fergus Murphy,3,1,Edo
-20060922-M-Davis_Cup_World_Group_PO-RR-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20060922,Davis Cup World Group PO,RR,,,Hard,,3,1,Isaac
-20060826-M-US_Open-F-Roger_Federer-Andy_Roddick,Roger Federer,Andy Roddick,R,R,M,20060826,US Open,F,,,Hard,Carlos Bernardes,3,1,Amy
-20060813-M-Canada_Masters-F-Roger_Federer-Richard_Gasquet,Roger Federer,Richard Gasquet,R,R,M,20060813,Canada Masters,F,Day Match,Toronto,Hard,Steve Ullrich,3,1,Edo
-20060709-M-Wimbledon-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20060709,Wimbledon,F,,,Grass,Gerry Armstrong,3,1,Amy
-20060701-M-Wimbledon-R32-Rafael_Nadal-Andre_Agassi,Rafael Nadal,Andre Agassi,L,R,M,20060701,Wimbledon,R32,,Centre,Grass,Gerry Armstrong,5,0,Salvo
-20060627-M-Wimbledon-R128-Roger_Federer-Richard_Gasquet,Roger Federer,Richard Gasquet,R,R,M,20060627,Wimbledon,R128,,,Grass,,5,0,Amy
-20060611-M-Roland_Garros-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20060611,Roland Garros,F,2:00 PM,Philippe Chatrier,Clay,,5,0,Edo
-20060514-M-Rome_Masters-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20060514,Rome Masters,F,,Centrale,Clay,Romano Grillotti,5,1,Salvo
-20060509-M-Rome_Masters-R64-Carlos_Moya-Rafael_Nadal,Carlos Moya,Rafael Nadal,R,L,M,20060509,Rome Masters,R64,,Centrale,Clay,Romano Grillotti,3,1,Salvo
-20060319-M-Indian_Wells_Masters-F-Roger_Federer-James_Blake,Roger Federer,James Blake,R,R,M,20060319,Indian Wells Masters,F,2:00:00 PM,Centre,Hard,Lars Graff,5,1,Edo
-20060318-M-Indian_Wells_Masters-SF-James_Blake-Rafael_Nadal,James Blake,Rafael Nadal,R,L,M,20060318,Indian Wells Masters,SF,,,Hard,,3,1,Isaac
-20060305-M-Dubai-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20060305,Dubai,F,,,Hard,,3,1,Isaac
-20060129-M-Australian_Open-F-Roger_Federer-Marcos_Baghdatis,Roger Federer,Marcos Baghdatis,R,R,M,20060129,Australian Open,F,,Laver,Hard,Pascal Maria,5,0,jeffsackmann
-20060123-M-Australian_Open-QF-David_Nalbandian-Fabrice_Santoro,David Nalbandian,Fabrice Santoro,R,R,M,20060123,Australian Open,QF,,Rod Laver Arena,Hard,,5,0,1HandBH
-20051120-M-Masters_Cup-F-Roger_Federer-David_Nalbandian,Roger Federer,David Nalbandian,R,R,M,20051120,Masters Cup,F,,,Hard,,5,1,jeffsackmann
-20051002-M-Bangkok-F-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20051002,Bangkok,F,,Centre,Hard,Lars Graff,3,1,Edo
-20050911-M-US_Open-F-Roger_Federer-Andre_Agassi,Roger Federer,Andre Agassi,R,R,M,20050911,US Open,F,,Arthur Ashe Stadium,Hard,,5,1,1HandBH
-20050908-M-US_Open-QF-Andre_Agassi-James_Blake,Andre Agassi,James Blake,R,R,M,20050908,US Open,QF,,Arthur Ashe Stadium,Hard,,5,1,Isaac
-20050821-M-Cincinnati_Masters-F-Andy_Roddick-Roger_Federer,Andy Roddick,Roger Federer,R,R,M,20050821,Cincinnati Masters,F,,Stadium,Hard,Carlos Bernardes,3,1,Edo
-20050815-M-Canada_Masters-F-Rafael_Nadal-Andre_Agassi,Rafael Nadal,Andre Agassi,L,R,M,20050815,Canada Masters,F,,Center,Hard,Lars Graff,3,1,Salvo
-20050703-M-Wimbledon-F-Roger_Federer-Andy_Roddick,Roger Federer,Andy Roddick,R,R,M,20050703,Wimbledon,F,2:00 PM,Centre,Grass,Wayne McKewen,5,0,Edo
-20050608-M-Roland_Garros-F-Mariano_Puerta-Rafael_Nadal,Mariano Puerta,Rafael Nadal,L,L,M,20050608,Roland Garros,F,,Chatrier,Clay,Pascal Maria,5,0,jeffsackmann
-20050601-M-Roland_Garros-SF-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20050601,Roland Garros,SF,,,Clay,,5,0,Isaac
-20050508-M-Rome_Masters-F-Rafael_Nadal-Guillermo_Coria,Rafael Nadal,Guillermo Coria,L,R,M,20050508,Rome Masters,F,,Centrale,Clay,Lars Graff,5,1,Salvo
-20050507-M-Rome_Masters-SF-Andre_Agassi-Guillermo_Coria,Andre Agassi,Guillermo Coria,R,R,M,20050507,Rome Masters,SF,,Centrale,Clay,Mohamed Lahyani,3,1,Salvo
-20050505-M-Rome_Masters-R16-Andy_Roddick-Fernando_Verdasco,Andy Roddick,Fernando Verdasco,R,L,M,20050505,Rome Masters,R16,,Centrale,Clay,Fergus Murphy,3,1,Salvo
-20050320-M-Indian_Wells_Masters-F-Lleyton_Hewitt-Roger_Federer,Lleyton Hewitt,Roger Federer,R,R,M,20050320,Indian Wells Masters,F,2:00:00 PM,Centre,Hard,Lars Graff,5,1,Edo
-20050318-M-Indian_Wells_Masters-SF-Roger_Federer-Guillermo_Canas,Roger Federer,Guillermo Canas,R,R,M,20050318,Indian Wells Masters,SF,,,Hard,,3,1,Isaac
-20050226-M-Acapulco-F-Rafael_Nadal-Albert_Montanes,Rafael Nadal,Albert Montanes,L,R,M,20050226,Acapulco,F,,Cancha Central,Clay,Carlos Bernardes,3,1,Salvo
-20050221-M-Dubai-SF-Roger_Federer-Andre_Agassi,Roger Federer,Andre Agassi,R,R,M,20050221,Dubai,SF,,,Hard,,3,1,Isaac
-20050130-M-Australian_Open-F-Lleyton_Hewitt-Marat_Safin,Lleyton Hewitt,Marat Safin,R,R,M,20050130,Australian Open,F,18:55,Rod Laver Arena,Hard,Carlos Ramos,5,0,1HandBH
-20050127-M-Australian_Open-SF-Roger_Federer-Marat_Safin,Roger Federer,Marat Safin,R,R,M,20050127,Australian Open,SF,20:00,Centre,Hard,Enric Molina,5,0,1HandBH
-20050108-M-Doha-F-Roger_Federer-Ivan_Ljubicic,Roger Federer,Ivan Ljubicic,R,R,M,20050108,Doha,F,6:00 PM,Center,Hard,Romano Grillotti,3,1,Edo
-20041115-M-Masters_Cup-F-Roger_Federer-Lleyton_Hewitt,Roger Federer,Lleyton Hewitt,R,R,M,20041115,Masters Cup,F,,,Hard,,3,1,Isaac
-20041107-M-Paris_Masters-F-Marat_Safin-Radek_Stepanek,Marat Safin,Radek Stepanek,R,R,M,20041107,Paris Masters,F,,,Indoor Hard,Lars Graff,5,1,jeffsackmann
-20041025-M-St_Petersburg-F-Karol_Beck-Mikhail_Youzhny,Karol Beck,Mikhail Youzhny,R,R,M,20041025,St Petersburg,F,,,Carpet,,3,1,Isaac
-20041003-M-Bangkok-F-Andy_Roddick-Roger_Federer,Andy Roddick,Roger Federer,R,R,M,20041003,Bangkok,F,,Centre,Hard,Carlos Bernardes,3,1,Edo
-20040912-M-US_Open-F-Lleyton_Hewitt-Roger_Federer,Lleyton Hewitt,Roger Federer,R,R,M,20040912,US Open,F,4:00 PM,Ashe,Hard,Norm Chryst,5,1,Edo
-20040807-M-Cincinnati_Masters-SF-Andy_Roddick-Andre_Agassi,Andy Roddick,Andre Agassi,R,R,M,20040807,Cincinnati Masters,SF,,,Hard,,3,1,Isaac
-20040801-M-Canada_Masters-F-Roger_Federer-Andy_Roddick,Roger Federer,Andy Roddick,R,R,M,20040801,Canada Masters,F,Day Match,Toronto,Hard,Carlos Bernardes,3,1,Edo
-20040726-M-Canada_Masters-R32-Andy_Roddick-Feliciano_Lopez,Andy Roddick,Feliciano Lopez,R,L,M,20040726,Canada Masters,R32,,Center ,Hard,,3,1,Isaac
-20040704-M-Wimbledon-F-Roger_Federer-Andy_Roddick,Roger Federer,Andy Roddick,R,R,M,20040704,Wimbledon,F,2:00 PM,Centre,Grass,Mike Morrissey,5,0,Edo
-20040613-M-Halle-F-Roger_Federer-Mardy_Fish,Roger Federer,Mardy Fish,R,R,M,20040613,Halle,F,2:00 PM,Stadion,Grass,Carlos Bernardes,3,0,Edo
-20040606-M-Roland_Garros-F-Gaston_Gaudio-Guillermo_Coria,Gaston Gaudio,Guillermo Coria,R,R,M,20040606,Roland Garros,F,3:00 PM,Philippe Chatrier,Clay,Cedric Mourier,5,0,Edo
-20040516-M-Hamburg_Masters-F-Roger_Federer-Guillermo_Coria,Roger Federer,Guillermo Coria,R,R,M,20040516,Hamburg Masters,F,3:00 PM,,Clay,Mohamed Lahyani,5,1,Edo
-20040328-M-Miami_Masters-R32-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20040328,Miami Masters,R32,,,Hard,,3,1,Isaac
-20040314-M-Indian_Wells_Masters-F-Roger_Federer-Tim_Henman,Roger Federer,Tim Henman,R,R,M,20040314,Indian Wells Masters,F,2:00:00 PM,Centre,Hard,Steve Ullrich,3,1,Edo
-20040201-M-Australian_Open-F-Roger_Federer-Marat_Safin,Roger Federer,Marat Safin,R,R,M,20040201,Australian Open,F,,,Hard,,5,0,Amy
-20031116-M-Masters_Cup-F-Roger_Federer-Andre_Agassi,Roger Federer,Andre Agassi,R,R,M,20031116,Masters Cup,F,16:00:00,Centre,Hard,Mike Morrissey,5,1,Edo
-20031110-M-Masters_Cup-RR-Roger_Federer-Juan_Carlos_Ferrero,Roger Federer,Juan Carlos Ferrero,R,R,M,20031110,Masters Cup,RR,,,Hard,,3,1,Isaac
-20030907-M-US_Open-F-Andy_Roddick-Juan_Carlos_Ferrero,Andy Roddick,Juan Carlos Ferrero,R,R,M,20030907,US Open,F,4:00 PM,Ashe,Hard,Wayne McKewen,5,1,Edo
-20030809-M-Canada_Masters-SF-Roger_Federer-Andy_Roddick,Roger Federer,Andy Roddick,R,R,M,20030809,Canada Masters,SF,,,Hard,,3,1,Isaac
-20030804-M-Canada_Masters-R16-Roger_Federer-Tommy_Robredo,Roger Federer,Tommy Robredo,R,R,M,20030804,Canada Masters,R16,,,Hard,,3,1,Isaac
-20030706-M-Wimbledon-F-Roger_Federer-Mark_Philippousis,Roger Federer,Mark Philippousis,R,R,M,20030706,Wimbledon,F,2:00 PM,Centre,Grass,Gerry Armostrong,5,0,Edo
-20030615-M-Halle-F-Roger_Federer-Nicolas_Kiefer,Roger Federer,Nicolas Kiefer,R,R,M,20030615,Halle,F,2:00 PM,Stadion,Grass,Romano Grillotti,3,1,Edo
-20030608-M-Roland_Garros-F-Martin_Verkerk-Juan_Carlos_Ferrero,Martin Verkerk,Juan Carlos Ferrero,R,R,M,20030608,Roland Garros,F,15:00:00,Philippe Chatrier,Clay,Pascal Maria,5,0,Edo
-20030505-M-Rome_Masters-R64-David_Ferrer-Andre_Agassi,David Ferrer,Andre Agassi,R,R,M,20030505,Rome Masters,R64,,Centrale,Clay,Romano Grillotti,3,1,Salvo
-20030330-M-Miami_Masters-F-Andre_Agassi-Carlos_Moya,Andre Agassi,Carlos Moya,R,R,M,20030330,Miami Masters,F,,Stadium,Hard,Carlos Bernardes,3,1,Salvo
-20030126-M-Australian_Open-F-Rainer_Schuettler-Andre_Agassi,Rainer Schuettler,Andre Agassi,R,R,M,20030126,Australian Open,F,3:00 PM,Rod Laver Arena,Hard,,5,0,Edo
-20021111-M-Masters_Cup-RR-Andre_Agassi-Jiri_Novak,Andre Agassi,Jiri Novak,R,R,M,20021111,Masters Cup,RR,,,Hard,,3,1,Isaac
-20020908-M-US_Open-F-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,20020908,US Open,F,4:00 PM,Ashe,Hard,Norm Chryst,5,0,Edo
-20020707-M-Wimbledon-F-David_Nalbandian-Lleyton_Hewitt,David Nalbandian,Lleyton Hewitt,R,R,M,20020707,Wimbledon,F,14:00:00,Centre,Grass,Mike Morrissey,5,0,Edo
-20020609-M-Roland_Garros-F-Albert_Costa-Juan_Carlos_Ferrero,Albert Costa,Juan Carlos Ferrero,R,R,M,20020609,Roland Garros,F,15:00:00,Philippe Chatrier,Clay,Pascal Maria,5,0,Edo
-20020428-M-Houston-SF-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,20020428,Houston,SF,,,Hard,,3,1,Isaac
-20020324-M-Miami_Masters-F-Roger_Federer-Andre_Agassi,Roger Federer,Andre Agassi,R,R,M,20020324,Miami Masters,F,3:00:00 PM,Centre,Hard,Lars Graff,5,1,Edo
-20020127-M-Australian_Open-F-Thomas_Johansson-Marat_Safin,Thomas Johansson,Marat Safin,R,R,M,20020127,Australian Open,F,3:00 PM,Centre,Hard,Dennis Overberg,5,0,Edo
-20020113-M-Sydney-F-Roger_Federer-Juan_Ignacio_Chela,Roger Federer,Juan Ignacio Chela,R,R,M,20020113,Sydney,F,,Centre,Hard,,3,1,Edo
-20011112-M-Masters_Cup-RR-Patrick_Rafter-Andre_Agassi,Patrick Rafter,Andre Agassi,R,R,M,20011112,Masters Cup,RR,,,Hard,,3,1,Isaac
-20010909-M-US_Open-F-Pete_Sampras-Lleyton_Hewitt,Pete Sampras,Lleyton Hewitt,R,R,M,20010909,US Open,F,3:00 PM,Ashe,Hard,,5,1,Edo
-20010906-M-US_Open-QF-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,20010906,US Open,QF,,Arthur Ashe Stadium,Hard,Steve Ullrich,5,1,Salvo
-20010709-M-Wimbledon-F-Goran_Ivanisevic-Patrick_Rafter,Goran Ivanisevic,Patrick Rafter,L,R,M,20010709,Wimbledon,F,12:00:00,Centre,Grass,Jorge Diaz,5,0,Edo
-20010702-M-Wimbledon-R16-Roger_Federer-Pete_Sampras,Roger Federer,Pete Sampras,R,R,M,20010702,Wimbledon,R16,14:30:00,Centre,Grass,Mohamed Lahyani,5,0,Edo
-20010611-M-Halle-QF-Patrick_Rafter-Roger_Federer,Patrick Rafter,Roger Federer,R,R,M,20010611,Halle,QF,,,Grass,,3,1,Amy
-20010610-M-Roland_Garros-F-Alex_Corretja-Gustavo_Kuerten,Alex Corretja,Gustavo Kuerten,R,R,M,20010610,Roland Garros,F,15:00:00,Philippe Chatrier,Clay,Cedric Mourier,5,0,Edo
-20010508-M-Rome_Masters-R32-Roger_Federer-Marat_Safin,Roger Federer,Marat Safin,R,R,M,20010508,Rome Masters,R32,,Centrale,Clay,Pedro Bravo,3,1,Salvo
-20010319-M-Miami_Masters-R32-Pete_Sampras-Andy_Roddick,Pete Sampras,Andy Roddick,R,R,M,20010319,Miami Masters,R32,,,Hard,,3,1,Isaac
-20010312-M-Indian_Wells-QF-Nicolas_Lapentti-Andre_Agassi,Nicolas Lapentti,Andre Agassi,R,R,M,20010312,Indian Wells,QF,,,Hard,,3,1,Isaac
-20010204-M-Milan-F-Julien_Boutter-Roger_Federer,Julien Boutter,Roger Federer,R,R,M,20010204,Milan,F,,Centre,Carpet,Lars Graf,3,1,Edo
-20010128-M-Australian_Open-F-Arnaud_Clement-Andre_Agassi,Arnaud Clement,Andre Agassi,R,R,M,20010128,Australian Open,F,3:00 PM,Centre,Hard,Wayne McKewen,5,0,Edo
-20001127-M-Tour_Finals-SF-Marat_Safin-Andre_Agassi,Marat Safin,Andre Agassi,R,R,M,20001127,Tour Finals,SF,,,Hard,,3,1,EricJ
-20001029-M-Basel-F-Thomas_Enqvist-Roger_Federer,Thomas Enqvist,Roger Federer,R,R,M,20001029,Basel,F,,Centre,Indoor Hard,,5,1,Daya
-20000910-M-US_Open-F-Pete_Sampras-Marat_Safin,Pete Sampras,Marat Safin,R,R,M,20000910,US Open,F,3:00 PM,Ashe,Hard,Steve Ullrich,5,0,Edo
-20000709-M-Wimbledon-F-Patrick_Rafter-Pete_Sampras,Patrick Rafter,Pete Sampras,R,R,M,20000709,Wimbledon,F,2:00 PM,Centre,Grass,Michael Morrissey,5,0,Edo
-20000612-M-Queens_Club-QF-Bob_Bryan-Pete_Sampras,Bob Bryan,Pete Sampras,L,R,M,20000612,Queens Club,QF,,,Grass,,3,1,Isaac
-20000611-M-Roland_Garros-F-Magnus_Norman-Gustavo_Kuerten,Magnus Norman,Gustavo Kuerten,R,R,M,20000611,Roland Garros,F,15:00:00,Central,Clay,Pareau,5,0,Edo
-20000514-M-Rome_Masters-F-Magnus_Norman-Gustavo_Kuerten,Magnus Norman,Gustavo Kuerten,R,R,M,20000514,Rome Masters,F,,Centrale,Clay,Lars Graff,5,1,Salvo
-20000130-M-Australian_Open-F-Yevgeny_Kafelnikov-Andre_Agassi,Yevgeny Kafelnikov,Andre Agassi,R,R,M,20000130,Australian Open,F,3:00 PM,Rod Laver Arena,Hard,,5,0,Edo
-19991122-M-Tour_Finals-RR-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,19991122,Tour Finals,RR,,,Hard,,3,1,Isaac
-19990912-M-US_Open-F-Todd_Martin-Andre_Agassi,Todd Martin,Andre Agassi,R,R,M,19990912,US Open,F,4:00 PM,Ashe,Hard,Norm Chryst,5,1,Edo
-19990716-M-Davis_Cup_World_Group_QF-RR-Roger_Federer-Xavier_Malisse,Roger Federer,Xavier Malisse,R,R,M,19990716,Davis Cup World Group QF,RR,,,Clay,,5,0,Daya
-19990704-M-Wimbledon-F-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,19990704,Wimbledon,F,2:00 PM,Centre,Grass,,5,0,Edo
-19990606-M-Roland_Garros-F-Andrei_Medvedev-Andre_Agassi,Andrei Medvedev,Andre Agassi,R,R,M,19990606,Roland Garros,F,15:00:00,Central,Clay,Pareau,5,0,Edo
-19990508-M-Hamburg_Masters-SF-Marcelo_Rios-Carlos_Moya,Marcelo Rios,Carlos Moya,L,R,M,19990508,Hamburg Masters,SF,,,Clay,,3,1,Isaac
-19990131-M-Australian_Open-F-Yevgeny_Kafelnikov-Thomas_Enqvist,Yevgeny Kafelnikov,Thomas Enqvist,R,R,M,19990131,Australian Open,F,3:00 PM,Rod Laver Arena,Hard,Wayne McKewen,5,0,Edo
-19981123-M-Tour_Finals-RR-Pete_Sampras-Karol_Kucera,Pete Sampras,Karol Kucera,R,R,M,19981123,Tour Finals,RR,,,Hard,,3,1,Isaac
-19981123-M-Tour_Finals-RR-Pete_Sampras-Carlos_Moya,Pete Sampras,Carlos Moya,R,R,M,19981123,Tour Finals,RR,,,Hard,,3,1,Isaac
-19981102-M-Paris_Masters-R32-Todd_Woodbridge-Marcelo_Rios,Todd Woodbridge,Marcelo Rios,R,L,M,19981102,Paris Masters,R32,,,Hard,,3,1,Isaac
-19981005-M-Basel-R32-Andre_Agassi-Roger_Federer,Andre Agassi,Roger Federer,R,R,M,19981005,Basel,R32,,,Hard,,3,1,Amy
-19980913-M-US_Open-F-Patrick_Rafter-Mark_Philippousis,Patrick Rafter,Mark Philippousis,R,R,M,19980913,US Open,F,,Ashe,Hard,Steve Ullrich,5,1,Edo
-19980817-M-New_Haven-R32-Pete_Sampras-Lleyton_Hewitt,Pete Sampras,Lleyton Hewitt,R,R,M,19980817,New Haven,R32,,,Hard,,3,1,Isaac
-19980810-M-Cincinnati_Masters-SF-Yevgeny_Kafelnikov-Patrick_Rafter,Yevgeny Kafelnikov,Patrick Rafter,R,R,M,19980810,Cincinnati Masters,SF,,,Hard,,3,1,Isaac
-19980705-M-Wimbledon-F-Goran_Ivanisevic-Pete_Sampras,Goran Ivanisevic,Pete Sampras,L,R,M,19980705,Wimbledon,F,2:00 PM,Centre,Grass,Michael Morrissey,5,0,Edo
-19980607-M-Roland_Garros-F-Alex_Corretja-Carlos_Moya,Alex Corretja,Carlos Moya,R,R,M,19980607,Roland Garros,F,15:00:00,Central,Clay,Bruno Rebeuh,5,0,Edo
-19980223-M-Philadelphia-F-Pete_Sampras-Thomas_Enqvist,Pete Sampras,Thomas Enqvist,R,R,M,19980223,Philadelphia,F,,,Hard,,3,1,Isaac
-19980209-M-San_Jose-F-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,19980209,San Jose,F,,,Hard,,3,1,Isaac
-19980201-M-Australian_Open-F-Petr_Korda-Marcelo_Rios,Petr Korda,Marcelo Rios,L,L,M,19980201,Australian Open,F,3:00 PM,Rod Laver Arena,Hard,,5,0,Edo
-19971110-M-Tour_Finals-SF-Pete_Sampras-Jonas_Bjorkman,Pete Sampras,Jonas Bjorkman,R,R,M,19971110,Tour Finals,SF,,,Hard,,3,1,Isaac
-19971110-M-Tour_Finals-RR-Patrick_Rafter-Pete_Sampras,Patrick Rafter,Pete Sampras,R,R,M,19971110,Tour Finals,RR,,,Hard,,3,1,Isaac
-19971027-M-Paris_Masters-SF-Pete_Sampras-Yevgeny_Kafelnikov,Pete Sampras,Yevgeny Kafelnikov,R,R,M,19971027,Paris Masters,SF,,,Hard,,3,1,Isaac
-19971020-M-Stuttgart_Masters-R32-Pete_Sampras-Magnus_Gustafsson,Pete Sampras,Magnus Gustafsson,R,R,M,19971020,Stuttgart Masters,R32,,,Hard,Rudi Berger,3,1,Isaac
-19970923-M-Grand_Slam_Cup-QF-Pete_Sampras-Jonas_Bjorkman,Pete Sampras,Jonas Bjorkman,R,R,M,19970923,Grand Slam Cup,QF,,,Hard,,3,1,Isaac
-19970907-M-US_Open-F-Patrick_Rafter-Greg_Rusedski,Patrick Rafter,Greg Rusedski,R,L,M,19970907,US Open,F,4:00 PM,Ashe,Hard,,5,1,Edo
-19970706-M-Wimbledon-F-Cedric_Pioline-Pete_Sampras,Cedric Pioline,Pete Sampras,R,R,M,19970706,Wimbledon,F,2:00 PM,Centre,Grass,Gerry Armstrong,5,0,Edo
-19970608-M-Roland_Garros-F-Sergi_Bruguera-Gustavo_Kuerten,Sergi Bruguera,Gustavo Kuerten,R,R,M,19970608,Roland Garros,F,15:00:00,Central,Clay,Bruno Rebeuh,5,0,Edo
-19970126-M-Australian_Open-F-Pete_Sampras-Carlos_Moya,Pete Sampras,Carlos Moya,R,R,M,19970126,Australian Open,F,3:00 PM,Centre,Hard,Wayne McKewen,5,0,Edo
-19961119-M-Tour_Finals-RR-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,19961119,Tour Finals,RR,,,Hard,,3,1,Isaac
-19960908-M-US_Open-F-Pete_Sampras-Michael_Chang,Pete Sampras,Michael Chang,R,R,M,19960908,US Open,F,6:00 PM,Ashe,Hard,Rich Kaufman,5,1,Edo
-19960707-M-Wimbledon-F-Richard_Kraijcek-Malivai_Washington,Richard Kraijcek,Malivai Washington,R,R,M,19960707,Wimbledon,F,2:00 PM,Centre,Grass,John Frame,5,0,Edo
-19960609-M-Roland_Garros-F-Michael_Stich-Yevgeny_Kafelnikov,Michael Stich,Yevgeny Kafelnikov,R,R,M,19960609,Roland Garros,F,15:00:00,Central,Clay,Bruno Rebeuh,5,0,Edo
-19960128-M-Australian_Open-F-Michael_Chang-Boris_Becker,Michael Chang,Boris Becker,R,R,M,19960128,Australian Open,F,3:00 PM,Rod Laver Arena,Hard,,5,0,Edo
-19950910-M-US_Open-F-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,19950910,US Open,F,4:00 PM,Ashe,Hard,Steve Ullrich,5,1,Edo
-19950709-M-Wimbledon-F-Pete_Sampras-Boris_Becker,Pete Sampras,Boris Becker,R,R,M,19950709,Wimbledon,F,2:00 PM,Centre,Grass,,5,0,Edo
-19950611-M-Roland_Garros-F-Michael_Chang-Thomas_Muster,Michael Chang,Thomas Muster,R,L,M,19950611,Roland Garros,F,15:00:00,Central,Clay,Bruno Rebeuh,5,0,Edo
-19950129-M-Australian_Open-F-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,19950129,Australian Open,F,3:00 PM,Centre,Hard,,5,0,Edo
-19941120-M-Tour_Finals-SF-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,19941120,Tour Finals,SF,,,Hard,,3,1,Isaac
-19941116-M-Tour_Finals-RR-Michael_Chang-Andre_Agassi,Michael Chang,Andre Agassi,R,R,M,19941116,Tour Finals,RR,,,Hard,,3,1,Isaac
-19940911-M-US_Open-F-Michael_Stich-Andre_Agassi,Michael Stich,Andre Agassi,R,R,M,19940911,US Open,F,4:00 PM,Ashe,Hard,David Littlefield,5,1,Edo
-19940703-M-Wimbledon-F-Pete_Sampras-Goran_Ivanisevic,Pete Sampras,Goran Ivanisevic,R,L,M,19940703,Wimbledon,F,2:00 PM,Centre,Grass,Michael Morrissey,5,0,Edo
-19940605-M-Roland_Garros-F-Sergi_Bruguera-Alberto_Berasategui,Sergi Bruguera,Alberto Berasategui,R,R,M,19940605,Roland Garros,F,15:00:00,Central,Clay,Bruno Rebeuh,5,0,Edo
-19940130-M-Australian_Open-F-Pete_Sampras-Todd_Martin,Pete Sampras,Todd Martin,R,R,M,19940130,Australian Open,F,3:00 PM,Centre,Hard,Wayne McKewen,5,0,Edo
-19930912-M-US_Open-F-Cedric_Pioline-Pete_Sampras,Cedric Pioline,Pete Sampras,R,R,M,19930912,US Open,F,4:00 PM,Ashe,Hard,,5,0,Edo
-19930704-M-Wimbledon-F-Jim_Courier-Pete_Sampras,Jim Courier,Pete Sampras,R,R,M,19930704,Wimbledon,F,2:00 PM,Centre,Grass,Sultan Gangji,5,0,Edo
-19930606-M-Roland_Garros-F-Jim_Courier-Sergi_Bruguera,Jim Courier,Sergi Bruguera,R,R,M,19930606,Roland Garros,F,15:00:00,Central,Clay,Bruno Rebeuh,5,0,Edo
-19930131-M-Australian_Open-F-Jim_Courier-Stefan_Edberg,Jim Courier,Stefan Edberg,R,R,M,19930131,Australian Open,F,2:00 PM,Centre,Hard,Wayne McKewen,5,0,Edo
-19920913-M-US_Open-F-Pete_Sampras-Stefan_Edberg,Pete Sampras,Stefan Edberg,R,R,M,19920913,US Open,F,4:00 PM,Ashe,Hard,,5,1,Edo
-19920705-M-Wimbledon-F-Andre_Agassi-Goran_Ivanisevic,Andre Agassi,Goran Ivanisevic,R,L,M,19920705,Wimbledon,F,2:00 PM,Centre,Grass,John Frame,5,0,Edo
-19920704-M-Wimbledon-SF-John_Mcenroe-Andre_Agassi,John Mcenroe,Andre Agassi,L,R,M,19920704,Wimbledon,SF,,Centre,Grass,Jay Snyder,5,0,Salvo
-19920607-M-Roland_Garros-F-Jim_Courier-Petr_Korda,Jim Courier,Petr Korda,R,L,M,19920607,Roland Garros,F,15:00:00,Central,Clay,Bruno Rebeuh,5,0,Edo
-19920126-M-Australian_Open-F-Jim_Courier-Stefan_Edberg,Jim Courier,Stefan Edberg,R,R,M,19920126,Australian Open,F,,Centre,Hard,,5,0,Edo
-19910908-M-US_Open-F-Jim_Courier-Stefan_Edberg,Jim Courier,Stefan Edberg,R,R,M,19910908,US Open,F,3:00 PM,Stadium,Hard,Norm Chryst,5,1,Edo
-19910707-M-Wimbledon-F-Boris_Becker-Michael_Stich,Boris Becker,Michael Stich,R,R,M,19910707,Wimbledon,F,2:00 PM,Centre,Grass,John Bryson,5,0,Edo
-19910609-M-Roland_Garros-F-Andre_Agassi-Jim_Courier,Andre Agassi,Jim Courier,R,R,M,19910609,Roland Garros,F,15:00:00,Central,Clay,Bruno Rebeuh,5,0,Edo
-19910127-M-Australian_Open-F-Ivan_Lendl-Boris_Becker,Ivan Lendl,Boris Becker,R,R,M,19910127,Australian Open,F,,Centre,Hard,,5,0,Edo
-19900909-M-US_Open-F-Andre_Agassi-Pete_Sampras,Andre Agassi,Pete Sampras,R,R,M,19900909,US Open,F,4:00 PM,Ashe,Hard,David Littlefield,5,1,Edo
-19900708-M-Wimbledon-F-Boris_Becker-Stefan_Edberg,Boris Becker,Stefan Edberg,R,R,M,19900708,Wimbledon,F,2:00 PM,Centre,Grass,Jeremy Shales,5,0,Edo
-19900611-M-Queens_Club-F-Boris_Becker-Ivan_Lendl,Boris Becker,Ivan Lendl,R,R,M,19900611,Queens Club,F,,,Grass,,3,1,Isaac
-19900610-M-Roland_Garros-F-Andres_Gomez-Andre_Agassi,Andres Gomez,Andre Agassi,L,R,M,19900610,Roland Garros,F,15:00:00,Central,Clay,Rebeuh,5,0,Edo
-19900128-M-Australian_Open-F-Ivan_Lendl-Stefan_Edberg,Ivan Lendl,Stefan Edberg,R,R,M,19900128,Australian Open,F,,Centre,Hard,,5,0,Edo
-19890910-M-US_Open-F-Boris_Becker-Ivan_Lendl,Boris Becker,Ivan Lendl,R,R,M,19890910,US Open,F,4:00 PM,Centre,Hard,Dana Loconto,5,0,Edo
-19890709-M-Wimbledon-F-Boris_Becker-Stefan_Edberg,Boris Becker,Stefan Edberg,R,R,M,19890709,Wimbledon,F,,Centre,Grass,,5,0,Edo
-19890611-M-Roland_Garros-F-Michael_Chang-Stefan_Edberg,Michael Chang,Stefan Edberg,R,R,M,19890611,Roland Garros,F,15:00:00,Central,Clay,Bruno Rebeuh,5,0,Edo
-19890129-M-Australian_Open-F-Ivan_Lendl-Miroslav_Mecir,Ivan Lendl,Miroslav Mecir,R,R,M,19890129,Australian Open,F,,Centre,Hard,Rudy Berger,5,0,Edo
-19881202-M-Masters_Cup-F-Boris_Becker-Ivan_Lendl,Boris Becker,Ivan Lendl,R,R,M,19881202,Masters Cup,F,,,Carpet (Hard),,5,1,Isaac
-19880911-M-US_Open-F-Mats_Wilander-Ivan_Lendl,Mats Wilander,Ivan Lendl,R,R,M,19880911,US Open,F,4:00 PM,Centre,Hard,Jay Snyder,5,1,Edo
-19880704-M-Wimbledon-F-Stefan_Edberg-Boris_Becker,Stefan Edberg,Boris Becker,R,R,M,19880704,Wimbledon,F,2:00 PM,Centre,Grass,Gerry Armstrong,5,0,Edo
-19880605-M-Roland_Garros-F-Mats_Wilander-Henri_Leconte,Mats Wilander,Henri Leconte,R,L,M,19880605,Roland Garros,F,15:00:00,Central,Clay,Kaufman,5,0,Edo
-19880124-M-Australian_Open-F-Pat_Cash-Mats_Wilander,Pat Cash,Mats Wilander,R,R,M,19880124,Australian Open,F,3:00 PM,Centre,Hard,Richard Ings,5,0,Edo
-19870914-M-US_Open-F-Ivan_Lendl-Mats_Wilander,Ivan Lendl,Mats Wilander,R,R,M,19870914,US Open,F,2:00 PM,Stadium,Hard,Richard Kaufman,5,1,Edo
-19870901-M-US_Open-QF-John_Mcenroe-Ivan_Lendl,John Mcenroe,Ivan Lendl,L,R,M,19870901,US Open,QF,,,Clay,,3,1,Isaac
-19870705-M-Wimbledon-F-Pat_Cash-Ivan_Lendl,Pat Cash,Ivan Lendl,R,R,M,19870705,Wimbledon,F,2:00 pm,Centre,Grass,Winyard,5,0,Edo
-19870125-M-Australian_Open-F-Stefan_Edberg-Pat_Cash,Stefan Edberg,Pat Cash,R,R,M,19870125,Australian Open,F,2:00 PM,Kooyong,Grass,Jeremy Shales,5,0,Edo
-19860907-M-US_Open-F-Miroslav_Mecir-Ivan_Lendl,Miroslav Mecir,Ivan Lendl,R,R,M,19860907,US Open,F,2:00 PM,Stadium,Hard,Don Wiley,5,1,Edo
-19860706-M-Wimbledon-F-Boris_Becker-Ivan_Lendl,Boris Becker,Ivan Lendl,R,R,M,19860706,Wimbledon,F,2:00 pm,Centre,Grass,Grime,5,0,Edo
-19851208-M-Australian_Open-F-Stefan_Edberg-Mats_Wilander,Stefan Edberg,Mats Wilander,R,R,M,19851208,Australian Open,F,,Kooyong,Grass,Richard Kafmann,5,0,Edo
-19850908-M-US_Open-F-John_Mcenroe-Ivan_Lendl,John Mcenroe,Ivan Lendl,L,R,M,19850908,US Open,F,4:00 PM,Centre,Hard,,5,1,Edo
-19850825-M-Cincinnati-F-Mats_Wilander-Boris_Becker,Mats Wilander,Boris Becker,R,R,M,19850825,Cincinnati,F,,Center,Hard,Jeremy Shales,3,1,Salvo
-19850707-M-Wimbledon-F-Boris_Becker-Kevin_Curren,Boris Becker,Kevin Curren,R,R,M,19850707,Wimbledon,F,2:00 PM,Centre,Grass,,5,0,Edo
-19850609-M-Roland_Garros-F-Mats_Wilander-Ivan_Lendl,Mats Wilander,Ivan Lendl,R,R,M,19850609,Roland Garros,F,15:00:00,Central,Clay,Jacques Dorfmann,5,0,Edo
-19840909-M-US_Open-F-John_Mcenroe-Ivan_Lendl,John Mcenroe,Ivan Lendl,L,R,M,19840909,US Open,F,4:00 PM,Centre,Hard,,5,1,Edo
-19840708-M-Wimbledon-F-John_Mcenroe-Jimmy_Connors,John Mcenroe,Jimmy Connors,L,L,M,19840708,Wimbledon,F,2:00 PM,Centre,Grass,David Mercer,5,0,Edo
-19840610-M-Roland_Garros-F-John_Mcenroe-Ivan_Lendl,John Mcenroe,Ivan Lendl,L,R,M,19840610,Roland Garros,F,15:00:00,Central,Clay,Jacques Dorfmann,5,0,Edo
-19840506-M-Forest_Hills_WCT-F-John_Mcenroe-Ivan_Lendl,John Mcenroe,Ivan Lendl,L,R,M,19840506,Forest Hills WCT,F,,,Clay,,3,1,Isaac
-19831211-M-Australian_Open-F-Mats_Wilander-Ivan_Lendl,Mats Wilander,Ivan Lendl,R,R,M,19831211,Australian Open,F,3:00 PM,Kooyong,Grass,,5,0,Edo
-19830911-M-US_Open-F-Jimmy_Connors-Ivan_Lendl,Jimmy Connors,Ivan Lendl,L,R,M,19830911,US Open,F,4:00 PM,Centre,Hard,Kaufman,5,1,Edo
-19830703-M-Wimbledon-F-Chris_Lewis-John_Mcenroe,Chris Lewis,John Mcenroe,R,L,M,19830703,Wimbledon,F,2:00 PM,Centre,Grass,Malcom Huntington,5,0,Edo
-19830605-M-Roland_Garros-F-Mats_Wilander-Yannick_Noah,Mats Wilander,Yannick Noah,R,R,M,19830605,Roland Garros,F,14:00:00,Central,Clay,Jacques Dorfmann,5,0,Edo
-19821213-M-Australian_Open-F-Steve_Denton-Johan_Kriek,Steve Denton,Johan Kriek,R,R,M,19821213,Australian Open,F,3:00 PM,Kooyong,Grass,Jim Entink,5,0,Edo
-19820912-M-US_Open-F-Jimmy_Connors-Ivan_Lendl,Jimmy Connors,Ivan Lendl,L,R,M,19820912,US Open,F,4:00 PM,Centre,Hard,Jay Snyder,5,1,Edo
-19820704-M-Wimbledon-F-John_Mcenroe-Jimmy_Connors,John Mcenroe,Jimmy Connors,L,L,M,19820704,Wimbledon,F,2:00 PM,Centre,Grass,,5,0,Edo
-19820606-M-Roland_Garros-F-Guillermo_Vilas-Mats_Wilander,Guillermo Vilas,Mats Wilander,L,R,M,19820606,Roland Garros,F,14:00:00,Central,Clay,Jacques Dorfmann,5,0,Edo
-19810913-M-US_Open-F-John_Mcenroe-Bjorn_Borg,John Mcenroe,Bjorn Borg,L,R,M,19810913,US Open,F,,Centre,Hard,,5,1,Edo
-19810704-M-Wimbledon-F-John_Mcenroe-Bjorn_Borg,John Mcenroe,Bjorn Borg,L,R,M,19810704,Wimbledon,F,2:00 PM,Centre,Grass,Bob Jenkins,5,0,Edo
-19810607-M-Roland_Garros-F-Bjorn_Borg-Ivan_Lendl,Bjorn Borg,Ivan Lendl,R,R,M,19810607,Roland Garros,F,14:30:00,Central,Clay,Jacques Dorfmann,5,0,Edo
-19810104-M-Australian_Open-F-Kim_Warwick-Brian_Teacher,Kim Warwick,Brian Teacher,R,R,M,19810104,Australian Open,F,3:00 PM,Kooyong,Grass,Max Atkins,5,0,Edo
-19800907-M-US_Open-F-John_Mcenroe-Bjorn_Borg,John Mcenroe,Bjorn Borg,L,R,M,19800907,US Open,F,4:00 PM,Centre,Hard,Slye,5,1,Edo
-19800705-M-Wimbledon-F-John_Mcenroe-Bjorn_Borg,John Mcenroe,Bjorn Borg,L,R,M,19800705,Wimbledon,F,2:00 PM,Centre,Grass,Gerry Armstrong,5,0,Eric
-19800608-M-Roland_Garros-F-Vitas_Gerulaitis-Bjorn_Borg,Vitas Gerulaitis,Bjorn Borg,R,R,M,19800608,Roland Garros,F,14:00:00,Central,Clay,,5,0,Edo
-19780611-M-Roland_Garros-F-Bjorn_Borg-Guillermo_Vilas,Bjorn Borg,Guillermo Vilas,R,L,M,19780611,Roland Garros,F,,,Clay,,3,1,Isaac
-19780125-M-Pepsi_Grand_Slam-SF-Brian_Gottfried-Bjorn_Borg,Brian Gottfried,Bjorn Borg,R,R,M,19780125,Pepsi Grand Slam,SF,,,Clay,,3,1,Isaac
-19751219-M-Davis_Cup_World_Group_F-RR-Bjorn_Borg-Jiri_Hrebec,Bjorn Borg,Jiri Hrebec,R,R,M,19751219,Davis Cup World Group F,RR,,,Hard,,3,1,Isaac
+20150505-M-Madrid_Masters-R64-Fernando_Verdasco-Guillermo_Garcia_Lopez,Fernando Verdasco,Guillermo Garcia Lopez,L,R,M,20150505,Madrid Masters,R64,3:15 PM,Centre,Clay,,3,1,DavidAu
+20150503-M-Istanbul-F-Roger_Federer-Pablo_Cuevas,Roger Federer,Pablo Cuevas,R,R,M,20150503.0,Istanbul,F,4:00 PM,Centre,Clay,,3.0,1,Edo
+20150503-M-Estoril-F-Richard_Gasquet-Nick_Kyrgios,Richard Gasquet,Nick Kyrgios,R,R,M,20150503.0,Estoril,F,,,Clay,,3.0,1,Isaac
+20150502-M-Munich-QF-Philipp_Kohlschreiber-David_Goffin,Philipp Kohlschreiber,David Goffin,R,R,M,20150502.0,Munich,QF,,,Clay,James Keothavong,3.0,1,pvtennis
+20150502-M-Munich-QF-Andy_Murray-Lukas_Rosol,Andy Murray,Lukas Rosol,R,R,M,20150502.0,Munich,QF,10:00 AM,Centre,Clay,Cedric Mourier,3.0,1,Edo
+20150502-M-Istanbul-SF-Roger_Federer-Diego_Sebastian_Schwartzman,Roger Federer,Diego Sebastian Schwartzman,R,R,M,20150502.0,Istanbul,SF,3:00 PM,Centre,Clay,Mohamed Lahyani,3.0,1,Edo
+20150502-M-Istanbul-SF-Grigor_Dimitrov-Pablo_Cuevas,Grigor Dimitrov,Pablo Cuevas,R,R,M,20150502.0,Istanbul,SF,5:00 PM,Centre,Clay,R. Lichtenste,3.0,1,Edo
+20150501-M-Estoril-QF-Richard_Gasquet-Nicolas_Almagro,Richard Gasquet,Nicolas Almagro,R,R,M,20150501.0,Estoril,QF,2:45 PM,,Clay,Adel Nour,3.0,1,ChapelHeel66
+20150430-M-Munich-R16-Fabio_Fognini-Dominic_Thiem,Fabio Fognini,Dominic Thiem,R,R,M,20150430.0,Munich,R16,3:45 PM,Centre,Clay,,3.0,1,DavidAurora
+20150430-M-Istanbul-R16-Denis_Istomin-Thomaz_Bellucci,Denis Istomin,Thomaz Bellucci,R,L,M,20150430.0,Istanbul,R16,14:30 PM,Centre,Clay,,3.0,1,DavidAurora
+20150429-M-Istanbul-R16-Diego_Sebastian_Schwartzman-Jurgen_Melzer,Diego Sebastian Schwartzman,Jurgen Melzer,R,L,M,20150429.0,Istanbul,R16,,,Clay,,3.0,1,CEM
+20150426-M-Bucharest-F-Guillermo_Garcia_Lopez-Jiri_Vesely,Guillermo Garcia Lopez,Jiri Vesely,R,L,M,20150426.0,Bucharest,F,2:30 PM,Centre,Clay,Damien Dumusois,3.0,1,David Aurora
+20150425-M-Bucharest-SF-Jiri_Vesely-Daniel_Gimeno_Traver,Jiri Vesely,Daniel Gimeno Traver,L,R,M,20150425.0,Bucharest,SF,1:00 PM,Centre,Clay,,3.0,1,DavidAurora
+20150424-M-Bucharest-QF-Lukas_Rosol-Guillermo_Garcia_Lopez,Lukas Rosol,Guillermo Garcia Lopez,R,R,M,20150424.0,Bucharest,QF,11:50 AM,Central,Clay,Damien Dumusois,3.0,1,ChapelHeel66
+20150424-M-Barcelona-QF-Roberto_Bautista_Agut-Kei_Nishikori,Roberto Bautista Agut,Kei Nishikori,R,R,M,20150424.0,Barcelona,QF,12:30 PM,Centre,Clay,Carlos Bernardes,3.0,1,DavidAurora
+20150423-M-Barcelona-R16-Kei_Nishikori-Santiago_Giraldo,Kei Nishikori,Santiago Giraldo,R,R,M,20150423.0,Barcelona,R16,11:00 AM,Centre,Clay,Ali Nili,3.0,1,DavidAurora
+20150421-M-Barcelona-R64-Fernando_Verdasco-Andrey_Rublev,Fernando Verdasco,Andrey Rublev,L,R,M,20150421.0,Barcelona,R64,1:30 PM,Centre,Clay,Mohamed Lahyani,3.0,1,DavidAurora
+20150420-M-Barcelona-R64-Pablo_Carreno_Busta-Teymuraz_Gabashvili,Pablo Carreno Busta,Teymuraz Gabashvili,R,R,M,20150420.0,Barcelona,R64,5:30 PM,Centre,Clay,Ali Nili,3.0,1,DavidAurora
+20150419-M-Monte_Carlo_Masters-F-Novak_Djokovic-Tomas_Berdych,Novak Djokovic,Tomas Berdych,R,R,M,20150419.0,Monte Carlo Masters,F,2.45 PM,Ranieri III,Clay,Damien Dumusois,3.0,1,Edo
+20150418-M-Monte_Carlo_Masters-SF-Tomas_Berdych-Gael_Monfils,Tomas Berdych,Gael Monfils,R,R,M,20150418.0,Monte Carlo Masters,SF,1:00 PM,Centre,Clay,Carlos Bernardes,3.0,1,DavidAurora
+20150418-M-Monte_Carlo_Masters-SF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20150418.0,Monte Carlo Masters,SF,3.40PM,Centre,Clay,CŽdric Mourier,3.0,0,Edo
+20150417-M-Monte_Carlo_Masters-QF-Milos_Raonic-Tomas_Berdych,Milos Raonic,Tomas Berdych,R,R,M,20150417.0,Monte Carlo Masters,QF,10:30 AM,Centre,Clay,Manuel Messina,3.0,1,DavidAurora
+20150417-M-Monte_Carlo_Masters-QF-Grigor_Dimitrov-Gael_Monfils,Grigor Dimitrov,Gael Monfils,R,R,M,20150417.0,Monte Carlo Masters,QF,12:00 PM,Centre,Clay,Gianluca Moscarella,3.0,1,DavidAurora
+20150417-M-Monte_Carlo_Masters-QF-David_Ferrer-Rafael_Nadal,David Ferrer,Rafael Nadal,R,L,M,20150417.0,Monte Carlo Masters,QF,2:40 PM,Centre,Clay,Damien Dumusois,3.0,1,DavidAurora
+20150416-M-Monte_Carlo_Masters-R16-Roger_Federer-Gael_Monfils,Roger Federer,Gael Monfils,R,R,M,20150416.0,Monte Carlo Masters,R16,,Central,Clay,Manuel Messina,3.0,1,FedFan
+20150415-M-Monte_Carlo_Masters-R32-Jo_Wilfried_Tsonga-David_Goffin,Jo Wilfried Tsonga,David Goffin,R,R,M,20150415.0,Monte Carlo Masters,R32,,Central,Clay,Carlos Bernardes,3.0,1,pvtennis
+20150414-M-Monte_Carlo_Masters-R64-Tommy_Robredo-Andreas_Seppi,Tommy Robredo,Andreas Seppi,R,R,M,20150414.0,Monte Carlo Masters,R64,12:30 PM,,Court des Princes,Damien Dumusois,3.0,1,DavidAurora
+20150414-M-Monte_Carlo_Masters-R64-Dominic_Thiem-Lucas_Pouille,Dominic Thiem,Lucas Pouille,R,R,M,20150414.0,Monte Carlo Masters,R64,10:30 AM,,Clay,,3.0,1,DavidAurora
+20150413-M-Monte_Carlo_Masters-R64-Mikhail_Kukushkin-Philipp_Kohlschreiber,Mikhail Kukushkin,Philipp Kohlschreiber,R,R,M,20150413.0,Monte Carlo Masters,R64,11:00 AM,Court Des Princes,Clay,,3.0,1,dropshot
+20150413-M-Monte_Carlo_Masters-R64-Borna_Coric-Alexandr_Dolgopolov,Borna Coric,Alexandr Dolgopolov,R,R,M,20150413.0,Monte Carlo Masters,R64,12:00 PM,Centre,Clay,Carlos Bernardes,3.0,1,DavidAurora
+20150410-M-Casablanca-QF-Nicolas_Almagro-Martin_Klizan,Nicolas Almagro,Martin Klizan,R,L,M,20150410.0,Casablanca,QF,,,Clay,Roland Herfel,3.0,1,DavidAurora
+20150409-M-Casablanca-R16-Daniel_Gimeno_Traver-Mikhail_Kukushkin,Daniel Gimeno Traver,Mikhail Kukushkin,R,R,M,20150409.0,Casablanca,R16,3:00 PM,,Clay,Mohamed El Jennati,3.0,1,DavidAurora
+20150408-M-Casablanca-R16-Carlos_Berlocq-Nicolas_Almagro,Carlos Berlocq,Nicolas Almagro,R,R,M,20150408.0,Casablanca,R16,1:00 PM,,Clay,,3.0,1,DavidAurora
+20150407-M-Casablanca-R32-Nicolas_Almagro-Taro_Daniel,Nicolas Almagro,Taro Daniel,R,R,M,20150407.0,Casablanca,R32,,,Clay,Roland Herfel,3.0,1,DavidAurora
+20150406-M-Casablanca-R32-Carlos_Berlocq-Pablo_Carreno_Busta,Carlos Berlocq,Pablo Carreno Busta,R,R,M,20150406.0,Casablanca,R32,11:00 AM,,Clay,Adel Nour,3.0,1,DavidAurora
+20150405-M-Miami_Masters-F-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20150405.0,Miami Masters,F,,Center,Hard,Damien Dumusois,3.0,1,1HandBH
+20150401-M-Miami_Masters-QF-Dominic_Thiem-Andy_Murray,Dominic Thiem,Andy Murray,R,R,M,20150401.0,Miami Masters,QF,,Stadium,Hard,,3.0,1,chrisG
+20150331-M-San_Luis_Potosi_CH-R32-Giovanni_Lapentti-Chase_Buchanan,Giovanni Lapentti,Chase Buchanan,R,R,M,20150331.0,San Luis Potosi CH,R32,,,Clay,,3.0,1,Amy
+20150330-M-Miami_Masters-R32-Viktor_Troicki-Kei_Nishikori,Viktor Troicki,Kei Nishikori,R,R,M,20150330.0,Miami Masters,R32,,,Hard,,3.0,1,Amy
+20150329-M-Miami_Masters-R32-Leonardo_Mayer-Kevin_Anderson,Leonardo Mayer,Kevin Anderson,R,R,M,20150329.0,Miami Masters,R32,,1,Hard,,3.0,1,Jenn
+20150328-M-Miami_Masters-R64-Tim_Smyczek-Jo_Wilfried_Tsonga,Tim Smyczek,Jo Wilfried Tsonga,R,R,M,20150328.0,Miami Masters,R64,,Stadium,Hard,,3.0,1,pvtennis
+20150328-M-Miami_Masters-R64-Mikhail_Youzhny-Kei_Nishikori,Mikhail Youzhny,Kei Nishikori,R,R,M,20150328.0,Miami Masters,R64,,Grandstand,Hard,,3.0,0,GETJr
+20150325-M-Miami_Masters-R64-Vasek_Pospisil-Juan_Martin_Del_Potro,Vasek Pospisil,Juan Martin Del Potro,R,R,M,20150325.0,Miami Masters,R64,,,Hard,,3.0,1,Amy
+20150325-M-Miami_Masters-R128-Diego_Sebastian_Schwartzman-Dominic_Thiem,Diego Sebastian Schwartzman,Dominic Thiem,R,R,M,20150325.0,Miami Masters,R128,,Grandstand,Hard,,3.0,1,pablo
+20150322-M-Indian_Wells_Masters-F-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20150322.0,Indian Wells Masters,F,,Center,Hard,,3.0,1,camyu19
+20150321-M-Indian_Wells_Masters-SF-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20150321.0,Indian Wells Masters,SF,11am,Stadium 1,Hard,Carlos Bernardes,3.0,1,Edo
+20150321-M-Indian_Wells_Masters-SF-Milos_Raonic-Roger_Federer,Milos Raonic,Roger Federer,R,R,M,20150321.0,Indian Wells Masters,SF,,,Hard,,3.0,1,Edged
+20150321-M-Indian_Wells_Masters-QF-Milos_Raonic-Rafael_Nadal,Milos Raonic,Rafael Nadal,R,L,M,20150321.0,Indian Wells Masters,QF,,,Hard,,3.0,1,Edged
+20150320-M-Indian_Wells_Masters-QF-Tomas_Berdych-Roger_Federer,Tomas Berdych,Roger Federer,R,R,M,20150320.0,Indian Wells Masters,QF,,,Hard,Fergus Murphy,3.0,1,Amy
+20150318-M-Indian_Wells_Masters-R16-Roger_Federer-Jack_Sock,Roger Federer,Jack Sock,R,R,M,20150318.0,Indian Wells Masters,R16,,,Hard,,3.0,1,Amy
+20150318-M-Indian_Wells_Masters-R16-Milos_Raonic-Tommy_Robredo,Milos Raonic,Tommy Robredo,R,R,M,20150318.0,Indian Wells Masters,R16,,,Hard,,3.0,1,Edged
+20150316-M-Indian_Wells_Masters-R32-Feliciano_Lopez-Pablo_Cuevas,Feliciano Lopez,Pablo Cuevas,L,R,M,20150316.0,Indian Wells Masters,R32,,Stadium 2,Hard,Mo,3.0,1,Jenn
+20150316-M-Indian_Wells_Masters-R32-David_Ferrer-Bernard_Tomic,David Ferrer,Bernard Tomic,R,R,M,20150316.0,Indian Wells Masters,R32,,,Hard,Adel Nour,3.0,1,Amy
+20150315-M-Indian_Wells_Masters-R64-Diego_Sebastian_Schwartzman-Roger_Federer,Diego Sebastian Schwartzman,Roger Federer,R,R,M,20150315.0,Indian Wells Masters,R64,,Stadium 1,Hard,,3.0,1,FedFan
+20150313-M-Indian_Wells_Masters-R128-Sam_Querrey-Sergiy_Stakhovsky,Sam Querrey,Sergiy Stakhovsky,R,R,M,20150313.0,Indian Wells Masters,R128,,Stadium 1,Hard,,3.0,1,Isaac
+20150312-M-Indian_Wells_Masters-R128-Andreas_Haider_Maurer-Borna_Coric,Andreas Haider Maurer,Borna Coric,R,R,M,20150312.0,Indian Wells Masters,R128,,Stadium 3,Hard,,3.0,1,chrisG
+20150228-M-Dubai-F-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20150228.0,Dubai,F,,,Hard,Mohamed Lahyani,3.0,1,FedFan
+20150227-M-Dubai-SF-Roger_Federer-Borna_Coric,Roger Federer,Borna Coric,R,R,M,20150227.0,Dubai,SF,,,Hard,Kader Nouni,3.0,1,FedFan
+20150226-M-Dubai-QF-Novak_Djokovic-Marsel_Ilhan,Novak Djokovic,Marsel Ilhan,R,R,M,20150226.0,Dubai,QF,,Centre,Hard,Kader Nouni,3.0,1,Salvo
+20150226-M-Dubai-QF-Andy_Murray-Borna_Coric,Andy Murray,Borna Coric,R,R,M,20150226.0,Dubai,QF,,,Hard,,3.0,1,chrisG
+20150223-M-Buenos_Aires-QF-Rafael_Nadal-Federico_Delbonis,Rafael Nadal,Federico Delbonis,L,L,M,20150223.0,Buenos Aires,QF,,Center,Clay,,3.0,1,Isaac
+20150221-M-Marseille-SF-Sergiy_Stakhovsky-Gilles_Simon,Sergiy Stakhovsky,Gilles Simon,R,R,M,20150221.0,Marseille,SF,,,Hard,James Keothavong,3.0,1,pvtennis
+20150221-M-Marseille-SF-Roberto_Bautista_Agut-Gael_Monfils,Roberto Bautista Agut,Gael Monfils,R,R,M,20150221.0,Marseille,SF,,,Hard,,3.0,1,pvtennis
+20150220-M-Delray_Beach-QF-Steve_Johnson-Ivo_Karlovic,Steve Johnson,Ivo Karlovic,R,R,M,20150220.0,Delray Beach,QF,8:10 PM,,Hard,Pascal Maria,3.0,1,ChapelHeel66
+20150219-M-Rio_de_Janeiro-R16-Rafael_Nadal-Pablo_Carreno_Busta,Rafael Nadal,Pablo Carreno Busta,L,R,M,20150219.0,Rio de Janeiro,R16,,Center Court,Clay,Adel Nour,3.0,1,Isaac
+20150218-M-Delray_Beach-R16-Thanasi_Kokkinakis-Ivo_Karlovic,Thanasi Kokkinakis,Ivo Karlovic,R,R,M,20150218.0,Delray Beach,R16,12:45,,Hard,,3.0,1,ChapelHeel66
+20150217-M-Rio_de_Janeiro-R32-Thomaz_Bellucci-Rafael_Nadal,Thomaz Bellucci,Rafael Nadal,L,L,M,20150217.0,Rio de Janeiro,R32,,Center Court,Clay,,3.0,1,Isaac
+20150217-M-Marseille-R32-Alexander_Zverev-Gael_Monfils,Alexander Zverev,Gael Monfils,R,R,M,20150217.0,Marseille,R32,,,Hard,,3.0,1,pvtennis
+20150215-M-Rotterdam-F-Stanislas_Wawrinka-Tomas_Berdych,Stanislas Wawrinka,Tomas Berdych,R,R,M,20150215.0,Rotterdam,F,,Center court,Hard,Gerry Armstrong,3.0,1,Isaac
+20150213-M-Sao_Paulo-QF-Santiago_Giraldo-Fabio_Fognini,Santiago Giraldo,Fabio Fognini,R,R,M,20150213.0,Sao Paulo,QF,,,Clay,,3.0,1,Jenn
+20150212-M-Rotterdam-R16-Milos_Raonic-Simone_Bolelli,Milos Raonic,Simone Bolelli,R,R,M,20150212.0,Rotterdam,R16,,Center court,Hard,Cedric Mourier,3.0,1,Isaac
+20150210-M-Rotterdam-R32-Andrey_Kuznetsov-Milos_Raonic,Andrey Kuznetsov,Milos Raonic,R,R,M,20150210.0,Rotterdam,R32,,Center Court,Hard,,3.0,1,Isaac
+20150209-M-Rotterdam-R32-Grigor_Dimitrov-Paul_Henri_Mathieu,Grigor Dimitrov,Paul Henri Mathieu,R,R,M,20150209.0,Rotterdam,R32,,Center Court,Hard,,3.0,1,Isaac
+20150208-M-Zagreb-F-Andreas_Seppi-Guillermo_Garcia_Lopez,Andreas Seppi,Guillermo Garcia Lopez,R,R,M,20150208.0,Zagreb,F,,Center court,Hard,,3.0,1,Isaac
+20150208-M-Montpellier-F-Richard_Gasquet-Jerzy_Janowicz,Richard Gasquet,Jerzy Janowicz,R,R,M,20150208.0,Montpellier,F,,Centre Court,Indoor Hard,Manuel Messina,3.0,1,Isaac
+20150206-M-Montpellier-QF-Joao_Sousa-Philipp_Kohlschreiber,Joao Sousa,Philipp Kohlschreiber,R,R,M,20150206.0,Montpellier,QF,3:40 PM,,Hard,Arnaud Gabas,3.0,1,ChapelHeel66
+20150205-M-Zagreb-R16-Ivan_Dodig-Marcel_Granollers,Ivan Dodig,Marcel Granollers,R,R,M,20150205.0,Zagreb,R16,11:15 AM,,Hard,Ahmed Abdel Azim,3.0,1,ChapelHeel66
+20150201-M-Australian_Open-F-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20150201.0,Australian Open,F,,Rod Laver,Hard,,5.0,0,Lowell
+20150130-M-Australian_Open-SF-Novak_Djokovic-Stanislas_Wawrinka,Novak Djokovic,Stanislas Wawrinka,R,R,M,20150130.0,Australian Open,SF,,Rod Laver Arena,Hard,,5.0,0,Isaac
+20150129-M-Australian_Open-SF-Tomas_Berdych-Andy_Murray,Tomas Berdych,Andy Murray,R,R,M,20150129.0,Australian Open,SF,8.30pm,Rod Laver Arena,Hard,Pascal Maria,5.0,0,Edo
+20150127-M-Australian_Open-QF-Tomas_Berdych-Rafael_Nadal,Tomas Berdych,Rafael Nadal,R,L,M,20150127.0,Australian Open,QF,,Rod Laver Arena,Hard,Mohamed Lahyani,5.0,0,Bobby
+20150127-M-Australian_Open-QF-Stanislas_Wawrinka_-Kei_Nishikori,Stanislas Wawrinka ,Kei Nishikori,R,R,M,20150127.0,Australian Open,QF,,Rod Laver Arena,Hard,,5.0,0,Isaac
+20150125-M-Australian_Open-R16-Bernard_Tomic-Tomas_Berdych,Bernard Tomic,Tomas Berdych,R,R,M,20150125.0,Australian Open,R16,,Margaret Court Arena,Hard Court,,5.0,0,Bobby
+20150123-M-Australian_Open-R32-Fernando_Verdasco-Novak_Djokovic,Fernando Verdasco,Novak Djokovic,L,R,M,20150123.0,Australian Open,R32,,Rod Laver Arena,Hard,,5.0,0,Isaac
+20150111-M-Brisbane-F-Milos_Raonic-Roger_Federer,Milos Raonic,Roger Federer,R,R,M,20150111.0,Brisbane,F,19:10,Pat Rafter Arena,Hard,Mohamed Lahyani,3.0,1,1HandBH
+20150109-M-Brisbane-QF-Bernard_Tomic-Kei_Nishikori,Bernard Tomic,Kei Nishikori,R,R,M,20150109.0,Brisbane,QF,,Pat Rafter Arena (Centre),,,3.0,1,qthetennisfan
+20150106-M-Doha-R32-Novak_Djokovic-Dusan_Lajovic,Novak Djokovic,Dusan Lajovic,R,R,M,20150106.0,Doha,R32,,,Hard,Carlos Bernardes,3.0,1,MBLAIR
+20150106-M-Doha-R16-Tomas_Berdych-Blaz_Kavcic,Tomas Berdych,Blaz Kavcic,R,R,M,20150106.0,Doha,R16,,,Hard,Carlos Bernardes,3.0,1,MBLAIR
+20150105-M-Doha-R32-Rafael_Nadal-Michael_Berrer,Rafael Nadal,Michael Berrer,L,L,M,20150105.0,Doha,R32,,Centre,Hard,,3.0,1,Isaac
+20141123-M-Davis_Cup_World_Group_F-RR-Richard_Gasquet-Roger_Federer,Richard Gasquet,Roger Federer,R,R,M,20141123.0,Davis Cup World Group F,RR,14:00:00,Lille,Clay,James Keothavong,5.0,0,Edo
+20141117-M-Lima_CH-F-Jason_Kubler-Guido_Pella,Jason Kubler,Guido Pella,R,L,M,20141117.0,Lima CH,F,,,Clay,,3.0,1,Amy
+20141114-M-Tour_Finals-RR-Tomas_Berdych-Novak_Djokovic,Tomas Berdych,Novak Djokovic,R,R,M,20141114.0,Tour Finals,RR,,,Hard,,3.0,1,Amy
+20141111-M-Champaign_CH-R32-Jared_Donaldson-Alex_Kuznetsov,Jared Donaldson,Alex Kuznetsov,R,R,M,20141111.0,Champaign CH,R32,,Court 1,Hard,,3.0,1,Amy
+20141104-M-Knoxville_CH-R32-Jared_Donaldson-Daniel_Nguyen,Jared Donaldson,Daniel Nguyen,R,R,M,20141104.0,Knoxville CH,R32,,Center,Hard,,3.0,1,Amy
+20141029-M-Paris_Masters-R16-Grigor_Dimitrov-Andy_Murray,Grigor Dimitrov,Andy Murray,R,R,M,20141029.0,Paris Masters,R16,,,Hard,,3.0,1,Isaac
+20141004-M-Beijing-SF-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20141004.0,Beijing,SF,1pm,National Tennis Stadium,Hard,Damian Steiner,3.0,1,Edo
+20140929-M-Sacramento_CH-R16-Jared_Donaldson-Luca_Vanni,Jared Donaldson,Luca Vanni,R,R,M,20140929.0,Sacramento CH,R16,,,Hard,,3.0,1,Amy
+20140928-M-Shenzhen-F-Andy_Murray-Tommy_Robredo,Andy Murray,Tommy Robredo,R,R,M,20140928.0,Shenzhen,F,,Centre,Hard,Lahyani Mohamed,3.0,1,1HandBH
+20140922-M-Shenzhen-R16-Somdev_Devvarman-Andy_Murray,Somdev Devvarman,Andy Murray,R,R,M,20140922.0,Shenzhen,R16,,,Hard,,3.0,1,Amy
+20140915-M-USA_F25-SF-Tennys_Sandgren-Jarmere_Jenkins,Tennys Sandgren,Jarmere Jenkins,R,R,M,20140915.0,USA F25,SF,,,Hard,,3.0,1,Isaac
+20140914-M-Davis_Cup_World_Group_SF-RR-Roger_Federer-Fabio_Fognini,Roger Federer,Fabio Fognini,R,R,M,20140914.0,Davis Cup World Group SF,RR,15:00:00,Geneva,Hard,Pascal Maria,5.0,0,Edo
+20140908-M-USA_F24-QF-Jean_Yves_Aubone-Ty_Trombetta,Jean Yves Aubone,Ty Trombetta,R,R,M,20140908.0,USA F24,QF,,,Hard,,3.0,1,Isaac
+20140906-M-US_Open-SF-Novak_Djokovic-Kei_Nishikori,Novak Djokovic,Kei Nishikori,R,R,M,20140906.0,US Open,SF,1pm,Ashe,Hard,Eva Asderaki,5.0,1,Edo
+20140903-M-US_Open-QF-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20140903.0,US Open,QF,9pm,Ashe,Hard,Pascal Maria,5.0,1,Edo
+20140902-M-Shanghai_CH-R32-John_Millman-Ze_Zhang,John Millman,Ze Zhang,R,R,M,20140902.0,Shanghai CH,R32,Day,Stadium,Hard,,3.0,1,d
+20140815-M-Cincinnati_Masters-QF-Andy_Murray-Roger_Federer,Andy Murray,Roger Federer,R,R,M,20140815.0,Cincinnati Masters,QF,7pm,Center,Hard,Mohamed Lahyani,3.0,1,Edo
+20140810-M-Cincinnati_Masters-F-Roger_Federer-David_Ferrer,Roger Federer,David Ferrer,R,R,M,20140810.0,Cincinnati Masters,F,,,Hard,,3.0,1,DanF
+20140810-M-Canada_Masters-F-Jo_Wilfried_Tsonga-Roger_Federer,Jo Wilfried Tsonga,Roger Federer,R,R,M,20140810.0,Canada Masters,F,,,Hard,,3.0,1,Bobby
+20140807-M-Canada_Masters-R16-Novak_Djokovic-Jo_Wilfried_Tsonga,Novak Djokovic,Jo Wilfried Tsonga,R,R,M,20140807.0,Canada Masters,R16,,Centre,Hard,,3.0,1,Amy
+20140805-M-Canada_Masters-R32-Peter_Polansky-Roger_Federer,Peter Polansky,Roger Federer,R,R,M,20140805.0,Canada Masters,R32,,Centre,Hard,,3.0,1,Amy
+20140727-M-Atlanta-F-John_Isner-Dudi_Sela,John Isner,Dudi Sela,R,R,M,20140727.0,Atlanta,F,,,Hard,,3.0,1,Bobby
+20140725-M-Atlanta-QF-John_Isner-Marinko_Matosevic,John Isner,Marinko Matosevic,R,R,M,20140725.0,Atlanta,QF,,,Hard,,3.0,1,Bobby
+20140721-M-Umag-R32-Ante_Pavic-Horacio_Zeballos,Ante Pavic,Horacio Zeballos,R,L,M,20140721.0,Umag,R32,,,Clay,,3.0,1,Amy
+20140720-M-Bogota-F-Bernard_Tomic-Ivo_Karlovic,Bernard Tomic,Ivo Karlovic,R,R,M,20140720.0,Bogota,F,,,Hard,,3.0,1,Amy
+20140719-M-Bogota-SF-Bernard_Tomic-Victor_Estrella,Bernard Tomic,Victor Estrella,R,R,M,20140719.0,Bogota,SF,,,Hard,,3.0,1,Amy
+20140714-M-Bogota-QF-Jimmy_Wang-Ivo_Karlovic,Jimmy Wang,Ivo Karlovic,R,R,M,20140714.0,Bogota,QF,,,Hard,,3.0,1,Amy
+20140710-M-Stuttgart-R32-Jan_Lennard_Struff-Philipp_Kohlschreiber,Jan Lennard Struff,Philipp Kohlschreiber,R,R,M,20140710.0,Stuttgart,R32,5:10 PM,,Clay,Damian Steiner,3.0,1,ChapelHeel66
+20140706-M-Wimbledon-F-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20140706.0,Wimbledon,F,14:09,Centre Court,Grass,James Keothavong,5.0,0,1HandBH
+20140704-M-Wimbledon-SF-Milos_Raonic-Roger_Federer,Milos Raonic,Roger Federer,R,R,M,20140704.0,Wimbledon,SF,,Centre,Grass,,5.0,0,Isaac
+20140704-M-Wimbledon-SF-Grigor_Dimitrov-Novak_Djokovic,Grigor Dimitrov,Novak Djokovic,R,R,M,20140704.0,Wimbledon,SF,2pm,Centre,Grass,Ali Nili,5.0,0,Edo
+20140701-M-Wimbledon-R16-Nick_Kyrgios-Rafael_Nadal,Nick Kyrgios,Rafael Nadal,R ,L,M,20140701.0,Wimbledon,R16,4:00 PM,Centre,Grass,Carlos Bernardes,5.0,0,DebLDecker
+20140630-M-Winnetka_CH-F-Farrukh_Dustov-Denis_Kudla,Farrukh Dustov,Denis Kudla,R,R,M,20140630.0,Winnetka CH,F,,,Hard,,3.0,1,Amy
+20140628-M-Wimbledon-R32-Mikhail_Kukushkin-Rafael_Nadal,Mikhail Kukushkin,Rafael Nadal,R ,L,M,20140628.0,Wimbledon,R32,1:00 PM,Centre,Grass,Pascal Maria,5.0,0,DebLDecker
+20140628-M-Padova_CH-SF-Nikola_Cacic-Maximo_Gonzalez,Nikola Cacic,Maximo Gonzalez,R,R,M,20140628.0,Padova CH,SF,Day,Central,Clay,,3.0,1,d
+20140627-M-Wimbledon-R32-Grigor_Dimitrov-Alexandr_Dolgopolov,Grigor Dimitrov,Alexandr Dolgopolov,R,R,M,20140627.0,Wimbledon,R32,,No. 1 Court,Grass,,5.0,0,1HandBH
+20140626-M-Wimbledon-R64-Rafael_Nadal-Lukas_Rosol,Rafael Nadal,Lukas Rosol,L,R ,M,20140626.0,Wimbledon,R64,1:00 PM,Centre,Grass,James Keothavong,5.0,0,DebLDecker
+20140625-M-Wimbledon-R64-Tomas_Berdych-Bernard_Tomic,Tomas Berdych,Bernard Tomic,R,R,M,20140625.0,Wimbledon,R64,,Court 1,Grass,,5.0,0,Bobby
+20140616-M-Eastbourne-R32-Ivo_Karlovic-Jeremy_Chardy,Ivo Karlovic,Jeremy Chardy,R,R,M,20140616.0,Eastbourne,R32,,,Grass,,3.0,1,qthetennisfan
+20140615-M-Halle-F-Roger_Federer-Alejandro_Falla,Roger Federer,Alejandro Falla,R,L,M,20140615.0,Halle,F,2:00 PM,Stadion,Grass,Damien Dumusois,3.0,1,Edo
+20140614-M-Queens_Club-SF-Stanislas_Wawrinka-Grigor_Dimitrov,Stanislas Wawrinka,Grigor Dimitrov,R,R,M,20140614.0,Queens Club,SF,,,Grass,,3.0,1,Eric J
+20140613-M-Nottingham_CH-SF-Nick_Kyrgios-Miloslav_Mecir,Nick Kyrgios,Miloslav Mecir,R,R,M,20140613.0,Nottingham CH,SF,,,Grass,,3.0,1,Michal
+20140612-M-Halle-R16-Dustin_Brown-Rafael_Nadal,Dustin Brown,Rafael Nadal,R ,L,M,20140612.0,Halle,R16,5:30 PM,Stadium,Grass,Carlos Bernardes,3.0,1,DebLDecker
+20140611-M-Halle-R16-Pierre_Hugues_Herbert-Philipp_Kohlschreiber,Pierre Hugues Herbert,Philipp Kohlschreiber,R,R,M,20140611.0,Halle,R16,12:10,Gerry Weber Stadion (main court),Grass,Dimitar Trifunovski,3.0,1,1HandBH
+20140609-M-Queens_Club-R32-Grigor_Dimitrov-James_Ward,Grigor Dimitrov,James Ward,R,R,M,20140609.0,Queen's Club,R32,,,Grass,,3.0,1,Isaac
+20140609-M-Prague_CH-R32-Steven_Diez-Renzo_Olivo,Steven Diez,Renzo Olivo,R,R,M,20140609.0,Prague CH,R32,Day,Court 1,Clay,,3.0,1,d
+20140608-M-Roland_Garros-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R ,L,M,20140608.0,Roland Garros,F,3:00 PM,Philippe Chatrier,Clay,Pascal Maria,5.0,0,DebLDecker
+20140606-M-Roland_Garros-SF-Rafael_Nadal-Andy_Murray,Rafael Nadal,Andy Murray,L,R ,M,20140606.0,Roland Garros,SF,4:00 PM,Philippe Chatrier,Clay,Damien Dumusois,5.0,0,DebLDecker
+20140606-M-Roland_Garros-SF-Ernests_Gulbis-Novak_Djokovic,Ernests Gulbis,Novak Djokovic,R,R,M,20140606.0,Roland Garros,SF,1pm,Philippe Chatrier,Clay,Carlos Ramos,5.0,0,Edo
+20140604-M-Roland_Garros-QF-David_Ferrer-Rafael_Nadal,David Ferrer,Rafael Nadal,R ,L,M,20140604.0,Roland Garros,QF,6:45 PM,Suzanne Lenglen,Clay,James Keothavong,5.0,0,DebLDecker
+20140601-M-Roland_Garros-R16-Rafael_Nadal-Dusan_Lajovic,Rafael Nadal,Dusan Lajovic,L,R,M,20140601.0,Roland Garros,R16,13:30 PM,Philippe Chatrier,Clay,Pierre Bacchi,5.0,0,DebLDecker
+20140531-M-Roland_Garros-R32-Leonardo_Mayer-Rafael_Nadal,Leonardo Mayer,Rafael Nadal,R ,L,M,20140531.0,Roland Garros,R32,3:45 PM,Philippe Chartrier,Clay,Pascal Maria,5.0,0,DebLDecker
+20140529-M-Roland_Garros-R64-Rafael_Nadal-Dominic_Thiem,Rafael Nadal,Dominic Thiem,L,R ,M,20140529.0,Roland Garros,R64,1:00 PM,Philippe Chatrier,Clay,Carlos Bernardes,5.0,0,DebLDecker
+20140526-M-Roland_Garros-R128-Robby_Ginepri-Rafael_Nadal,Robby Ginepri,Rafael Nadal,R ,L,M,20140526.0,Roland Garros,R128,5:30 PM,Suzanne Lenglen,Clay,Pierre Bacchi,5.0,0,DebLDecker
+20140524-M-Nice-F-Ernests_Gulbis-Federico_Delbonis,Ernests Gulbis,Federico Delbonis,R,L,M,20140524.0,Nice,F,,Centre,Clay,,3.0,1,James
+20140518-M-Rome_Masters-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R ,L,M,20140518.0,Rome Masters,F,4:00 PM,Centrale,Clay,Carlos Bernardes,3.0,1,DebLDecker
+20140517-M-Rome_Masters-SF-Grigor_Dimitrov-Rafael_Nadal,Grigor Dimitrov,Rafael Nadal,R ,L,M,20140517.0,Rome Masters,SF,8:00 PM,Centrale,Clay,Mohamed El Jennati,3.0,1,DebLDecker
+20140516-M-Rome_Masters-QF-Andy_Murray-Rafael_Nadal,Andy Murray,Rafael Nadal,R ,L,M,20140516.0,Rome Masters,QF,9:00 PM,Centrale,Clay,Mohamed Lahyani,3.0,1,DebLDecker
+20140515-M-Rome_Masters-R16-Mikhail_Youzhny-Rafael_Nadal,Mikhail Youzhny,Rafael Nadal,R ,L,M,20140515.0,Rome Masters,R16,4:30 PM,Centrale,Clay,Mohamed Al Jennati,3.0,1,DebLDecker
+20140515-M-Busan_CH-R16-Amir_Weintraub-Daniel_Smethurst,Amir Weintraub,Daniel Smethurst,R,R,M,20140515.0,Busan CH,R16,Day,Court 1,Hard,,3.0,1,d
+20140514-M-Rome_Masters-R32-Roger_Federer-Jeremy_Chardy,Roger Federer,Jeremy Chardy,R,R,M,20140514.0,Rome Masters,R32,,Centre,Clay,,3.0,1,qthetennisfan
+20140514-M-Rome_Masters-R32-Gilles_Simon-Rafael_Nadal,Gilles Simon,Rafael Nadal,R ,L,M,20140514.0,Rome Masters,R32,7:15 PM,Centrale,Clay,Damian Steiner,3.0,1,DebLDecker
+20140511-M-Madrid_Masters-F-Rafael_Nadal-Kei_Nishikori,Rafael Nadal,Kei Nishikori,L,R ,M,20140511.0,Madrid Masters,F,7:15 PM,Manolo Santana,Clay,Damien Dumusois,3.0,1,DebLDecker
+20140510-M-Madrid_Masters-SF-Roberto_Bautista_Agut-Rafael_Nadal,Roberto Bautista Agut,Rafael Nadal,R ,L,M,20140510.0,Madrid Masters,SF,4:00 PM,Manolo Santana,Clay,Carlos Bernardes,3.0,1,DebLDecker
+20140509-M-Rome_CH-QF-Mate_Delic-Julian_Reister,Mate Delic,Julian Reister,R,R,M,20140509.0,Rome CH,QF,Day,Court 1,Clay,,3.0,1,d
+20140509-M-Madrid_Masters-QF-Tomas_Berdych-Rafael_Nadal,Tomas Berdych,Rafael Nadal,R ,L,M,20140509.0,Madrid Masters,QF,3:30 PM,Manolo Santana,Clay,Mohamed Lahyani,3.0,1,DebLDecker
+20140508-M-Madrid_Masters-R16-Jarkko_Nieminen-Rafael_Nadal,Jarkko Nieminen,Rafael Nadal,L,L,M,20140508.0,Madrid Masters,R16,3:30 PM,Manolo Santana,Clay,Damien Dumusois,3.0,1,DebLDecker
+20140507-M-Madrid_Masters-R32-Rafael_Nadal-Juan_Monaco,Rafael Nadal,Juan Monaco,L,R ,M,20140507.0,Madrid Masters,R32,3:15 PM,Manolo Santana,Clay,Carlos Bernardes,3.0,1,DebLDecker
+20140429-M-Cali_CH-R32-Mathias_Bourgue-Gonzalo_Lama,Mathias Bourgue,Gonzalo Lama,R,R,M,20140429.0,Cali CH,R32,Day,Court 1,Clay,,3.0,1,d
+20140425-M-Barcelona-QF-Nicolas_Almagro-Rafael_Nadal,Nicolas Almagro,Rafael Nadal,R ,L,M,20140425.0,Barcelona,QF,3:30 PM,Pista Central,Clay,Mohamed Lahyani,3.0,1,DebLDecker
+20140424-M-Barcelona-R16-Ivan_Dodig-Rafael_Nadal,Ivan Dodig,Rafael Nadal,R ,L,M,20140424.0,Barcelona,R16,7:30 PM,Pista Central,Clay,Mohamed El Jennati,3.0,1,DebLDecker
+20140423-M-Barcelona-R32-Albert_Ramos-Rafael_Nadal,Albert Ramos,Rafael Nadal,L,L,M,20140423.0,Barcelona,R32,3:30 PM,Pista Central,Clay,Magdi Somat,3.0,1,DebLDecker
+20140420-M-Monte_Carlo_Masters-F-Stanislas_Wawrinka-Roger_Federer,Stanislas Wawrinka,Roger Federer,R,R,M,20140420.0,Monte Carlo Masters,F,3pm,Central,Clay,Cedric Mourier,3.0,1,Edo
+20140418-M-Monte_Carlo_Masters-QF-David_Ferrer-Rafael_Nadal,David Ferrer,Rafael Nadal,R ,L,M,20140418.0,Monte Carlo Masters,QF,12:30 PM,Central,Clay,Carlos Bernardes,3.0,1,DebLDecker
+20140417-M-Monte_Carlo_Masters-R16-Andreas_Seppi-Rafael_Nadal,Andreas Seppi,Rafael Nadal,R ,L,M,20140417.0,Monte Carlo Masters,R16,2:00 PM,Central,Clay,Cedric Mourier,3.0,1,DebLDecker
+20140416-M-Monte_Carlo_Masters-R32-Rafael_Nadal-Teymuraz_Gabashvili,Rafael Nadal,Teymuraz Gabashvili,L,R ,M,20140416.0,Monte Carlo Masters,R32,2:00 PM,Central,Clay,Pascal Maria,3.0,1,DebLDecker
+20140415-M-San_Luis_Potosi_CH-R32-Paolo_Lorenzi-Mauricio_Echazu,Paolo Lorenzi,Mauricio Echazu,R,R,M,20140415.0,San Luis Potosi CH,R32,Afternoon,Central,Clay,,3.0,1,d
+20140414-M-Sao_Paulo_CH-R32-Horacio_Zeballos-Ricardo_Hocevar,Horacio Zeballos,Ricardo Hocevar,L,R,M,20140414.0,Sao Paulo CH,R32,Night,Quadra Central,Clay,,3.0,1,d
+20140413-M-Monte_Carlo_Masters-SF-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20140413.0,Monte Carlo Masters,SF,,,Clay,,3.0,0,DanF
+20140411-M-Houston-QF-Donald_Young-Fernando_Verdasco,Donald Young,Fernando Verdasco,L,L,M,20140411.0,Houston,QF,12:15,,Clay,,3.0,1,1HandBH
+20140409-M-Itajai-R32-Mohamed_Safwat-Eduardo_Russi,Mohamed Safwat,Eduardo Russi,R,R,M,20140409.0,Itajai,R32,Morning,Centre,Clay,,3.0,1,d
+20140330-M-Miami_Masters-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R ,L,M,20140330.0,Miami Masters,F,2:30 PM,Stadium,Hard,Mohamed Lahyani,3.0,1,DebLDecker
+20140327-M-Miami_Masters-QF-Milos_Raonic-Rafael_Nadal,Milos Raonic,Rafael Nadal,R ,L,M,20140327.0,Miami Masters,QF,7:00 PM,Stadium,Hard,Cedric Mourier,3.0,1,DebLDecker
+20140326-M-Miami_Masters-QF-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20140326.0,Miami Masters,QF,3pm,Stadium,Hard,Damien Steiner,3.0,1,Edo
+20140325-M-Miami_Masters-R16-Fabio_Fognini-Rafael_Nadal,Fabio Fognini,Rafael Nadal,R ,L,M,20140325.0,Miami Masters,R16,9:30 PM,Stadium,Hard,Damian Steiner,3.0,1,DebLDecker
+20140324-M-Miami_Masters-R32-Denis_Istomin-Rafael_Nadal,Denis Istomin,Rafael Nadal,R ,L,M,20140324.0,Miami Masters,R32,6:15 PM,Stadium,Hard,Carlos Bernardes,3.0,1,DebLDecker
+20140322-M-Miami_Masters-R64-Lleyton_Hewitt-Rafael_Nadal,Lleyton Hewitt,Rafael Nadal,R,L ,M,20140322.0,Miami Masters,R64,10:30 PM,Stadium,Hard,Gerry Armstrong,3.0,1,DebLDecker
+20140317-M-Rimouski_CH-R32-Izak_Van_Der_Merwe-Daniel_Cox,Izak Van Der Merwe,Daniel Cox,R,R,M,20140317.0,Rimouski CH,R32,,Centre,Indoor Hard,,3.0,1,d
+20140310-M-Indian_Wells_Masters-R32-Alexandr_Dolgopolov-Rafael_Nadal,Alexandr Dolgopolov,Rafael Nadal,R ,L,M,20140310.0,Indian Wells Masters,R32,5:55 PM,Center,Hard,Mohamed Lahyani,3.0,1,DebLDecker
+20140308-M-Indian_Wells_Masters-R64-Radek_Stepanek-Rafael_Nadal,Radek Stepanek,Rafael Nadal,R ,L,M,20140308.0,Indian Wells Masters,R64,7:15 PM,Center,Hard,Magdi Somat,3.0,1,DebLDecker
+20140228-M-Dubai-SF-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20140228.0,Dubai,SF,,Centre,Hard,Mohamed el Jennati,3.0,1,Sagar Manohar
+20140224-M-Cherbourg_CH-Q3-Rudy_Coco-Taro_Daniel,Rudy Coco,Taro Daniel,L,R,M,20140224.0,Cherbourg CH,Q3,Morning,Central,Indoor Hard,,3.0,1,d
+20140223-M-Rio_de_Janeiro-F-Rafael_Nadal-Alexandr_Dolgopolov,Rafael Nadal,Alexandr Dolgopolov,L,R ,M,20140223.0,Rio de Janeiro,F,5:00 PM,Center,Clay,Damien Dumusois,3.0,1,DebLDecker
+20140222-M-Rio_de_Janeiro-SF-Rafael_Nadal-Pablo_Andujar,Rafael Nadal,Pablo Andujar,L,R ,M,20140222.0,Rio de Janeiro,SF,7:00 PM,Center,Clay ,Mohamed Fitouhi,3.0,1,DebLDecker
+20140221-M-Rio_de_Janeiro-QF-Rafael_Nadal-Joao_Sousa,Rafael Nadal,Joao Sousa,L,R ,M,20140221.0,Rio de Janeiro,QF,21:30,Center,Clay,Damien Dumusois,3.0,1,DebLDecker
+20140220-M-Rio_de_Janeiro-R16-Albert_Montanes-Rafael_Nadal,Albert Montanes,Rafael Nadal,R,L,M,20140220.0,Rio de Janeiro,R16,08: PM,Center,Clay,Magdi Somat,3.0,1,DebLDecker
+20140218-M-Rio_de_Janeiro-R32-Rafael_Nadal-Daniel_Gimeno_Traver,Rafael Nadal,Daniel Gimeno Traver,L,R ,M,20140218.0,Rio de Janeiro,R32,20:20,Center,Clay,Adel Nour,3.0,1,DebLDecker
+20140210-M-Rotterdam-R32-Tomas_Berdych-Andreas_Seppi,Tomas Berdych,Andreas Seppi,R,R,M,20140210.0,Rotterdam,R32,,,Hard,,3.0,1,Isaac
+20140210-M-Memphis-R32-Nick_Kyrgios-Tim_Smyczek,Nick Kyrgios,Tim Smyczek,R,R,M,20140210.0,Memphis,R32,8:00PM,Centre,Indoor Hard,,3.0,1,FSOT
+20140201-M-Burnie_CH-F-Hiroki_Moriya-Matt_Reid,Hiroki Moriya,Matt Reid,R,R,M,20140201.0,Burnie CH,F,,Centre,Hard,,3.0,1,FSOT
+20140126-M-Australian_Open-F-Stanislas_Wawrinka-Rafael_Nadal,Stanislas Wawrinka,Rafael Nadal,R ,L,M,20140126.0,Australian Open,F,7:30,Rod Laver,Hard,Carlos Ramos,5.0,0,DebLDecker
+20140123-M-Australian_Open-SF-Stanislas_Wawrinka-Tomas_Berdych,Stanislas Wawrinka,Tomas Berdych,R,R,M,20140123.0,Australian Open,SF,6.30pm,Rod Laver Arena,Hard,John Blom,5.0,0,Edo
+20140122-M-Australian_Open-QF-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20140122.0,Australian Open,QF,,Rod Laver Arena,Hard,,5.0,1,Isaac
+20140122-M-Australian_Open-QF-Novak_Djokovic-Stanislas_Wawrinka_,Novak Djokovic,Stanislas Wawrinka ,R,R,M,20140122.0,Australian Open,QF,,,Hard,,5.0,0,Isaac
+20140122-M-Australian_Open-QF-Grigor_Dimitrov-Rafael_Nadal,Grigor Dimitrov,Rafael Nadal,R ,L,M,20140122.0,Australian Open,QF,3:00 PM,Rod Laver,Hard,Carlos Bernardes,5.0,0,DebLDecker
+20140120-M-Australian_Open-R16-Kei_Nishikori-Rafael_Nadal,Kei Nishikori,Rafael Nadal,R ,L,M,20140120.0,Australian Open,R16,3:45,Rod Laver,Hard,Eva Asderaki,5.0,0,DebLDecker
+20140118-M-Australian_Open-R32-Gael_Monfils-Rafael_Nadal,Gael Monfils,Rafael Nadal,R,L,M,20140118.0,Australian Open,R32,9:30 PM,Rod Laver,Hard,Jake Garner,5.0,0,DebLDecker
+20140116-M-Australian_Open-R64-Thanasi_Kokkinakis-Rafael_Nadal,Thanasi Kokkinakis,Rafael Nadal,R,L,M,20140116.0,Australian Open,R64,5:15 PM,Rod Laver,Hard,Gerry Armstrong,5.0,0,DebLDecker
+20140113-M-Australian_Open-R128-Ricardas_Berankis-Alexandr_Dolgopolov,Ricardas Berankis,Alexandr Dolgopolov,R,R,M,20140113.0,Australian Open,R128,17:40,Court 6,Hard,Mariana Alves,5.0,0,1HandBH
+20140113-M-Australian_Open-R128-Bernard_Tomic-Rafael_Nadal,Bernard Tomic,Rafael Nadal,R ,L,M,20140113.0,Australian Open,R128,8:40 PM,Rod Laver Arena,Hard,James Keothavong,5.0,0,DebLDecker
+20140111-M-Sydney-F-Bernard_Tomic-Juan_Martin_Del_Potro,Bernard Tomic,Juan Martin Del Potro,R,R,M,20140111.0,Sydney,F,,,Hard,,3.0,1,Backstop5
+20140109-M-Sydney-QF-Marinko_Matosevic-Sergiy_Stakhovsky,Marinko Matosevic,Sergiy Stakhovsky,R,R,M,20140109.0,Sydney,QF,,,Hard,,3.0,1,FSOT
+20140109-M-Sydney-QF-Juan_Martin_Del_Potro-Radek_Stepanek,Juan Martin Del Potro,Radek Stepanek,R,R,M,20140109.0,Sydney,QF,11:40,Centre,Hard,Tony Nimmons,3.0,1,1HandBH
+20140109-M-Auckland-QF-Roberto_Bautista_Agut-Jack_Sock,Roberto Bautista Agut,Jack Sock,R,R,M,20140109.0,Auckland,QF,,Centre,Hard,Paula Vieira,3.0,1,FSOT
+20140107-M-Auckland-R32-Michal_Przysiezny-Benoit_Paire,Michal Przysiezny,Benoit Paire,R,R,M,20140107.0,Auckland,R32,3:00PM,Centre,Hard,,3.0,1,FSOT
+20140107-M-Auckland-R32-Jose_Rubin_Statham-Lukas_Lacko,Jose Rubin Statham,Lukas Lacko,R,R,M,20140107.0,Auckland,R32,12:00PM,Centre,Hard,Paula Vieira,3.0,1,FSOT
+20140106-M-Sydney-R32-Matthew_Ebden-Julien_Benneteau,Matthew Ebden,Julien Benneteau,R,R,M,20140106.0,Sydney,R32,,,Hard,,3.0,1,Isaac
+20140106-M-Sydney-R32-Bernard_Tomic-Marcel_Granollers,Bernard Tomic,Marcel Granollers,R,R,M,20140106.0,Sydney,R32,,,Hard,,3.0,1,Isaac
+20140105-M-Sao_Paulo_CH-F-Alejandro_Gonzalez-Joao_Souza,Alejandro Gonzalez,Joao Souza,R,R,M,20140105.0,Sao Paulo CH,F,11:00AM,C,Hard,,3.0,1,FSOT
+20140104-M-Doha-F-Rafael_Nadal-Gael_Monfils,Rafael Nadal,Gael Monfils,L,R,M,20140104.0,Doha,F,6:00 PM,,Hard,Manuel Messina,3.0,1,DebLDecker
+20140104-M-Chennai-SF-Edouard_Roger_Vasselin-Marcel_Granollers,Edouard Roger Vasselin,Marcel Granollers,R,R,M,20140104.0,Chennai,SF,5:00PM,Centre,Hard,Christophe Damaske,3.0,1,FSOT
+20140103-M-Sao_Paulo_CH-QF-Gastao_Elias-Facundo_Arguello,Gastao Elias,Facundo Arguello,R,R,M,20140103.0,Sao Paulo CH,QF,,Centre,Hard,,3.0,1,JJ
+20140103-M-Doha-SF-Peter_Gojowczyk-Rafael_Nadal,Peter Gojowczyk,Rafael Nadal,R ,L,M,20140103.0,Doha,SF,6:25,Centre,Hard,Cedric Mourier,3.0,1,DebLDecker
+20140103-M-Chennai-QF-Aljaz_Bedene-Stanislas_Wawrinka,Aljaz Bedene,Stanislas Wawrinka,R,R,M,20140103.0,Chennai,QF,5:00pm,One,Hard,Christophe Damaske,3.0,1,FSOT
+20140103-M-Brisbane-QF-Marin_Cilic-Kei_Nishikori,Marin Cilic,Kei Nishikori,R,R,M,20140103.0,Brisbane,QF,,,Hard,,3.0,1,Pero
+20140102-M-Doha-QF-Ernests_Gulbis-Rafael_Nadal,Ernests Gulbis,Rafael Nadal,R ,L,M,20140102.0,Doha,QF,8:10 PM,Centre,Hard,Cedric Mourier,3.0,1,DebLDecker
+20140102-M-Brisbane-R16-Lleyton_Hewitt-Feliciano_Lopez,Lleyton Hewitt,Feliciano Lopez,R,L,M,20140102.0,Brisbane,R16,,Centre,Hard,Lahyani Mohamed,3.0,1,1HandBH
+20140102-M-Brisbane-QF-Roger_Federer-Marinko_Matosevic,Roger Federer,Marinko Matosevic,R,R,M,20140102.0,Brisbane,QF,,,Hard,,3.0,1,Isaac
+20140101-M-Doha-R16-Rafael_Nadal-Tobias_Kamke,Rafael Nadal,Tobias Kamke,L,R ,M,20140101.0,Doha,R16,5:50 PM,Centre,Hard,Manuel Messina,3.0,1,DebLDecker
+20140101-M-Brisbane-R16-Matthew_Ebden-Kei_Nishikori,Matthew Ebden,Kei Nishikori,R,R,M,20140101.0,Brisbane,R16,,,Hard,,3.0,1,Briton Park
+20140101-M-Brisbane-R16-Marin_Cilic-Grigor_Dimitrov,Marin Cilic,Grigor Dimitrov,R,R,M,20140101.0,Brisbane,R16,,,Hard,Mohamed Lahyani,3.0,1,dropshot
+20140101-M-Brisbane-R16-Jarkko_Nieminen-Roger_Federer,Jarkko Nieminen,Roger Federer,L,R,M,20140101.0,Brisbane,R16,,,Hard,,3.0,1,Briton
+20131231-M-Doha-R32-Rafael_Nadal-Lukas_Rosol,Rafael Nadal,Lukas Rosol,L ,R,M,20131231.0,Doha,R32,6:00 PM,Centre,Hard,Cedric Mourier,3.0,1,DebLDecker
+20131230-M-Brisbane-R32-Grigor_Dimitrov-Robin_Haase,Grigor Dimitrov,Robin Haase,R,R,M,20131230.0,Brisbane,R32,,,Hard,,3.0,1,EricJ
+20131105-M-Tour_Finals-RR-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20131105.0,Tour Finals,RR,,O2 Arena,Hard,,3.0,1,camyu19
+20131104-M-Tour_Finals-RR-Richard_Gasquet-Novak_Djokovic,Richard Gasquet,Novak Djokovic,R,R,M,20131104.0,Tour Finals,RR,,,Hard,,3.0,1,Isaac
+20131103-M-Paris_Masters-F-Novak_Djokovic-David_Ferrer,Novak Djokovic,David Ferrer,R,R,M,20131103.0,Paris Masters,F,3:00pm,Centre,Hard Indoor,Damien Dumusois,3.0,1,Backstop5
+20131102-M-Paris_Masters-SF-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20131102.0,Paris Masters,SF,,,Hard,,3.0,1,Isaac
+20131102-M-Paris_Masters-SF-David_Ferrer-Rafael_Nadal,David Ferrer,Rafael Nadal,R,L,M,20131102.0,Paris Masters,SF,,,Hard,,3.0,1,Isaac
+20131101-M-Paris_Masters-QF-Roger_Federer-Juan_Martin_Del_Potro,Roger Federer,Juan Martin del Potro,R,R,M,20131101.0,Paris Masters,QF,,,Hard,,3.0,1,Amy
+20131101-M-Paris_Masters-QF-Novak_Djokovic-Stanislas_Wawrinka,Novak Djokovic,Stanislas Wawrinka,R,R,M,20131101.0,Paris Masters,QF,,,Hard,,3.0,1,Isaac
+20131031-M-Paris_Masters-R16-John_Isner-Novak_Djokovic,John Isner,Novak Djokovic,R,R,M,20131031.0,Paris Masters,R16,,,Hard,,3.0,1,Isaac
+20131028-M-Paris_Masters-QF-Richard_Gasquet-Rafael_Nadal,Richard Gasquet,Rafael Nadal,R,L,M,20131028.0,Paris Masters,QF,,,Hard,,3.0,1,Isaac
+20131027-M-Basel-F-Juan_Martin_Del_Potro-Roger_Federer,Juan Martin Del Potro,Roger Federer,R,R,M,20131027.0,Basel,F,2:30 PM,Center,Indoor Hard,,3.0,1,Vaibhav Shevade
+20131025-M-Basel-QF-Grigor_Dimitrov-Roger_Federer,Grigor Dimitrov,Roger Federer,R,R,M,20131025.0,Basel,QF,,,Hard,,3.0,1,Amy
+20131013-M-Shanghai_Masters-F-Novak_Djokovic-Juan_Martin_Del_Potro,Novak Djokovic,Juan Martin del Potro,R,R,M,20131013.0,Shanghai Masters,F,,Stadium,Hard,Damien Dumusois,3.0,1,Backstop5
+20131012-M-Shanghai_Masters-SF-Rafael_Nadal-Juan_Martin_Del_Potro,Rafael Nadal,Juan Martin del Potro,L,R,M,20131012.0,Shanghai Masters,SF,,,Hard,,3.0,1,Amy
+20131011-M-Shanghai_Masters-QF-Nicolas_Almagro-Juan_Martin_Del_Potro,Nicolas Almagro,Juan Martin del Potro,R,R,M,20131011.0,Shanghai Masters,QF,,,Hard,,3.0,1,Amy
+20131010-M-Shanghai_Masters-R16-Roger_Federer-Gael_Monfils,Roger Federer,Gael Monfils,R,R,M,20131010.0,Shanghai Masters,R16,16:30:00,Center,Hard,,3.0,1,Joey Hanf
+20131007-M-Shanghai_Masters-R32-Roger_Federer-Andreas_Seppi,Roger Federer,Andreas Seppi,R,R,M,20131007.0,Shanghai Masters,R32,,,Hard,Mohamed Lahyani,3.0,1,Isaac
+20131007-M-Shanghai_Masters-R32-Rafael_Nadal-Alexandr_Dolgopolov,Rafael Nadal,Alexandr Dolgopolov,L,R,M,20131007.0,Shanghai Masters,R32,,Stadium,Hard,,3.0,1,Isaac
+20131007-M-Shanghai_Masters-R32-Marcel_Granollers-Novak_Djokovic,Marcel Granollers,Novak Djokovic,R,R,M,20131007.0,Shanghai Masters,R32,,,Hard,,3.0,1,Isaac
+20131006-M-Tokyo-F-Juan_Martin_Del_Potro-Milos_Raonic,Juan Martin Del Potro,Milos Raonic,R,R,M,20131006.0,Tokyo,F,,,Hard,,3.0,1,Amy
+20131005-M-Tokyo-SF-Nicolas_Almagro-Juan_Martin_Del_Potro,Nicolas Almagro,Juan Martin Del Potro,R,R,M,20131005.0,Tokyo,SF,,,Hard,,3.0,1,Amy
+20131005-M-Beijing-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20131005.0,Beijing,F,,,Hard,,3.0,1,Isaac
+20130921-M-Metz-SF-Jo_Wilfried_Tsonga-Florian_Mayer,Jo Wilfried Tsonga,Florian Mayer,R,R,M,20130921.0,Metz,SF,,Centre,Hard,Manuel Messina,3.0,1,ChapelHeel66
+20130913-M-Davis_Cup_World_Group_PO-RR-Sergiy_Stakhovsky-Rafael_Nadal,Sergiy Stakhovsky,Rafael Nadal,R,L,M,20130913.0,Davis Cup World Group PO,RR,,Estadio Manolo Santana,Clay,Emmanuel Joseph,5.0,0,Salvo
+20130816-M-Cincinnati_Masters-QF-Rafael_Nadal-Roger_Federer,Rafael Nadal,Roger Federer,L,R,M,20130816.0,Cincinnati Masters,QF,6:00:00 PM,Stadium,Hard,Carlos Bernardes,3.0,1,Edo
+20130813-M-Canada_Masters-QF-Novak_Djokovic-Richard_Gasquet,Novak Djokovic,Richard Gasquet,R,R,M,20130813.0,Canada Masters,QF,,,Hard,,3.0,1,Isaac
+20130811-M-Canada_Masters-F-Milos_Raonic-Rafael_Nadal,Milos Raonic,Rafael Nadal,R,L,M,20130811.0,Canada Masters,F,,Court Central,Hard,,3.0,1,Isaac
+20130810-M-Canada_Masters-SF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20130810.0,Canada Masters,SF,8pm,Central,Hard,Gerry Armstrong,3.0,1,Edo
+20130808-M-Canada_Masters-R16-Ernests_Gulbis-Andy_Murray,Ernests Gulbis,Andy Murray,R,R,M,20130808.0,Canada Masters,R16,,,Hard,,3.0,1,qthetennisfan
+20130806-M-Canada_Masters-R64-Vasek_Pospisil-John_Isner,Vasek Pospisil,John Isner,R,R,M,20130806.0,Canada Masters,R64,,Court Central,Hard,,3.0,1,@CanuckKicker
+20130805-M-Canada_Masters-R64-Peter_Polansky-Kei_Nishikori,Peter Polansky,Kei Nishikori,R,R,M,20130805.0,Canada Masters,R64,,Court Central,Hard,Damian Steiner,3.0,1,@CanuckKicker
+20130729-M-Washington-R16-Bernard_Tomic-Juan_Martin_Del_Potro,Bernard Tomic,Juan Martin Del Potro,R,R,M,20130729.0,Washington,R16,,,Hard,,3.0,1,Amy
+20130728-M-Atlanta-F-Kevin_Anderson-John_Isner,Kevin Anderson,John Isner,R,R,M,20130728.0,Atlanta,F,,Center,Hard,,3.0,1,1HandBH
+20130724-M-Lexington_CH-R16-James_Ward-Mitchell_Krueger,James Ward,Mitchell Krueger,R,R,M,20130724.0,Lexington CH,R16,,Stadium 1,Hard,,3.0,1,Joey Hanf
+20130707-M-Wimbledon-F-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20130707.0,Wimbledon,F,2:00 PM,Centre,Grass,Mohamed Lahyani,5.0,0,Verity or @vab14
+20130705-M-Wimbledon-SF-Novak_Djokovic-Juan_Martin_Del_Potro,Novak Djokovic,Juan Martin Del Potro,R,R,M,20130705.0,Wimbledon,SF,2pm,Centre,Grass,James Keothavong,5.0,0,Edo
+20130705-M-Wimbledon-SF-Andy_Murray-Jerzy_Janowicz,Andy Murray,Jerzy Janowicz,R,R,M,20130705.0,Wimbledon,SF,6pm,Centre,Grass,Jake Garner,5.0,0,Edo
+20130703-M-Wimbledon-QF-David_Ferrer-Juan_Martin_Del_Potro,David Ferrer,Juan Martin Del Potro,R,R,M,20130703.0,Wimbledon,QF,,,Grass,,5.0,0,Amy
+20130614-M-Halle-QF-Roger_Federer-Mischa_Zverev,Roger Federer,Mischa Zverev,R,L,M,20130614.0,Halle,QF,,Centre,Grass,,3.0,1,Daya
+20130612-M-Halle-R16-Gael_Monfils-Jan_Hernych,Gael Monfils,Jan Hernych,R,R,M,20130612.0,Halle,R16,8:30 AM,,Grass,Roland Herfel,3.0,1,ChapelHeel66
+20130609-M-Roland_Garros-F-David_Ferrer-Rafael_Nadal,David Ferrer,Rafael Nadal,R,L,M,20130609.0,Roland Garros,F,,,Clay,Cedric Mourier,5.0,0,Amy
+20130607-M-Roland_Garros-SF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20130607.0,Roland Garros,SF,,,Clay,,5.0,0,Amy
+20130519-M-Rome_Masters-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20130519.0,Rome Masters,F,,Campo Centrale,Clay,Carlos Bernardes,3.0,1,Isaac
+20130518-M-Rome_Masters-SF-Roger_Federer-Benoit_Paire,Roger Federer,Benoit Paire,R,R,M,20130518.0,Rome Masters,SF,8:00 PM,Centrale,Clay,Mohamed El Jennati,3.0,1,Edo
+20130517-M-Rome_Masters-SF-Tomas_Berdych-Rafael_Nadal,Tomas Berdych,Rafael Nadal,R,L,M,20130517.0,Rome Masters,SF,,,Clay,,3.0,1,Isaac
+20130514-M-Rome_Masters-R32-Juan_Martin_Del_Potro-Andrey_Kuznetsov,Juan Martin Del Potro,Andrey Kuznetsov,R,R,M,20130514.0,Rome Masters,R32,,,Clay,,3.0,1,Amy
+20130512-M-Madrid_Masters-F-Stanislas_Wawrinka-Rafael_Nadal,Stanislas Wawrinka,Rafael Nadal,R ,L,M,20130512.0,Madrid Masters,F,,Manolo Santana,Clay,,3.0,1,Backstop5
+20130509-M-Madrid_Masters-R16-Grigor_Dimitrov-Stanislas_Wawrinka,Grigor Dimitrov,Stanislas Wawrinka,R,R,M,20130509.0,Madrid Masters,R16,21:16,Arantxa Sanchez Vicario,Clay,Damien Dumosois,3.0,1,1HandBH
+20130419-M-Monte_Carlo_Masters-SF-Novak_Djokovic-Fabio_Fognini,Novak Djokovic,Fabio Fognini,R,R,M,20130419.0,Monte Carlo Masters,SF,,,Clay,,3.0,1,Isaac
+20130419-M-Monte_Carlo_Masters-QF-Richard_Gasquet-Fabio_Fognini,Richard Gasquet,Fabio Fognini,R,R,M,20130419.0,Monte Carlo Masters,QF,,Centre,Clay,Fergus Murphy,3.0,1,Dead Net Cord
+20130417-M-Monte_Carlo_Masters-R16-Andy_Murray-Stanislas_Wawrinka,Andy Murray,Stanislas Wawrinka,R,R,M,20130417.0,Monte Carlo Masters,R16,,,Clay,,3.0,1,Isaac
+20130414-M-Monte_Carlo_Masters-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20130414.0,Monte Carlo Masters,F,,Court Centrale,Clay,Mohamed Lahyani,3.0,1,Isaac
+20130331-M-Miami_Masters-F-David_Ferrer-Andy_Murray,David Ferrer,Andy Murray,R,R,M,20130331.0,Miami Masters,F,3:00 PM,Stadium,Hard,Cedric Mourier,3.0,1,Edo
+20130327-M-Miami_Masters-R16-Novak_Djokovic-Tommy_Haas,Novak Djokovic,Tommy Haas,R,R,M,20130327.0,Miami Masters,R16,,,Hard,,3.0,1,Amy
+20130323-M-Miami_Masters-R64-Bernard_Tomic-Andy_Murray,Bernard Tomic,Andy Murray,R,R,M,20130323.0,Miami Masters,R64,,,Hard,,3.0,1,Amy
+20130317-M-Indian_Wells_Masters-F-Rafael_Nadal-Juan_Martin_Del_Potro,Rafael Nadal,Juan Martin Del Potro,L,R,M,20130317.0,Indian Wells Masters,F,,Centre,Hard,Steve Ulrich,3.0,1,Salvo
+20130315-M-Indian_Wells_Masters-QF-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20130315.0,Indian Wells Masters,QF,2:00:00 PM,Stadium 1,Hard,Mohamed Lahyani,3.0,1,Edo
+20130314-M-Indian_Wells-R16-Tommy_Haas-Juan_Martin_Del_Potro,Tommy Haas,Juan Martin Del Potro,R,R,M,20130314.0,Indian Wells,R16,,,Hard,,3.0,1,Amy
+20130307-M-Indian_Wells_Masters-R32-Richard_Gasquet-Jerzy_Janowicz,Richard Gasquet,Jerzy Janowicz,R,R,M,20130307.0,Indian Wells Masters,R32,,,Hard,,3.0,1,Isaac
+20130302-M-Dubai-F-Novak_Djokovic-Tomas_Berdych,Novak Djokovic,Tomas Berdych,R,R,M,20130302.0,Dubai,F,7:15PM,Centre,Hard,,3.0,1,cameron10
+20130225-M-Acapulco-F-David_Ferrer-Rafael_Nadal,David Ferrer,Rafael Nadal,R,L,M,20130225.0,Acapulco,F,,,Clay,,3.0,1,Isaac
+20130224-M-Memphis-F-Feliciano_Lopez-Kei_Nishikori,Feliciano Lopez,Kei Nishikori,L,R,M,20130224.0,Memphis,F,15:10,Final Stadium,Hard,Fergus Murphy,3.0,1,1HandBH
+20130127-M-Australian_Open-F-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20130127.0,Australian Open,F,,,Hard,,5.0,0,Amy
+20130125-M-Australian_Open-SF-Roger_Federer-Andy_Murray_,Roger Federer,Andy Murray ,R,R,M,20130125.0,Australian Open,SF,,Rod Laver Arena,Hard,,5.0,0,Isaac
+20130125-M-Australian_Open-SF-David_Ferrer-Novak_Djokovic,David Ferrer,Novak Djokovic,R,R,M,20130125.0,Australian Open,SF,,,Hard,,3.0,1,Isaac
+20130123-M-Australian_Open-QF-Jo_Wilfried_Tsonga-Roger_Federer,Jo Wilfried Tsonga,Roger Federer,R,R,M,20130123.0,Australian Open,QF,7:40 PM,Rod Laver Arena,Hard,,5.0,1,Michal
+20130120-M-Australian_Open-R16-Novak_Djokovic-Stanislas_Wawrinka,Novak Djokovic,Stanislas Wawrinka,R,R,M,20130120.0,Australian Open,R16,20:38,Rod Laver Arena,Hard,,5.0,0,1HandBH
+20130117-M-Davis_Cup_World_Group_F-RR-Novak_Djokovic-Tomas_Berdych,Novak Djokovic,Tomas Berdych,R,R,M,20130117.0,Davis Cup World Group F,RR,14:00:00,Belgrade Arena,Hard,Eric Molina,5.0,0,Edo
+20130112-M-Sydney-F-Bernard_Tomic-Kevin_Anderson,Bernard Tomic,Kevin Anderson,R,R,M,20130112.0,Sydney,F,,,Hard,,3.0,1,Advanced Baseline
+20130109-M-Sydney-R16-Bernard_Tomic-Florian_Mayer,Bernard Tomic,Florian Mayer,R,R,M,20130109.0,Sydney,R16,,,Hard,Gerry Armstrong,3.0,1,Amy
+20130108-M-Sydney-R32-Bernard_Tomic-Marinko_Matosevic,Bernard Tomic,Marinko Matosevic,R,R,M,20130108.0,Sydney,R32,,,Hard,,3.0,1,Amy
+20130105-M-Brisbane-SF-Kei_Nishikori-Andy_Murray,Kei Nishikori,Andy Murray,R,R,M,20130105.0,Brisbane,SF,,,Hard,,3.0,0,Briton
+20130102-M-Brisbane-R16-Jarkko_Nieminen-Alexandr_Dolgopolov,Jarkko Nieminen,Alexandr Dolgopolov,L,R,M,20130102.0,Brisbane,R16,,Centre,Hard,,3.0,1,1HandBH
+20130102-M-Brisbane-R16-Florian_Mayer-Marcos_Baghdatis,Florian Mayer,Marcos Baghdatis,R,R,M,20130102.0,Brisbane,R16,,Centre,Hard,Damian Steiner,3.0,1,Antonio_Eni
+20121112-M-Tour_Finals-F-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20121112.0,Tour Finals,F,15:19,O2 arena,Indoor Hard,Lars Graff,3.0,1,Sagar Manohar
+20121111-M-Tour_Finals-SF-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20121111.0,Tour Finals,SF,,,Hard,,3.0,1,Isaac
+20121107-M-Tour_Finals-RR-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20121107.0,Tour Finals,RR,3pm,Centre,Hard,Lars Graff,3.0,1,Edo
+20121102-M-Paris_Masters-QF-David_Ferrer-Jo_Wilfried_Tsonga,David Ferrer,Jo Wilfried Tsonga,R,R,M,20121102.0,Paris Masters,QF,7:40PM,Centre,Hard,,3.0,1,cameron10
+20121029-M-Paris_Masters-R16-Michael_Llodra-Juan_Martin_Del_Potro,Michael Llodra,Juan Martin Del Potro,L,R,M,20121029.0,Paris Masters,R16,,,Hard,,3.0,1,Isaac
+20121029-M-Paris_Masters-F-David_Ferrer-Jerzy_Janowicz,David Ferrer,Jerzy Janowicz,R,R,M,20121029.0,Paris Masters,F,,Centre,Hard,,3.0,1,Isaac
+20121028-M-Basel-F-Roger_Federer-Juan_Martin_Del_Potro,Roger Federer,Juan Martin Del Potro,R,R,M,20121028.0,Basel,F,3:00 PM,Centre,Hard,Lars Graff,3.0,1,Edo
+20121012-M-Shanghai_Masters-SF-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20121012.0,Shanghai Masters,SF,,,Hard,,3.0,1,Isaac
+20121011-M-Shanghai_Masters-R16-Alexandr_Dolgopolov-Andy_Murray,Alexandr Dolgopolov,Andy Murray,R,R,M,20121011.0,Shanghai Masters,R16,,Stadium,Hard,Cedric Mourier,3.0,1,Mark G
+20121011-M-Shanghai_Masters-QF-Marin_Cilic-Roger_Federer,Marin Cilic,Roger Federer,R,R,M,20121011.0,Shanghai Masters,QF,,,Hard,,3.0,1,Isaac
+20121008-M-Shanghai_Masters-R32-Novak_Djokovic-Grigor_Dimitrov,Novak Djokovic,Grigor Dimitrov,R,R,M,20121008.0,Shanghai Masters,R32,,,Hard,,3.0,1,Isaac
+20121008-M-Shanghai_Masters-R16-Roger_Federer-Stanislas_Wawrinka,Roger Federer,Stanislas Wawrinka,R,R,M,20121008.0,Shanghai Masters,R16,,,Hard,,3.0,1,DanF
+20121008-M-Shanghai_Masters-F-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20121008.0,Shanghai Masters,F,,,Hard,,3.0,0,DanF
+20121007-M-Beijing-F-Novak_Djokovic-Jo_Wilfried_Tsonga,Novak Djokovic,Jo Wilfried Tsonga,R,R,M,20121007.0,Beijing,F,3pm,National Tennis Stadium,Hard,Mohamed Lahyani,3.0,1,Edo
+20120909-M-US_Open-SF-Novak_Djokovic-David_Ferrer,Novak Djokovic,David Ferrer,R,R,M,20120909.0,US Open,SF,3pm,Ashe,Hard,Carlos Bernardes,5.0,1,Edo
+20120909-M-US_Open-F-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20120909.0,US Open,F,,Arthur Ashe,Hard,,5.0,1,Amy
+20120908-M-US_Open-SF-Tomas_Berdych-Andy_Murray,Tomas Berdych,Andy Murray,R,R,M,20120908.0,US Open,SF,3pm,Ashe,Hard,Pascal Maria,5.0,1,Edo
+20120904-M-US_Open-QF-Novak_Djokovic-Juan_Martin_Del_Potro,Novak Djokovic,Juan Martin Del Potro,R,R,M,20120904.0,US Open,QF,,,Hard,,5.0,1,Isaac
+20120829-M-US_Open-R64-Ivan_Dodig-Andy_Murray,Ivan Dodig,Andy Murray,R,R,M,20120829.0,US Open,R64,,,Hard,Roland Herfel,5.0,1,Amy
+20120820-M-Finland_F3-SF-Vladimir_Ivanov-Alexander_Vasilenko,Vladimir Ivanov,Alexander Vasilenko,R,R,M,20120820.0,Finland F3,SF,,,Clay,,3.0,1,Isaac
+20120820-M-Finland_F3-SF-Markus_Eriksson-Alexandre_Penaud,Markus Eriksson,Alexandre Penaud,R,R,M,20120820.0,Finland F3,SF,,,Clay,,3.0,1,Isaac
+20120818-M-Cincinnati_Masters-F-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20120818.0,Cincinnati Masters,F,,,Hard,,3.0,1,Amy
+20120812-M-Finland_F1-F-Milos_Sekulic-Vladimir_Ivanov,Milos Sekulic,Vladimir Ivanov,R,R,M,20120812.0,Finland F1,F,,,Clay,,3.0,1,Isaac
+20120812-M-Canada_Masters-F-Novak_Djokovic-Richard_Gasquet,Novak Djokovic,Richard Gasquet,R,R,M,20120812.0,Canada Masters,F,,,Hard,,3.0,1,Isaac
+20120806-M-Finland_F1-SF-Andres_Artunedo-Vladimir_Ivanov,Andres Artunedo,Vladimir Ivanov,R,R,M,20120806.0,Finland F1,SF,,,Clay,,3.0,1,Isaac
+20120805-M-Olympics-BR-Novak_Djokovic-Juan_Martin_Del_Potro,Novak Djokovic,Juan Martin Del Potro,R,R,M,20120805.0,Olympics,BR,,1,Grass,Lars Graff,3.0,0,Salvo
+20120804-M-Olympics-F-Andy_Murray-Roger_Federer,Andy Murray,Roger Federer,R,R,M,20120804.0,Olympics,F,,,Grass,,3.0,1,Isaac
+20120803-M-Olympics-SF-Andy_Murray-Novak_Djokovic,Andy Murray,Novak Djokovic,R,R,M,20120803.0,Olympics,SF,18:30,Centre,Grass,Jake Garner,3.0,0,hnjc95
+20120802-M-Olympics-QF-Novak_Djokovic-Jo_Wilfried_Tsonga,Novak Djokovic,Jo Wilfried Tsonga,R,R,M,20120802.0,Olympics,QF,,Centre,Grass,Enric Molina,3.0,0,Salvo
+20120802-M-Olympics-QF-Nicolas_Almagro-Andy_Murray,Nicolas Almagro,Andy Murray,R,R,M,20120802.0,Olympics,QF,,1,Grass,John Blom,3.0,0,Salvo
+20120802-M-Olympics-QF-John_Isner-Roger_Federer,John Isner,Roger Federer,R,R,M,20120802.0,Olympics,QF,,Centre,Grass,Carlos Bernardes,3.0,0,Salvo
+20120801-M-Olympics-R16-Roger_Federer-Denis_Istomin,Roger Federer,Denis Istomin,R,R,M,20120801.0,Olympics,R16,,1,Grass,Eva Asderaki,3.0,0,Salvo
+20120801-M-Olympics-R16-Novak_Djokovic-Lleyton_Hewitt,Novak Djokovic,Lleyton Hewitt,R,R,M,20120801.0,Olympics,R16,,Centre,Grass,,3.0,0,Albertini
+20120801-M-Olympics-R16-Andy_Murray-Marcos_Baghdatis,Andy Murray,Marcos Baghdatis,R,R,M,20120801.0,Olympics,R16,,Centre,Grass,Carlos Bernardes,3.0,0,Salvo
+20120731-M-Olympics-R32-Novak_Djokovic-Andy_Roddick,Novak Djokovic,Andy Roddick,R,R,M,20120731.0,Olympics,R32,,,Grass,,3.0,0,EricJ
+20120731-M-Olympics-R32-Jarkko_Nieminen-Andy_Murray,Jarkko Nieminen,Andy Murray,L,R,M,20120731.0,Olympics,R32,,Centre,Grass,Pascal Maria,3.0,0,Salvo
+20120730-M-Olympics-R32-Juan_Martin_Del_Potro-Andreas_Seppi,Juan Martin Del Potro,Andreas Seppi,R,R,M,20120730.0,Olympics,R32,,Centre,Grass,Jake Garner,3.0,0,Salvo
+20120729-M-Olympics-R64-Novak_Djokovic-Fabio_Fognini,Novak Djokovic,Fabio Fognini,R,R,M,20120729.0,Olympics,R64,,1,Grass,Pascal Maria,3.0,0,Salvo
+20120729-M-Olympics-R64-Jo_Wilfried_Tsonga-Thomaz_Bellucci,Jo Wilfried Tsonga,Thomaz Bellucci,R,L,M,20120729.0,Olympics,R64,,Centre,Grass,Enric Molina,3.0,0,Salvo
+20120729-M-Olympics-R64-Andy_Murray-Stanislas_Wawrinka,Andy Murray,Stanislas Wawrinka,R,R,M,20120729.0,Olympics,R64,,Centre,Grass,Lars Graff,3.0,0,Salvo
+20120728-M-Olympics-R64-Roger_Federer-Alejandro_Falla,Roger Federer,Alejandro Falla,R,L,M,20120728.0,Olympics,R64,,Centre,Grass,Carlos Bernardes,3.0,0,Salvo
+20120725-M-Olympics-R32-Roger_Federer-Julien_Benneteau,Roger Federer,Julien Benneteau,R,R,M,20120725.0,Olympics,R32,,,Grass,,3.0,1,Isaac
+20120708-M-Wimbledon-F-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20120708.0,Wimbledon,F,2:00 PM,Centre,Grass,Enric Molina,5.0,0,Paul
+20120706-M-Wimbledon-SF-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20120706.0,Wimbledon,SF,,Centre,Grass,,5.0,0,Geethika
+20120706-M-Wimbledon-SF-Andy_Murray-Jo_Wilfried_Tsonga,Andy Murray,Jo Wilfried Tsonga,R,R,M,20120706.0,Wimbledon,SF,4pm,Centre,Grass,Carlos Ramos,5.0,0,Edo
+20120617-M-Halle-F-Tommy_Haas-Roger_Federer,Tommy Haas,Roger Federer,R,R,M,20120617.0,Halle,F,2:00 PM,Stadion,Grass,Ali Nili,3.0,1,Edo
+20120608-M-Roland_Garros-SF-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20120608.0,Roland Garros,SF,,Centre,Clay,,5.0,0,JEH
+20120608-M-Roland_Garros-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20120608.0,Roland Garros,F,,Chatrier,Clay,,5.0,0,Amy
+20120519-M-Rome_Masters-SF-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20120519.0,Rome Masters,SF,20:00:00,Centrale,Clay,Damien Dumusois,3.0,0,Edo
+20120519-M-Rome_Masters-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20120519.0,Rome Masters,F,,Campo Centrale,Clay,,3.0,1,Isaac
+20120516-M-Rome_Masters-R32-Roger_Federer-Carlos_Berlocq,Roger Federer,Carlos Berlocq,R,R,M,20120516.0,Rome Masters,R32,,,Clay,,3.0,0,Isaac
+20120512-M-Madrid_Masters-SF-Tomas_Berdych-Juan_Martin_Del_Potro,Tomas Berdych,Juan Martin Del Potro,R,R,M,20120512.0,Madrid Masters,SF,,,Clay,,3.0,1,Isaac
+20120512-M-Madrid_Masters-F-Tomas_Berdych-Roger_Federer,Tomas Berdych,Roger Federer,R,R,M,20120512.0,Madrid Masters,F,4:00 PM,Manolo Santana,Clay,Mohamed Layhani,3.0,1,Edo
+20120510-M-Madrid_Masters-R16-Roger_Federer-Richard_Gasquet,Roger Federer,Richard Gasquet,R,R,M,20120510.0,Madrid Masters,R16,,,Clay,,3.0,1,Amy
+20120510-M-Madrid_Masters-QF-David_Ferrer-Roger_Federer,David Ferrer,Roger Federer,R,R,M,20120510.0,Madrid Masters,QF,,,Clay,,3.0,1,Isaac
+20120422-M-Monte_Carlo_Masters-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20120422.0,Monte Carlo Masters,F,,Campo Centrale,Clay,,3.0,1,Isaac
+20120406-M-Davis_Cup_World_Group_QF-RR-Ivo_Karlovic-Juan_Martin_Del_Potro,Ivo Karlovic,Juan Martin Del Potro,R,R,M,20120406.0,Davis Cup World Group QF,RR,16:15,Parque Roca,Clay,,5.0,0,1HandBH
+20120401-M-Miami_Masters-F-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20120401.0,Miami Masters,F,3:00 PM,Stadium,Hard,Damian Steiner,3.0,1,Edo
+20120327-M-Miami_Masters-QF-David_Ferrer-Novak_Djokovic,David Ferrer,Novak Djokovic,R,R,M,20120327.0,Miami Masters,QF,,,Hard,,3.0,1,Isaac
+20120319-M-Indian_Wells_Masters-F-Roger_Federer-John_Isner,Roger Federer,John Isner,R,R,M,20120319.0,Indian Wells Masters,F,7:10PM,Stadium 1,Hard Outdoor,Mohamed Lahyani,3.0,1,cameron10
+20120316-M-Indian_Wells_Masters-SF-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20120316.0,Indian Wells Masters,SF,12:17,Centre Court,Hard,Steve Ullrich,3.0,1,Sagar Manohar
+20120303-M-Dubai-F-Andy_Murray-Roger_Federer,Andy Murray,Roger Federer,R,R,M,20120303.0,Dubai,F,7:10 PM,Centre,Hard,Mohamed Lahyani,3.0,1,Chris Devine
+20120227-M-Dubai-SF-Andy_Murray-Novak_Djokovic,Andy Murray,Novak Djokovic,R,R,M,20120227.0,Dubai,SF,,Centre,Hard,,3.0,1,Isaac
+20120225-M-Buenos_Aires-SF-David_Ferrer-David_Nalbandian,David Ferrer,David Nalbandian,R,R,M,20120225.0,Buenos Aires,SF,,,Clay,,3.0,1,Isaac
+20120219-M-Rotterdam-F-Roger_Federer-Juan_Martin_Del_Potro,Roger Federer,Juan Martin del Potro,R,R,M,20120219.0,Rotterdam,F,,,Hard,,3.0,1,Amy
+20120210-M-Davis_Cup_World_Group_R1-RR-Julien_Benneteau-Milos_Raonic,Julien Benneteau,Milos Raonic,R,R,M,20120210.0,Davis Cup World Group R1,RR,,,Hard,,5.0,0,@CanuckKicker
+20120129-M-Australian_Open-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20120129.0,Australian Open,F,,Rod Laver,Hard,,5.0,0,Amy
+20120127-M-Australian_Open-SF-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20120127.0,Australian Open,SF,,Rod laver Arena,Hard,,5.0,0,Isaac
+20120127-M-Australian_Open-SF-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20120127.0,Australian Open,SF,,Rod Laver Arena,Hard,,5.0,0,Isaac
+20120125-M-Australian_Open-QF-Andy_Murray-Kei_Nishikori,Andy Murray,Kei Nishikori,R,R,M,20120125.0,Australian Open,QF,0330 GMT,Rod Laver Arena,Hard,,5.0,0,Rex
+20120124-M-Australian_Open-QF-David_Ferrer-Novak_Djokovic,David Ferrer,Novak Djokovic,R,R,M,20120124.0,Australian Open,QF,,Rod Laver Arena,Hard,,5.0,0,Isaac
+20120122-M-Australian_Open-R16-Novak_Djokovic-Lleyton_Hewitt,Novak Djokovic,Lleyton Hewitt,R,R,M,20120122.0,Australian Open,R16,,Rod Laver Arena,Hard,,5.0,0,Isaac
+20120121-M-Australian_Open-R32-Michael_Llodra-Andy_Murray,Michael Llodra,Andy Murray,L,R,M,20120121.0,Australian Open,R32,19:09,Hisense Arena,Hard,Enric Molina,5.0,0,1HandBH
+20120108-M-Chennai-F-Milos_Raonic-Janko_Tipsarevic,Milos Raonic,Janko Tipsarevic,R,R,M,20120108.0,Chennai,F,,Centre,Hard,,3.0,1,@CanuckKicker
+20111127-M-Tour_Finals-F-Roger_Federer-Jo_Wilfried_Tsonga,Roger Federer,Jo Wilfried Tsonga,R,R,M,20111127.0,Tour Finals,F,8:00 PM,Centre,Hard,Steve Ullrich,3.0,1,Edo
+20111125-M-Tour_Finals-SF-David_Ferrer-Roger_Federer,David Ferrer,Roger Federer,R,R,M,20111125.0,Tour Finals,SF,,Centre,Hard,,3.0,1,Isaac
+20111122-M-Tour_Finals-RR-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20111122.0,Tour Finals,RR,,,Hard,Steve Ulrich,3.0,1,Amy
+20111113-M-Paris_Masters-F-Roger_Federer-Jo_Wilfried_Tsonga,Roger Federer,Jo Wilfried Tsonga,R,R,M,20111113.0,Paris Masters,F,3:00 PM,Court Central,Hard,Lars Graff,3.0,1,Edo
+20111111-M-Paris_Masters-QF-Roger_Federer-Juan_Monaco,Roger Federer,Juan Monaco,R,R,M,20111111.0,Paris Masters,QF,,,Hard,,3.0,1,Isaac
+20111110-M-Paris_Masters-R16-Richard_Gasquet-Roger_Federer,Richard Gasquet,Roger Federer,R,R,M,20111110.0,Paris Masters,R16,,,Hard,,3.0,1,Isaac
+20111106-M-Basel-F-Kei_Nishikori-Roger_Federer,Kei Nishikori,Roger Federer,R,R,M,20111106.0,Basel,F,14:15,Center,Hard,Mohamed El Jennati,3.0,1,1HandBH
+20111021-M-Stockholm-QF-Grigor_Dimitrov-Milos_Raonic,Grigor Dimitrov,Milos Raonic,R,R,M,20111021.0,Stockholm,QF,,,Hard,,3.0,1,Isaac
+20111016-M-Shanghai_Masters-F-David_Ferrer-Andy_Murray,David Ferrer,Andy Murray,R,R,M,20111016.0,Shanghai Masters,F,16:30:00,Stadium,Hard,Carlos Bernardes,3.0,1,Edo
+20111009-M-Tokyo-F-Rafael_Nadal-Andy_Murray,Rafael Nadal,Andy Murray,L,R,M,20111009.0,Tokyo,F,,,Hard,,3.0,1,Isaac
+20111009-M-Shanghai_Masters-R32-David_Ferrer-Milos_Raonic,David Ferrer,Milos Raonic,R,R,M,20111009.0,Shanghai Masters,R32,,,Hard,,3.0,1,Isaac
+20111008-M-Tokyo-SF-David_Ferrer-Andy_Murray,David Ferrer,Andy Murray,R,R,M,20111008.0,Tokyo,SF,,,Hard,,3.0,1,Isaac
+20110918-M-Davis_Cup_World_Group_SF-RR-Jo_Wilfried_Tsonga-Rafael_Nadal,Jo Wilfried Tsonga,Rafael Nadal,R,L,M,20110918.0,Davis Cup World Group SF,RR,,Plaza de Toros de los Califas,Clay,Jake Garner,5.0,0,Salvo
+20110917-M-Davis_Cup_World_Group_PO-RR-Roger_Federer-Lleyton_Hewitt,Roger Federer,Lleyton Hewitt,R,R,M,20110917.0,Davis Cup World Group PO,RR,,,Grass,Alexandre Juge,5.0,0,Palaver
+20110916-M-Davis_Cup_World_Group_SF-RR-Richard_Gasquet-Rafael_Nadal,Richard Gasquet,Rafael Nadal,R,L,M,20110916.0,Davis Cup World Group SF,RR,,Plaza de Toros de los Califas,Clay,Jake Garner,5.0,0,Salvo
+20110911-M-US_Open-SF-Andy_Murray-Rafael_Nadal,Andy Murray,Rafael Nadal,R,L,M,20110911.0,US Open,SF,,Ashe,Hard,Carlos Bernardes,5.0,1,Edo
+20110911-M-US_Open-F-Rafael_Nadal_-Novak_Djokovic,Rafael Nadal ,Novak Djokovic,L,R,M,20110911.0,US Open,F,,Arthur Ashe Stadium,Hard,Carlos Ramos,3.0,1,Isaac
+20110909-M-US_Open-SF-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20110909.0,US Open,SF,,,Hard,,5.0,1,Isaac
+20110821-M-Cincinnati_Masters-F-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20110821.0,Cincinnati Masters,F,,Center,Hard,Fergus Murphy,3.0,1,Salvo
+20110815-M-Cincinnati_Masters-R32-Roger_Federer-Juan_Martin_Del_Potro,Roger Federer,Juan Martin Del Potro,R,R,M,20110815.0,Cincinnati Masters,R32,,,Hard,,3.0,1,Isaac
+20110717-M-Bastad-F-David_Ferrer-Robin_Soderling,David Ferrer,Robin Soderling,R,R,M,20110717.0,Bastad,F,,,Clay,,3.0,1,Amy
+20110703-M-Wimbledon-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20110703.0,Wimbledon,F,,,Grass,,5.0,0,Isaac
+20110701-M-Wimbledon-SF-Novak_Djokovic-Jo_Wilfried_Tsonga,Novak Djokovic,Jo Wilfried Tsonga,R,R,M,20110701.0,Wimbledon,SF,1pm,Centre,Grass,Carlos Ramos,5.0,0,Edo
+20110701-M-Wimbledon-SF-Andy_Murray-Rafael_Nadal,Andy Murray,Rafael Nadal,R,L,M,20110701.0,Wimbledon,SF,4pm,Centre,Grass,Mohamed Lahyani,5.0,0,Edo
+20110606-M-Queens_Club-SF-Andy_Murray-Andy_Roddick,Andy Murray,Andy Roddick,R,R,M,20110606.0,Queens Club,SF,,,Grass,,3.0,1,Isaac
+20110605-M-Roland_Garros-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20110605.0,Roland Garros,F,3:00 PM,Philippe Chatrier,Clay,Pascal Maria,5.0,0,Edo
+20110603-M-Roland_Garros-SF-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20110603.0,Roland Garros,SF,,Philippe Chatrier,Clay,,5.0,0,Edged
+20110603-M-Roland_Garros-SF-Andy_Murray-Rafael_Nadal,Andy Murray,Rafael Nadal,R,L,M,20110603.0,Roland Garros,SF,5.30pm,Philippe Chatrier,Clay,Kader Nouni,5.0,0,Edo
+20110513-M-Rome_Masters-SF-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20110513.0,Rome Masters,SF,,,Clay,,3.0,1,Isaac
+20110508-M-Rome_Masters-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20110508.0,Rome Masters,F,,Campo Centrale,Clay,,3.0,1,Isaac
+20110508-M-Madrid_Masters-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20110508.0,Madrid Masters,F,8:00 PM,Manolo Santana,Clay,Lars Graff,3.0,1,Edo
+20110507-M-Madrid_Masters-SF-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20110507.0,Madrid Masters,SF,8:00 PM,Manolo Santana,Clay,Mohamed Lahyani,3.0,1,Edo
+20110504-M-Madrid_Masters-R32-Novak_Djokovic-Kevin_Anderson,Novak Djokovic,Kevin Anderson,R,R,M,20110504.0,Madrid Masters,R32,,,Clay,,3.0,1,Isaac
+20110424-M-Barcelona-F-David_Ferrer-Rafael_Nadal,David Ferrer,Rafael Nadal,R,L,M,20110424.0,Barcelona,F,,,Clay,Mohamed Lahyani,3.0,1,Isaac
+20110417-M-Monte_Carlo-F-David_Ferrer-Rafael_Nadal,David Ferrer,Rafael Nadal,R,L,M,20110417.0,Monte Carlo,F,2.30PM,Court Central,Clay,CŽdric Mourier,3.0,1,Edo
+20110403-M-Miami_Masters-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20110403.0,Miami Masters,F,3:00 PM,Stadium,Hard,Fergus Murphy,3.0,1,Edo
+20110401-M-Miami_Masters-SF-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20110401.0,Miami Masters,SF,,Stadium,Hard,Steve Ullrich,3.0,1,Isaac
+20110319-M-Indian_Wells_Masters-SF-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20110319.0,Indian Wells Masters,SF,2:00:00 PM,Stadium 1,Hard,Steve Ullrich,3.0,1,Edo
+20110319-M-Indian_Wells_Masters-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20110319.0,Indian Wells Masters,F,,,Hard,,3.0,1,Isaac
+20110316-M-Indian_Wells_Masters-QF-Roger_Federer-Stanislas_Wawrinka,Roger Federer,Stanislas Wawrinka,R,R,M,20110316.0,Indian Wells Masters,QF,,Stadium 1,Hard,,3.0,1,Isaac
+20110310-M-Indian_Wells_Masters-QF-Richard_Gasquet-Novak_Djokovic,Richard Gasquet,Novak Djokovic,R,R,M,20110310.0,Indian Wells Masters,QF,,,Hard,Damian Steiner,3.0,1,Isaac
+20110221-M-Dubai-F-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20110221.0,Dubai,F,,,Hard,Mohamed Lahyani,3.0,1,Isaac
+20110130-M-Australian_Open-F-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20110130.0,Australian Open,F,,,Hard,,3.0,1,Isaac
+20110128-M-Australian_Open-SF-David_Ferrer-Andy_Murray,David Ferrer,Andy Murray,R,R,M,20110128.0,Australian Open,SF,7.30pm,Rod Laver Arena,Hard,Carlos Ramos,5.0,0,Edo
+20110127-M-Australian_Open-SF-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20110127.0,Australian Open,SF,,Rod Laver Arena,Hard,Enric Molina,5.0,0,Tanmay
+20110123-M-Australian_Open-R16-Robin_Soderling-Alexandr_Dolgopolov,Robin Soderling,Alexandr Dolgopolov,R,R,M,20110123.0,Australian Open,R16,,,Hard,,5.0,1,Isaac
+20110120-M-Australian_Open-R64-Gilles_Simon-Roger_Federer,Gilles Simon,Roger Federer,R,R,M,20110120.0,Australian Open,R64,,Rod Laver Arena,Hard,,5.0,0,Isaac
+20110118-M-Australian_Open-R128-David_Nalbandian-Lleyton_Hewitt,David Nalbandian,Lleyton Hewitt,R,R,M,20110118.0,Australian Open,R128,20:18,Rod Laver Arena,Hard,Pascal Maria,5.0,0,1HandBH
+20110115-M-Sydney-F-Gilles_Simon-Viktor_Troicki,Gilles Simon,Viktor Troicki,R,R,M,20110115.0,Sydney,F,18:45,Centre,Hard,Steve Ullrich,3.0,1,1HandBH
+20110108-M-Doha-F-Roger_Federer-Nikolay_Davydenko,Roger Federer,Nikolay Davydenko,R,R,M,20110108.0,Doha,F,6:00 PM,Center,Hard,Mohamed Lahyani,3.0,1,Edo
+20110102-M-Brisbane-R16-Robin_Soderling-Michael_Berrer,Robin Soderling,Michael Berrer,R,L,M,20110102.0,Brisbane,R16,,,Hard,,3.0,1,Amy
+20101128-M-Tour_Finals-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20101128.0,Tour Finals,F,18:00:00,Centre,Hard,Mohamed Lahyani,3.0,1,Edo
+20101126-M-Tour_Finals-SF-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20101126.0,Tour Finals,SF,,,Hard,,3.0,1,Isaac
+20101124-M-Tour_Finals-RR-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20101124.0,Tour Finals,RR,7pm,Centre,Hard,Steve Ullrich,3.0,1,Edo
+20101122-M-Tour_Finals-RR-Robin_Soderling-Andy_Murray,Robin Soderling,Andy Murray,R,R,M,20101122.0,Tour Finals,RR,,,Hard,,3.0,1,Isaac
+20101121-M-Tour_Finals-RR-Tomas_Berdych-Novak_Djokovic,Tomas Berdych,Novak Djokovic,R,R,M,20101121.0,Tour Finals,RR,,,Hard,,3.0,1,Isaac
+20101121-M-Tour_Finals-RR-Novak_Djokovic-Andy_Roddick,Novak Djokovic,Andy Roddick,R,R,M,20101121.0,Tour Finals,RR,,Centre Court,Hard,,3.0,1,Isaac
+20101121-M-Tour_Finals-RR-Andy_Roddick-Rafael_Nadal,Andy Roddick,Rafael Nadal,R,L,M,20101121.0,Tour Finals,RR,,,Hard,,3.0,1,Isaac
+20101121-M-Tour_Finals-RR-Andy_Murray_-Roger_Federer,Andy Murray ,Roger Federer,R,R,M,20101121.0,Tour Finals,RR,,Centre Court,Hard,,3.0,1,Isaac
+20101112-M-Paris_Masters-F-Robin_Soderling-Gael_Monfils,Robin Soderling,Gael Monfils,R,R,M,20101112.0,Paris Masters,F,3:30 PM,Centre,Hard,Fergus Murphy,3.0,1,Edo
+20101107-M-Basel-F-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20101107.0,Basel,F,3:00 PM,Centre,Hard,Mohamed Layhani,3.0,1,Edo
+20101024-M-Stockholm-F-Roger_Federer-Florian_Mayer,Roger Federer,Florian Mayer,R,R,M,20101024.0,Stockholm,F,12:15:00 PM,,Hard,Lars Graff,3.0,1,ChapelHeel66
+20101017-M-Shanghai_Masters-F-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20101017.0,Shanghai Masters,F,5:00:00 PM,Centre,Hard,Cedric Mourier,3.0,1,Edo
+20101015-M-Shanghai_Masters-SF-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20101015.0,Shanghai Masters,SF,,Stadium,Hard,,3.0,1,Isaac
+20101010-M-Tokyo-F-Rafael_Nadal-Gael_Monfils,Rafael Nadal,Gael Monfils,L,R,M,20101010.0,Tokyo,F,,,Hard,,3.0,1,Isaac
+20101010-M-Shanghai_Masters-QF-Robin_Soderling-Roger_Federer,Robin Soderling,Roger Federer,R,R,M,20101010.0,Shanghai Masters,QF,,,Hard,,3.0,1,Amy
+20100912-M-US_Open-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20100912.0,US Open,F,,Arthur Ashe Stadium,Hard,,5.0,1,Isaac
+20100911-M-US_Open-SF-Rafael_Nadal-Mikhail_Youzhny,Rafael Nadal,Mikhail Youzhny,L,R,M,20100911.0,US Open,SF,3pm,Ashe,Hard,Jake Garner,5.0,1,Edo
+20100903-M-US_Open-SF-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20100903.0,US Open,SF,3pm,Ashe,Hard,Enric Molina,5.0,1,Edo
+20100821-M-Cincinnati_Masters-F-Mardy_Fish-Roger_Federer,Mardy Fish,Roger Federer,R,R,M,20100821.0,Cincinnati Masters,F,3:00:00 PM,Centre,Hard,Gerry Armstrong,3.0,1,Edo
+20100815-M-Canada_Masters-SF-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20100815.0,Canada Masters,SF,,,Hard,,3.0,1,Isaac
+20100815-M-Canada_Masters-F-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20100815.0,Canada Masters,F,3:00:00 PM,Toronto,Hard,Lars Graff,3.0,1,Edo
+20100704-M-Wimbledon-F-Tomas_Berdych-Rafael_Nadal,Tomas Berdych,Rafael Nadal,R,L,M,20100704.0,Wimbledon,F,2:00 PM,Centre,Grass,Jake Garner,5.0,0,Edo
+20100702-M-Wimbledon-SF-Tomas_Berdych-Novak_Djokovic,Tomas Berdych,Novak Djokovic,R,R,M,20100702.0,Wimbledon,SF,1pm,Centre,Grass,Carlos Ramos,5.0,0,Edo
+20100702-M-Wimbledon-SF-Andy_Murray-Rafael_Nadal,Andy Murray,Rafael Nadal,R,L,M,20100702.0,Wimbledon,SF,4pm,Centre,Grass,Carlos Bernardes,5.0,0,Edo
+20100613-M-Halle-F-Roger_Federer-Lleyton_Hewitt,Roger Federer,Lleyton Hewitt,R,R,M,20100613.0,Halle,F,2:00 PM,Stadion,Grass,Mohamed El Jennati,3.0,1,Edo
+20100606-M-Roland_Garros-F-Robin_Soderling-Rafael_Nadal,Robin Soderling,Rafael Nadal,R,L,M,20100606.0,Roland Garros,F,,,Clay,,5.0,0,Amy
+20100512-M-Madrid_Masters-R16-John_Isner-Rafael_Nadal,John Isner,Rafael Nadal,R,R,M,20100512.0,Madrid Masters,R16,,,Clay,,3.0,1,Isaac
+20100509-M-Madrid_Masters-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20100509.0,Madrid Masters,F,,Manolo Santana,Clay,,3.0,1,Isaac
+20100502-M-Rome_Masters-F-David_Ferrer-Rafael_Nadal,David Ferrer,Rafael Nadal,R,L,M,20100502.0,Rome Masters,F,16:30:00,Pietrangeli,Clay,Carlos Bernardes,3.0,1,Edo
+20100501-M-Rome_Masters-SF-Ernests_Gulbis-Rafael_Nadal,Ernests Gulbis,Rafael Nadal,R,L,M,20100501.0,Rome Masters,SF,4:00 PM,Centre,Clay,Mohamed Lahyani,3.0,1,MaGav
+20100418-M-Monte_Carlo_Masters-F-Fernando_Verdasco-Rafael_Nadal,Fernando Verdasco,Rafael Nadal,L,L,M,20100418.0,Monte Carlo Masters,F,2:30 PM,Centre,Clay,,3.0,1,cameron10
+20100415-M-Monte_Carlo_Masters-R16-Rafael_Nadal-Michael_Berrer,Rafael Nadal,Michael Berrer,L,L,M,20100415.0,Monte Carlo Masters,R16,,,Clay,,3.0,1,Isaac
+20100404-M-Miami_Masters-F-Tomas_Berdych-Andy_Roddick,Tomas Berdych,Andy Roddick,R,R,M,20100404.0,Miami Masters,F,3:00 PM,Stadium,Hard,Cedric Mourier,3.0,1,Edo
+20100131-M-Australian_Open-F-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20100131.0,Australian Open,F,,Rod Laver,Hard,,5.0,0,Edged
+20100128-M-Australian_Open-SF-Roger_Federer-Jo_Wilfried_Tsonga,Roger Federer,Jo Wilfried Tsonga,R,R,M,20100128.0,Australian Open,SF,7pm,Rod Laver Arena,Hard,Jake Garner,5.0,0,Edo
+20100128-M-Australian_Open-SF-Andy_Murray-Marin_Cilic,Andy Murray,Marin Cilic,R,R,M,20100128.0,Australian Open,SF,6.30pm,Rod Laver Arena,Hard,Pascal Maria,5.0,0,Edo
+20100126-M-Australian_Open-QF-Novak_Djokovic-Jo_Wilfried_Tsonga,Novak Djokovic,Jo Wilfried Tsonga,R,R,M,20100126.0,Australian Open,QF,,,Hard,,5.0,0,Isaac
+20100126-M-Australian_Open-QF-Andy_Murray-Rafael_Nadal,Andy Murray,Rafael Nadal,R,L,M,20100126.0,Australian Open,QF,,Rod Laver Arena,Hard,,5.0,0,Isaac
+20100124-M-Australian_Open-R16-Roger_Federer-Lleyton_Hewitt,Roger Federer,Lleyton Hewitt,R,R,M,20100124.0,Australian Open,R16,,Rod Laver Arena,Hard,Pascal Maria,5.0,0,Palaver
+20100110-M-Doha-F-Rafael_Nadal-Nikolay_Davydenko,Rafael Nadal,Nikolay Davydenko,L,R,M,20100110.0,Doha,F,,Center,Hard,Mohamed Lahyani,3.0,1,Palaver
+20100108-M-Doha-SF-Roger_Federer-Nikolay_Davydenko,Roger Federer,Nikolay Davydenko,R,R,M,20100108.0,Doha,SF,,Centre,Hard,,3.0,1,Isaac
+20091129-M-Tour_Finals-F-Nikolay_Davydenko-Juan_Martin_Del_Potro,Nikolay Davydenko,Juan Martin Del Potro,R,R,M,20091129.0,Tour Finals,F,14:30:00,Centre,Hard,Lars Graff,3.0,1,Edo
+20091129-M-Tour_Finals-F-Nikolay_Davydenko-Juan_Martin_Del_Potro,Nikolay Davydenko,Juan Martin Del Potro,R,R,M,20091129.0,Tour Finals,F,14:30:00,Centre,Hard,Lars Graff,3.0,1,Edo
+20091127-M-Tour_Finals-SF-Robin_Soderling-Juan_Martin_Del_Potro,Robin Soderling,Juan Martin Del Potro,R,R,M,20091127.0,Tour Finals,SF,,,Hard,,3.0,1,Amy
+20091127-M-Tour_Finals-RR-Rafael_Nadal-Novak_Djokovic,Rafael Nadal,Novak Djokovic,L,R,M,20091127.0,Tour Finals,RR,7pm,Centre,Hard,Lars Graff,3.0,1,Edo
+20091123-M-Tour_Finals-RR-Robin_Soderling-Rafael_Nadal,Robin Soderling,Rafael Nadal,R,L,M,20091123.0,Tour Finals,RR,,O2 Arena,Hard,,3.0,1,Isaac
+20091122-M-Tour_Finals-RR-Robin_Soderling-Nikolay_Davydenko,Robin Soderling,Nikolay Davydenko,R,R,M,20091122.0,Tour Finals,RR,,,Hard,,3.0,1,Isaac
+20091122-M-Tour_Finals-RR-Andy_Murray-Roger_Federer,Andy Murray,Roger Federer,R,R,M,20091122.0,Tour Finals,RR,,Centre Court,Hard,,3.0,1,Isaac
+20091122-M-London-RR-Robin_Soderling-Novak_Djokovic,Robin Soderling,Novak Djokovic,R,R,M,20091122.0,London,RR,,,Hard,,3.0,1,Amy
+20091115-M-Paris_Masters-F-Novak_Djokovic-Gael_Monfils,Novak Djokovic,Gael Monfils,R,R,M,20091115.0,Paris Masters,F,3:30 PM,Centre,Hard,Carlos Bernardes,3.0,1,Edo
+20091114-M-Paris_Masters-SF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20091114.0,Paris Masters,SF,2pm,Central,Hard,Mohamed Lahyani,3.0,1,Edo
+20091110-M-Paris_Masters-R32-Marat_Safin-Juan_Martin_Del_Potro,Marat Safin,Juan Martin Del Potro,R,R,M,20091110.0,Paris Masters,R32,,,Hard,,3.0,1,Amy
+20091108-M-Basel-F-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20091108.0,Basel,F,3:00 PM,Centre,Hard,Lars Graff,3.0,1,Edo
+20090914-M-US_Open-F-Roger_Federer-Juan_Martin_Del_Potro,Roger Federer,Juan Martin Del Potro,R,R,M,20090914.0,US Open,F,,Ashe,Hard,,5.0,1,Amy
+20090913-M-US_Open-SF-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20090913.0,US Open,SF,,Arthur Ashe,Hard,,5.0,1,camyu19
+20090913-M-US_Open-SF-Juan_Martin_Del_Potro-Rafael_Nadal,Juan Martin Del Potro,Rafael Nadal,R,L,M,20090913.0,US Open,SF,1pm,Ashe,Hard,Steve Ullrich,5.0,1,Edo
+20090913-M-US_Open-SF-Juan_Martin_Del_Potro-Rafael_Nadal,Juan Martin Del Potro,Rafael Nadal,R,L,M,20090913.0,US Open,SF,1pm,Ashe,Hard,Steve Ullrich,5.0,1,Edo
+20090905-M-US_Open-R32-Roger_Federer-Lleyton_Hewitt,Roger Federer,Lleyton Hewitt,R,R,M,20090905.0,US Open,R32,,Arthur Ashe,Hard,Jake Garner,5.0,1,Palaver
+20090823-M-Cincinnati_Masters-SF-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20090823.0,Cincinnati Masters,SF,,,Hard,,3.0,1,DanF
+20090822-M-Cincinnati_Masters-SF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20090822.0,Cincinnati Masters,SF,8pm,Central,Hard,Fergus Murphy,3.0,1,Edo
+20090821-M-Cincinnati_Masters-QF-Roger_Federer-Lleyton_Hewitt,Roger Federer,Lleyton Hewitt,R,R,M,20090821.0,Cincinnati Masters,QF,,Center,Hard,Carlos Bernardes,3.0,1,Palaver
+20090816-M-Cincinnati_Masters-F-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20090816.0,Cincinnati Masters,F,,,Hard,,3.0,1,Isaac
+20090705-M-Wimbledon-F-Andy_Roddick-Roger_Federer,Andy Roddick,Roger Federer,R,R,M,20090705.0,Wimbledon,F,,Centre,Grass,Lars Graff,5.0,0,Paul
+20090703-M-Wimbledon-SF-Tommy_Haas-Roger_Federer,Tommy Haas,Roger Federer,R,R,M,20090703.0,Wimbledon,SF,1pm,Centre,Grass,Enric Molina,5.0,0,Edo
+20090703-M-Wimbledon-SF-Andy_Roddick-Andy_Murray,Andy Roddick,Andy Murray,R,R,M,20090703.0,Wimbledon,SF,4pm,Centre,Grass,Pascal Maria,5.0,0,Edo
+20090607-M-Roland_Garros-F-Robin_Soderling-Roger_Federer,Robin Soderling,Roger Federer,R,R,M,20090607.0,Roland Garros,F,15:00:00,Philippe Chatrier,Clay,Pascal Maria,5.0,0,Edo
+20090605-M-Roland_Garros-SF-Roger_Federer-Juan_Martin_Del_Potro,Roger Federer,Juan Martin Del Potro,R,R,M,20090605.0,Roland Garros,SF,,Court Philippe Chatrier,Clay,Enric Molina,5.0,0,marct
+20090601-M-Roland_Garros-R16-Roger_Federer-Tommy_Haas,Roger Federer,Tommy Haas,R,R,M,20090601.0,Roland Garros,R16,,Philipp Chatrier,Clay,,5.0,0,tns
+20090531-M-Roland_Garros-R16-Robin_Soderling-Rafael_Nadal,Robin Soderling,Rafael Nadal,R,L,M,20090531.0,Roland Garros,R16,,,Clay,,5.0,0,Amy
+20090517-M-Madrid_Masters-F-Rafael_Nadal-Roger_Federer,Rafael Nadal,Roger Federer,L,R,M,20090517.0,Madrid Masters,F,3:00 PM,Manolo Santana,Clay,Lars Graff,3.0,1,Edo
+20090515-M-Madrid_Masters-SF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20090515.0,Madrid Masters,SF,,,Clay,,3.0,1,Skarmydable
+20090504-M-Rome_Masters-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20090504.0,Rome Masters,F,16:30:00,Pietrangeli,Clay,Mohamed Lahyani,3.0,1,Edo
+20090503-M-Rome_Masters-SF-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20090503.0,Rome Masters,SF,14:00:00,Pietrangeli,Clay,Carlos Bernardes,3.0,1,Edo
+20090412-M-Monte_Carlo_Masters-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20090412.0,Monte Carlo Masters,F,,,Clay,,3.0,1,DanF
+20090405-M-Miami_Masters-F-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20090405.0,Miami Masters,F,,,Hard,Gerry Armstrong,3.0,1,Isaac
+20090404-M-Miami_Masters-SF-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20090404.0,Miami Masters,SF,3pm,Stadium,Hard,Fergus Murphy,3.0,1,Edo
+20090323-M-Indian_Wells_Masters-F-Rafael_Nadal-Andy_Murray,Rafael Nadal,Andy Murray,L,R,M,20090323.0,Indian Wells Masters,F,,Stadium 1,Hard,Cedric Mourier,3.0,1,Salvo
+20090321-M-Indian_Wells_Masters-SF-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20090321.0,Indian Wells Masters,SF,2pm,Stadium 1,Hard,Steve Ulrich,3.0,1,Edo
+20090228-M-Dubai-F-Novak_Djokovic-David_Ferrer,Novak Djokovic,David Ferrer,R,R,M,20090228.0,Dubai,F,7pm,Centre,Hard,Cedric Mourier,3.0,1,Edo
+20090201-M-Australian_Open-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20090201.0,Australian Open,F,8:30 PM,Centre,Hard,Pascal Maria,5.0,0,Edo
+20090130-M-Australian_Open-SF-Fernando_Verdasco-Rafael_Nadal,Fernando Verdasco,Rafael Nadal,L,L,M,20090130.0,Australian Open,SF,,Rod Laver,Hard,,5.0,0,Edged
+20090129-M-Australian_Open-SF-Andy_Roddick-Roger_Federer,Andy Roddick,Roger Federer,R,R,M,20090129.0,Australian Open,SF,7pm,Rod Laver Arena,Hard,Enric Molina,5.0,0,Edo
+20090110-M-Doha-F-Andy_Roddick-Andy_Murray,Andy Roddick,Andy Murray,R,R,M,20090110.0,Doha,F,6.30pm,Centre,Hard,Mohamed Lahyani,3.0,1,Edo
+20090109-M-Doha-SF-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20090109.0,Doha,SF,6.30pm,Centre,Hard,,3.0,1,Edo
+20081116-M-Tour_Finals-F-Novak_Djokovic-Nikolay_Davydenko,Novak Djokovic,Nikolay Davydenko,R,R,M,20081116.0,Tour Finals,F,16:00:00,Stadium,Hard,Mohamed Lahyani,3.0,1,Edo
+20081114-M-Masters_Cup-RR-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20081114.0,Masters Cup,RR,8pm,Centre,Hard,Cedric Mourier,3.0,1,Edo
+20081102-M-Paris_Masters-F-Jo_Wilfried_Tsonga-David_Nalbandian,Jo Wilfried Tsonga,David Nalbandian,R,R,M,20081102.0,Paris Masters,F,4:15 PM,Centre,Hard,Lars Graff,3.0,1,Edo
+20081026-M-Basel-F-Roger_Federer-David_Nalbandian,Roger Federer,David Nalbandian,R,R,M,20081026.0,Basel,F,,Centre,Hard,Mohamed Layhani,3.0,1,Edo
+20081019-M-Madrid_Masters-F-Gilles_Simon-Andy_Murray,Gilles Simon,Andy Murray,R,R,M,20081019.0,Madrid Masters,F,3:00:00 PM,Pista Central,Hard,Mohamed Lahyani,3.0,1,Edo
+20081018-M-Madrid_Masters-SF-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20081018.0,Madrid Masters,SF,3:00:00 PM,Pista Central,Hard,Damian Stainer,3.0,1,Edo
+20080908-M-US_Open-F-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20080908.0,US Open,F,5:00 PM,Ashe,Hard,Carlos Bernardes,5.0,1,Edo
+20080905-M-US_Open-SF-Rafael_Nadal-Andy_Murray,Rafael Nadal,Andy Murray,L,R,M,20080905.0,US Open,SF,,Arthur Ashe Stadium,Hard,,5.0,1,Isaac
+20080817-M-Olympics-F-Rafael_Nadal-Fernando_Gonzalez,Rafael Nadal,Fernando Gonzalez,L,R,M,20080817.0,Olympics,F,,Diamond Court,Hard,Jake Garner,5.0,0,Salvo
+20080815-M-Olympics-SF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20080815.0,Olympics,SF,,Centre,Hard,Carlos Ramos,3.0,0,Salvo
+20080803-M-Cincinnati_Masters-F-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20080803.0,Cincinnati Masters,F,3:00:00 PM,Center,Hard,Mohamed Lahyani,3.0,1,Edo
+20080802-M-Cincinnati_Masters-SF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20080802.0,Cincinnati Masters,SF,,,Hard,,3.0,1,Isaac
+20080727-M-Canada_Masters-F-Nicolas_Kiefer-Rafael_Nadal,Nicolas Kiefer,Rafael Nadal,R,L,M,20080727.0,Canada Masters,F,,,Hard,,3.0,1,Isaac
+20080726-M-Canada_Masters-SF-Andy_Murray-Rafael_Nadal,Andy Murray,Rafael Nadal,R,L,M,20080726.0,Canada Masters,SF,,,Hard,Cedric Mourier,3.0,1,Isaac
+20080706-M-Wimbledon-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20080706.0,Wimbledon,F,,,Grass,Pascal Maria,5.0,0,Amy
+20080704-M-Wimbledon-SF-Roger_Federer-Marat_Safin,Roger Federer,Marat Safin,R,R,M,20080704.0,Wimbledon,SF,1pm,Centre,Grass,Lars Graff,5.0,0,Edo
+20080704-M-Wimbledon-SF-Rainer_Schuettler-Rafael_Nadal,Rainer Schuettler,Rafael Nadal,R,L,M,20080704.0,Wimbledon,SF,4pm,Centre,Grass,Jake Garner,5.0,0,Edo
+20080702-M-Wimbledon-QF-Rafael_Nadal-Andy_Murray,Rafael Nadal,Andy Murray,L,R,M,20080702.0,Wimbledon,QF,6pm,Centre,Grass,Mohamed Lahyani,5.0,0,Edo
+20080630-M-Wimbledon-R16-Roger_Federer-Lleyton_Hewitt,Roger Federer,Lleyton Hewitt,R,R,M,20080630.0,Wimbledon,R16,,Centre,Grass,Norm Chryst,5.0,0,Palaver
+20080615-M-Queens_Club-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20080615.0,Queens Club,F,,Centre,Grass,Steve Ulrich,3.0,1,Salvo
+20080615-M-Halle-F-Roger_Federer-Philipp_Kohlschreiber,Roger Federer,Philipp Kohlschreiber,R,R,M,20080615.0,Halle,F,2:00 PM,Stadion,Grass,Carlos Bernardes,3.0,1,Edo
+20080614-M-Queens_Club-SF-Andy_Roddick-Rafael_Nadal,Andy Roddick,Rafael Nadal,R,L,M,20080614.0,Queens Club,SF,,Centre,Grass,Mohamed El Jennati,3.0,1,Salvo
+20080608-M-Roland_Garros-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20080608.0,Roland Garros,F,2:00 PM,Philippe Chatrier,Clay,Carlos Ramos,5.0,0,Edo
+20080606-M-Roland_Garros-SF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20080606.0,Roland Garros,SF,,Chatrier,Clay,,5.0,0,Isaac
+20080606-M-Roland_Garros-SF-Gael_Monfils-Roger_Federer,Gael Monfils,Roger Federer,R,R,M,20080606.0,Roland Garros,SF,13:00,Philippe Chatrier,Clay,Jake Garner,5.0,0,Edo
+20080517-M-Hamburg_Masters-SF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20080517.0,Hamburg Masters,SF,3pm,Centre,Clay,Gerry Armstrong,3.0,1,Edo
+20080511-M-Rome_Masters-F-Novak_Djokovic-Stanislas_Wawrinka,Novak Djokovic,Stanislas Wawrinka,R,R,M,20080511.0,Rome Masters,F,3pm,Pietrangeli,Clay,Carlos Bernardes,3.0,1,Edo
+20080511-M-Hamburg_Masters-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20080511.0,Hamburg Masters,F,3:00 PM,Centre,Clay,Fergus Murphy,3.0,1,Edo
+20080420-M-Monte_Carlo_Masters-F-Rafael_Nadal-Roger_Federer,Rafael Nadal,Roger Federer,L,R,M,20080420.0,Monte Carlo Masters,F,2:00:00 PM,Central,Clay,Lars Graff,3.0,1,Edo
+20080420-M-Estoril-F-Nikolay_Davydenko-Roger_Federer,Nikolay Davydenko,Roger Federer,R,R,M,20080420.0,Estoril,F,,Centre,Clay,Carlos Bernardes,3.0,1,Edo
+20080419-M-Monte_Carlo_Masters-SF-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20080419.0,Monte Carlo Masters,SF,14:00,Central,Clay,Carlos Bernardes,3.0,1,Edo
+20080322-M-Indian_Wells_Masters-SF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20080322.0,Indian Wells Masters,SF,2pm,Central,Hard,Steve Ulrich,3.0,1,Edo
+20080307-M-Dubai-QF-Igor_Andreev-Novak_Djokovic,Igor Andreev,Novak Djokovic,R,R,M,20080307.0,Dubai,QF,,,Hard,,3.0,1,Isaac
+20080304-M-Dubai-R32-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20080304.0,Dubai,R32,7:00:00 PM,Centre,Hard,Mohamed Lahyani,3.0,1,Edo
+20080127-M-Australian_Open-SF-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20080127.0,Australian Open,SF,,Rod Laver Arena,Hard,,5.0,0,Isaac
+20080125-M-Australian_Open-SF-Jo_Wilfried_Tsonga_-Rafael_Nadal,Jo Wilfried Tsonga ,Rafael Nadal,R,L,M,20080125.0,Australian Open,SF,,,Hard,,5.0,0,Isaac
+20080106-M-Chennai-F-Mikhail_Youzhny-Rafael_Nadal,Mikhail Youzhny,Rafael Nadal,R,L,M,20080106.0,Chennai,F,5pm,Ashe,Hard,Cedric Mourier,3.0,1,Edo
+20080105-M-Doha-F-Stanislas_Wawrinka-Andy_Murray,Stanislas Wawrinka,Andy Murray,R,R,M,20080105.0,Doha,F,6.30pm,Centre,Hard,Mohamed Lahyani,3.0,1,Edo
+20071118-M-Masters_Cup-F-David_Ferrer-Roger_Federer,David Ferrer,Roger Federer,R,R,M,20071118.0,Masters Cup,F,,Centre,Hard,Pascal Maria,5.0,1,Edo
+20071115-M-Tour_Finals-RR-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20071115.0,Tour Finals,RR,7pm,Centre,Hard,Pascal Maria,3.0,1,Edo
+20071112-M-Masters_Cup-SF-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20071112.0,Masters Cup,SF,,Centre,Hard,,3.0,1,Isaac
+20071112-M-Masters_Cup-RR-Novak_Djokovic-Richard_Gasquet,Novak Djokovic,Richard Gasquet,R,R,M,20071112.0,Masters Cup,RR,,,Hard,,3.0,1,Isaac
+20071028-M-Paris_Masters-F-Rafael_Nadal-David_Nalbandian,Rafael Nadal,David Nalbandian,L,R,M,20071028.0,Paris Masters,F,,,Hard,,3.0,1,Isaac
+20071028-M-Basel-F-Roger_Federer-Jarkko_Nieminen,Roger Federer,Jarkko Nieminen,R,L,M,20071028.0,Basel,F,,,Hard,,3.0,1,Isaac
+20071022-M-Basel-R16-Roger_Federer-Juan_Martin_Del_Potro,Roger Federer,Juan Martin Del Potro,R,R,M,20071022.0,Basel,R16,,,Hard,Mohamed Lahyani,3.0,1,Amy
+20071021-M-Madrid_Masters-F-Roger_Federer-David_Nalbandian,Roger Federer,David Nalbandian,R,R,M,20071021.0,Madrid Masters,F,3:00 PM,Central,Hard,Carlos Bernardes,3.0,1,Edo
+20071018-M-Madrid_Masters-R16-Andy_Murray-Rafael_Nadal,Andy Murray,Rafael Nadal,R,L,M,20071018.0,Madrid Masters,R16,8pm,Centre,Hard,Carlos Bernardes,3.0,1,Edo
+20070909-M-US_Open-F-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20070909.0,US Open,F,4:00 PM,Ashe,Hard,Jake Garner,5.0,1,Edo
+20070908-M-US_Open-SF-Roger_Federer-Nikolay_Davydenko,Roger Federer,Nikolay Davydenko,R,R,M,20070908.0,US Open,SF,12am,Ashe,Hard,Carlos Ramos,5.0,1,Edo
+20070908-M-US_Open-SF-David_Ferrer-Novak_Djokovic,David Ferrer,Novak Djokovic,R,R,M,20070908.0,US Open,SF,3pm,Ashe,Hard,,5.0,1,Edo
+20070905-M-US_Open-QF-Roger_Federer-Andy_Roddick,Roger Federer,Andy Roddick,R,R,M,20070905.0,US Open,QF,19:00:00,Arthur Ashe,Hard,Enric Molina,5.0,1,Edo
+20070819-M-Cincinnati_Masters-F-Roger_Federer-James_Blake,Roger Federer,James Blake,R,R,M,20070819.0,Cincinnati Masters,F,3:00:00 PM,Stadium,Hard,Fergus Murphy,3.0,1,Edo
+20070818-M-Cincinnati_Masters-SF-Roger_Federer-Lleyton_Hewitt,Roger Federer,Lleyton Hewitt,R,R,M,20070818.0,Cincinnati Masters,SF,,Center,Hard,,3.0,1,Palaver
+20070812-M-Canada_Masters-SF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20070812.0,Canada Masters,SF,5pm,Central,Hard,Steve Ullrich,3.0,1,Edo
+20070812-M-Canada_Masters-F-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20070812.0,Canada Masters,F,Day Match,Montreal,Hard,Gerry Armstrong,3.0,1,Edo
+20070810-M-Canada_Masters-SF-Roger_Federer-Radek_Stepanek,Roger Federer,Radek Stepanek,R,R,M,20070810.0,Canada Masters,SF,,,Hard,,3.0,1,Isaac
+20070708-M-Wimbledon-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20070708.0,Wimbledon,F,,,Grass,Carlos Ramos,5.0,0,Amy
+20070707-M-Wimbledon-SF-Roger_Federer-Richard_Gasquet,Roger Federer,Richard Gasquet,R,R,M,20070707.0,Wimbledon,SF,12am,Centre,Grass,Enric Molina,5.0,0,Edo
+20070707-M-Wimbledon-SF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20070707.0,Wimbledon,SF,1pm,Centre,Grass,,5.0,0,Edo
+20070617-M-Queens_Club-F-Nicolas_Mahut-Andy_Roddick,Nicolas Mahut,Andy Roddick,R,R,M,20070617.0,Queens Club,F,,Centre,Grass,Mohamed Lahyani,3.0,1,MaGav
+20070610-M-Roland_Garros-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20070610.0,Roland Garros,F,,Chatrier,Clay,,5.0,0,Amy
+20070608-M-Roland_Garros-SF-Roger_Federer-Nikolay_Davydenko,Roger Federer,Nikolay Davydenko,R,R,M,20070608.0,Roland Garros,SF,1pm,Philippe Chatrier,Clay,Cedric Mourier,5.0,0,Edo
+20070608-M-Roland_Garros-SF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20070608.0,Roland Garros,SF,,,Clay,Pascal Maria,5.0,0,Isaac
+20070520-M-Hamburg_Masters-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20070520.0,Hamburg Masters,F,3:00 PM,,Clay,Cedric Mourier,3.0,1,Edo
+20070513-M-Rome_Masters-F-Fernando_Gonzalez-Rafael_Nadal,Fernando Gonzalez,Rafael Nadal,R,L,M,20070513.0,Rome Masters,F,3PM,Pietrangeli,Clay,Mohamed Lahyani,3.0,1,Edo
+20070512-M-Rome_Masters-SF-Fernando_Gonzalez-Filippo_Volandri,Fernando Gonzalez,Filippo Volandri,R,R,M,20070512.0,Rome Masters,SF,,Centrale,Clay,Lars Graff,3.0,1,Salvo
+20070511-M-Rome_Masters-QF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20070511.0,Rome Masters,QF,5.30pm,Centre,Clay,Lars Graff,3.0,1,Edo
+20070510-M-Rome_Masters-R16-Roger_Federer-Filippo_Volandri,Roger Federer,Filippo Volandri,R,R,M,20070510.0,Rome Masters,R16,,Centrale,Clay,Mohamed Lahyani,3.0,1,Salvo
+20070415-M-Monte_Carlo_Masters-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20070415.0,Monte Carlo Masters,F,2:00:00 PM,Central,Clay,Carlos Bernardes,3.0,1,Edo
+20070330-M-Miami_Masters-SF-Novak_Djokovic-Andy_Murray,Novak Djokovic,Andy Murray,R,R,M,20070330.0,Miami Masters,SF,,,Hard,,3.0,1,Isaac
+20070329-M-Miami_Masters-QF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20070329.0,Miami Masters,QF,9pm,Central,Hard,Norm Chryst,3.0,1,Edo
+20070325-M-Miami_Masters-F-Novak_Djokovic-Guillermo_Canas,Novak Djokovic,Guillermo Canas,R,R,M,20070325.0,Miami Masters,F,3:00 PM,Stadium,Hard,Steve Ullrich,5.0,1,Edo
+20070314-M-Indian_Wells_Masters-F-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20070314.0,Indian Wells Masters,F,,Stadium 1,Hard,Mohamed Lahyani,3.0,1,Isaac
+20070305-M-Indian_Wells-SF-Andy_Murray-Novak_Djokovic,Andy Murray,Novak Djokovic,R,R,M,20070305.0,Indian Wells,SF,,,Hard,,3.0,1,DanF
+20070303-M-Dubai-F-Roger_Federer-Mikhail_Youzhny,Roger Federer,Mikhail Youzhny,R,R,M,20070303.0,Dubai,F,7pm,Centre,Hard,Cedric Mourier,3.0,1,Edo
+20070301-M-Dubai-QF-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20070301.0,Dubai,QF,7:00:00 PM,Centre,Hard,Mohamed Lahyani,3.0,1,Edo
+20070126-M-Australian_Open-SF-Tommy_Haas-Fernando_Gonzalez,Tommy Haas,Fernando Gonzalez,R,R,M,20070126.0,Australian Open,SF,18:50,Rod Laver Arena,Hard,Carlos Ramos,5.0,0,1HandBH
+20070125-M-Australian_Open-SF-Andy_Roddick-Roger_Federer,Andy Roddick,Roger Federer,R,R,M,20070125.0,Australian Open,SF,,Rod Laver Arena,Hard,,5.0,0,Tanmay
+20070123-M-Australian_Open-QF-Rafael_Nadal-Fernando_Gonzalez,Rafael Nadal,Fernando Gonzalez,L,R,M,20070123.0,Australian Open,QF,,,Hard,,5.0,0,Isaac
+20070122-M-Australian_Open-R16-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20070122.0,Australian Open,R16,7pm,Rod Laver Arena,Hard,Alison Hughes,5.0,0,Edo
+20070122-M-Australian_Open-R16-Rafael_Nadal-Andy_Murray,Rafael Nadal,Andy Murray,L,R,M,20070122.0,Australian Open,R16,8pm,Rod Laver Arena,Hard,,5.0,0,Edo
+20070107-M-Adelaide-F-Chris_Guccione-Novak_Djokovic,Chris Guccione,Novak Djokovic,L,R,M,20070107.0,Adelaide,F,1pm,Centre,Hard,Lars Graff,3.0,1,Edo
+20061119-M-Masters_Cup-F-Roger_Federer-James_Blake,Roger Federer,James Blake,R,R,M,20061119.0,Masters Cup,F,,Centre,Hard,Lars Graf,5.0,1,Edo
+20061114-M-Masters_Cup-RR-Roger_Federer-Andy_Roddick,Roger Federer,Andy Roddick,R,R,M,20061114.0,Masters Cup,RR,,,Hard,,3.0,1,Natf
+20061113-M-Masters_Cup-SF-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20061113.0,Masters Cup,SF,,Center,Hard,Mohamed Lahyani,3.0,1,Isaac
+20061105-M-Paris_Masters-F-Nikolay_Davydenko-Dominik_Hrbaty,Nikolay Davydenko,Dominik Hrbaty,R,R,M,20061105.0,Paris Masters,F,4:15 PM,Centre,Hard,Cedric Mourier,5.0,1,Edo
+20061029-M-Basel-F-Roger_Federer-Fernando_Gonzalez,Roger Federer,Fernando Gonzalez,R,R,M,20061029.0,Basel,F,,Centre,Carpet,Norm Chryst,5.0,1,Edo
+20061022-M-Madrid_Masters-F-Roger_Federer-Fernando_Gonzalez,Roger Federer,Fernando Gonzalez,R,R,M,20061022.0,Madrid Masters,F,3:00 PM,Central,Hard,Mohamed Lahyani,5.0,1,Edo
+20061008-M-Tokyo-F-Roger_Federer-Tim_Henman,Roger Federer,Tim Henman,R,R,M,20061008.0,Tokyo,F,2:00:00 PM,Centre,Hard,Fergus Murphy,3.0,1,Edo
+20061008-M-Metz-F-Novak_Djokovic-Jurgen_Melzer,Novak Djokovic,Jurgen Melzer,R,L,M,20061008.0,Metz,F,3pm,Centre,Hard,Cedric Mourier,3.0,1,Edo
+20060922-M-Davis_Cup_World_Group_PO-RR-Roger_Federer-Novak_Djokovic,Roger Federer,Novak Djokovic,R,R,M,20060922.0,Davis Cup World Group PO,RR,,,Hard,,3.0,1,Isaac
+20060909-M-US_Open-SF-Roger_Federer-Nikolay_Davydenko,Roger Federer,Nikolay Davydenko,R,R,M,20060909.0,US Open,SF,12am,Ashe,Hard,Sandra de Jenken,5.0,1,Edo
+20060909-M-US_Open-SF-Andy_Roddick-Mikhail_Youzhny,Andy Roddick,Mikhail Youzhny,R,R,M,20060909.0,US Open,SF,3pm,Ashe,Hard,Pascal Maria,5.0,1,Edo
+20060907-M-US_Open-QF-James_Blake-Roger_Federer,James Blake,Roger Federer,R,R,M,20060907.0,US Open,QF,,Arthur Ashe Stadium,Hard,,5.0,1,Palaver
+20060831-M-US_Open-R64-Marcos_Baghdatis-Andre_Agassi,Marcos Baghdatis,Andre Agassi,R,R,M,20060831.0,US Open,R64,20:48,Arthur Ashe Stadium,Hard,Carlos Ramos,5.0,1,1HandBH
+20060826-M-US_Open-F-Roger_Federer-Andy_Roddick,Roger Federer,Andy Roddick,R,R,M,20060826.0,US Open,F,,,Hard,Carlos Bernardes,3.0,1,Amy
+20060816-M-Cincinnati_Masters-R32-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20060816.0,Cincinnati Masters,R32,3:00:00 PM,Centre,Hard,Carlos Bernardes,3.0,1,Edo
+20060813-M-Canada_Masters-F-Roger_Federer-Richard_Gasquet,Roger Federer,Richard Gasquet,R,R,M,20060813.0,Canada Masters,F,Day Match,Toronto,Hard,Steve Ullrich,3.0,1,Edo
+20060723-M-Amersfoort-F-Novak_Djokovic-Nicolas_Massu,Novak Djokovic,Nicolas Massu,R,R,M,20060723.0,Amersfoort,F,3pm,Centre,Clay,Mohamed Lahyani,3.0,1,Edo
+20060709-M-Wimbledon-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20060709.0,Wimbledon,F,,,Grass,Gerry Armstrong,3.0,1,Amy
+20060707-M-Wimbledon-SF-Marcos_Baghdatis-Rafael_Nadal,Marcos Baghdatis,Rafael Nadal,R,L,M,20060707.0,Wimbledon,SF,4.30pm,Centre,Grass,Andreas Egli,5.0,0,Edo
+20060707-M-Wimbledon-SF-Jonas_Bjorkman-Roger_Federer,Jonas Bjorkman,Roger Federer,R,R,M,20060707.0,Wimbledon,SF,3pm,Centre,Grass,Sandra de Jenken,5.0,0,Edo
+20060701-M-Wimbledon-R32-Rafael_Nadal-Andre_Agassi,Rafael Nadal,Andre Agassi,L,R,M,20060701.0,Wimbledon,R32,,Centre,Grass,Gerry Armstrong,5.0,0,Salvo
+20060627-M-Wimbledon-R128-Roger_Federer-Richard_Gasquet,Roger Federer,Richard Gasquet,R,R,M,20060627.0,Wimbledon,R128,,,Grass,,5.0,0,Amy
+20060618-M-Halle-F-Roger_Federer-Tomas_Berdych,Roger Federer,Tomas Berdych,R,R,M,20060618.0,Halle,F,2:00 PM,Stadion,Grass,Fergus Murphy,3.0,1,Edo
+20060611-M-Roland_Garros-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20060611.0,Roland Garros,F,2:00 PM,Philippe Chatrier,Clay,,5.0,0,Edo
+20060609-M-Roland_Garros-SF-Roger_Federer-David_Nalbandian,Roger Federer,David Nalbandian,R,R,M,20060609.0,Roland Garros,SF,1pm,Philippe Chatrier,Clay,Pascal Maria,5.0,0,Edo
+20060607-M-Roland_Garros-QF-Novak_Djokovic-Rafael_Nadal,Novak Djokovic,Rafael Nadal,R,L,M,20060607.0,Roland Garros,QF,2pm,Philippe Chatrier,Clay,A woman,5.0,0,Edo
+20060521-M-Hamburg_Masters-F-Tommy_Robredo-Radek_Stepanek,Tommy Robredo,Radek Stepanek,R,R,M,20060521.0,Hamburg Masters,F,3:00 PM,Central,Clay,Norm Chryst,5.0,1,Edo
+20060514-M-Rome_Masters-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20060514.0,Rome Masters,F,,Centrale,Clay,Romano Grillotti,5.0,1,Salvo
+20060509-M-Rome_Masters-R64-Carlos_Moya-Rafael_Nadal,Carlos Moya,Rafael Nadal,R,L,M,20060509.0,Rome Masters,R64,,Centrale,Clay,Romano Grillotti,3.0,1,Salvo
+20060423-M-Monte_Carlo_Masters-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20060423.0,Monte Carlo Masters,F,2:00:00 PM,Central,Clay,Gerry Armstrong,5.0,1,Edo
+20060419-M-Monte_Carlo_Masters-R64-Novak_Djokovic-Roger_Federer,Novak Djokovic,Roger Federer,R,R,M,20060419.0,Monte Carlo Masters,R64,2:30:00 PM,Central,Clay,Pascal Maria,3.0,1,Edo
+20060326-M-Miami_Masters-F-Roger_Federer-Ivan_Ljubicic,Roger Federer,Ivan Ljubicic,R,R,M,20060326.0,Miami Masters,F,3:00:00 PM,Centre,Hard,Carlos Bernardes,5.0,1,Edo
+20060319-M-Indian_Wells_Masters-F-Roger_Federer-James_Blake,Roger Federer,James Blake,R,R,M,20060319.0,Indian Wells Masters,F,2:00:00 PM,Centre,Hard,Lars Graff,5.0,1,Edo
+20060318-M-Indian_Wells_Masters-SF-James_Blake-Rafael_Nadal,James Blake,Rafael Nadal,R,L,M,20060318.0,Indian Wells Masters,SF,,,Hard,,3.0,1,Isaac
+20060305-M-Dubai-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20060305.0,Dubai,F,,,Hard,,3.0,1,Isaac
+20060219-M-San_Jose-F-Lleyton_Hewitt-Andy_Murray,Lleyton Hewitt,Andy Murray,R,R,M,20060219.0,San Jose,F,Evening,Centre,Hard,Lars Graff,3.0,1,Edo
+20060126-M-Australian_Open-SF-Roger_Federer-Nicolas_Kiefer,Roger Federer,Nicolas Kiefer,R,R,M,20060126.0,Australian Open,SF,7pm,Rod Laver Arena,Hard,Carlos Ramos,5.0,0,Edo
+20060126-M-Australian_Open-SF-David_Nalbandian-Marcos_Baghdatis,David Nalbandian,Marcos Baghdatis,R,R,M,20060126.0,Australian Open,SF,6.30pm,Rod Laver Arena,Hard,Andreas Egli,5.0,0,Edo
+20060125-M-Australian_Open-QF-Roger_Federer-Nikolay_Davydenko,Roger Federer,Nikolay Davydenko,R,R,M,20060125.0,Australian Open,QF,,Rod Laver Arena,Hard,Sandra De Jenken,5.0,1,Palaver
+20060123-M-Australian_Open-QF-David_Nalbandian-Fabrice_Santoro,David Nalbandian,Fabrice Santoro,R,R,M,20060123.0,Australian Open,QF,,Rod Laver Arena,Hard,,5.0,0,1HandBH
+20060107-M-Doha-F-Roger_Federer-Gael_Monfils,Roger Federer,Gael Monfils,R,R,M,20060107.0,Doha,F,6pm,Centre,Hard,Mohamed Lahyani,3.0,1,Edo
+20051120-M-Masters_Cup-SF-Roger_Federer-Gaston_Gaudio,Roger Federer,Gaston Gaudio,R,R,M,20051120.0,Masters Cup,SF,,Centre,Carpet,,3.0,1,Palaver
+20051106-M-Paris_Masters-F-Tomas_Berdych-Ivan_Ljubicic,Tomas Berdych,Ivan Ljubicic,R,R,M,20051106.0,Paris Masters,F,3pm,Centre,Carpet,Romano Grillotti,5.0,1,Edo
+20051023-M-Madrid_Masters-F-Ivan_Ljubicic-Rafael_Nadal,Ivan Ljubicic,Rafael Nadal,R,L,M,20051023.0,Madrid Masters,F,3:00:00 PM,Pista Central,Hard,Lars Graff,5.0,1,Edo
+20051002-M-Bangkok-F-Roger_Federer-Andy_Murray,Roger Federer,Andy Murray,R,R,M,20051002.0,Bangkok,F,,Centre,Hard,Lars Graff,3.0,1,Edo
+20050911-M-US_Open-F-Roger_Federer-Andre_Agassi,Roger Federer,Andre Agassi,R,R,M,20050911.0,US Open,F,,Arthur Ashe Stadium,Hard,,5.0,1,1HandBH
+20050910-M-US_Open-SF-Roger_Federer-Lleyton_Hewitt,Roger Federer,Lleyton Hewitt,R,R,M,20050910.0,US Open,SF,,Arthur Ashe,Hard,Norm Chryst,5.0,1,Palaver
+20050910-M-US_Open-SF-Robby_Ginepri-Andre_Agassi,Robby Ginepri,Andre Agassi,R,R,M,20050910.0,US Open,SF,12am,Ashe,Hard,Steve Ullrich,5.0,1,Edo
+20050908-M-US_Open-QF-Andre_Agassi-James_Blake,Andre Agassi,James Blake,R,R,M,20050908.0,US Open,QF,,Arthur Ashe Stadium,Hard,,5.0,1,Isaac
+20050821-M-Cincinnati_Masters-SF-Lleyton_Hewitt-Andy_Roddick,Lleyton Hewitt,Andy Roddick,R,R,M,20050821.0,Cincinnati Masters,SF,,,Hard,,3.0,1,Natf
+20050821-M-Cincinnati_Masters-F-Andy_Roddick-Roger_Federer,Andy Roddick,Roger Federer,R,R,M,20050821.0,Cincinnati Masters,F,,Stadium,Hard,Carlos Bernardes,3.0,1,Edo
+20050815-M-Canada_Masters-F-Rafael_Nadal-Andre_Agassi,Rafael Nadal,Andre Agassi,L,R,M,20050815.0,Canada Masters,F,,Center,Hard,Lars Graff,3.0,1,Salvo
+20050703-M-Wimbledon-F-Roger_Federer-Andy_Roddick,Roger Federer,Andy Roddick,R,R,M,20050703.0,Wimbledon,F,2:00 PM,Centre,Grass,Wayne McKewen,5.0,0,Edo
+20050701-M-Wimbledon-SF-Roger_Federer-Lleyton_Hewitt,Roger Federer,Lleyton Hewitt,R,R,M,20050701.0,Wimbledon,SF,,Centre,Grass,Pascal Maria,5.0,0,Palaver
+20050701-M-Wimbledon-SF-Andy_Roddick-Thomas_Johansson,Andy Roddick,Thomas Johansson,R,R,M,20050701.0,Wimbledon,SF,3pm,Court 1,Grass,Enric Molina,5.0,0,Edo
+20050621-M-Wimbledon-R128-George_Bastl-Andy_Murray,George Bastl,Andy Murray,R,R,M,20050621.0,Wimbledon,R128,13:00,2,Grass,Steve Ullrich,5.0,0,1HandBH
+20050612-M-Halle-F-Roger_Federer-Marat_Safin,Roger Federer,Marat Safin,R,R,M,20050612.0,Halle,F,3pm,Centre,Grass,Romano Grillotti,3.0,1,Edo
+20050601-M-Roland_Garros-SF-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20050601.0,Roland Garros,SF,,,Clay,,5.0,0,Isaac
+20050515-M-Hamburg_Masters-F-Roger_Federer-Richard_Gasquet,Roger Federer,Richard Gasquet,R,R,M,20050515.0,Hamburg Masters,F,3:00 PM,Central,Clay,Norm Chryst,5.0,1,Edo
+20050508-M-Rome_Masters-F-Rafael_Nadal-Guillermo_Coria,Rafael Nadal,Guillermo Coria,L,R,M,20050508.0,Rome Masters,F,,Centrale,Clay,Lars Graff,5.0,1,Salvo
+20050507-M-Rome_Masters-SF-Andre_Agassi-Guillermo_Coria,Andre Agassi,Guillermo Coria,R,R,M,20050507.0,Rome Masters,SF,,Centrale,Clay,Mohamed Lahyani,3.0,1,Salvo
+20050505-M-Rome_Masters-R16-Andy_Roddick-Fernando_Verdasco,Andy Roddick,Fernando Verdasco,R,L,M,20050505.0,Rome Masters,R16,,Centrale,Clay,Fergus Murphy,3.0,1,Salvo
+20050417-M-Monte_Carlo_Masters-F-Rafael_Nadal-Guillermo_Coria,Rafael Nadal,Guillermo Coria,L,R,M,20050417.0,Monte Carlo Masters,F,15:00:00,Central,Clay,Mohamed Lahyani,5.0,1,Edo
+20050415-M-Monte_Carlo_Masters-QF-Roger_Federer-Richard_Gasquet,Roger Federer,Richard Gasquet,R,R,M,20050415.0,Monte Carlo Masters,QF,16:00,Court Central,Clay,Enric Molina,3.0,1,1HandBH
+20050403-M-Miami_Masters-F-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20050403.0,Miami Masters,F,3:00:00 PM,Centre,Hard,Steve Ullrich,5.0,1,Edo
+20050320-M-Indian_Wells_Masters-F-Lleyton_Hewitt-Roger_Federer,Lleyton Hewitt,Roger Federer,R,R,M,20050320.0,Indian Wells Masters,F,2:00:00 PM,Centre,Hard,Lars Graff,5.0,1,Edo
+20050319-M-Indian_Wells_Masters-SF-Lleyton_Hewitt-Andy_Roddick,Lleyton Hewitt,Andy Roddick,R,R,M,20050319.0,Indian Wells Masters,SF,,,Hard,,3.0,1,Natf
+20050318-M-Indian_Wells_Masters-SF-Roger_Federer-Guillermo_Canas,Roger Federer,Guillermo Canas,R,R,M,20050318.0,Indian Wells Masters,SF,,,Hard,,3.0,1,Isaac
+20050226-M-Dubai-F-Roger_Federer-Ivan_Ljubicic,Roger Federer,Ivan Ljubicic,R,R,M,20050226.0,Dubai,F,9pm,Centre,Hard,Romano Grillotti,3.0,1,Edo
+20050226-M-Acapulco-F-Rafael_Nadal-Albert_Montanes,Rafael Nadal,Albert Montanes,L,R,M,20050226.0,Acapulco,F,,Cancha Central,Clay,Carlos Bernardes,3.0,1,Salvo
+20050221-M-Dubai-SF-Roger_Federer-Andre_Agassi,Roger Federer,Andre Agassi,R,R,M,20050221.0,Dubai,SF,,,Hard,,3.0,1,Isaac
+20050220-M-Rotterdam-F-Roger_Federer-Ivan_Ljubicic,Roger Federer,Ivan Ljubicic,R,R,M,20050220.0,Rotterdam,F,3pm,Centre,Hard,Mohamed Lahyani,3.0,1,Edo
+20050130-M-Australian_Open-F-Lleyton_Hewitt-Marat_Safin,Lleyton Hewitt,Marat Safin,R,R,M,20050130.0,Australian Open,F,18:55,Rod Laver Arena,Hard,Carlos Ramos,5.0,0,1HandBH
+20050128-M-Australian_Open-SF-Andy_Roddick-Lleyton_Hewitt,Andy Roddick,Lleyton Hewitt,R,R,M,20050128.0,Australian Open,SF,,,Hard,,5.0,0,Natf
+20050127-M-Australian_Open-SF-Roger_Federer-Marat_Safin,Roger Federer,Marat Safin,R,R,M,20050127.0,Australian Open,SF,20:00,Centre,Hard,Enric Molina,5.0,0,1HandBH
+20050126-M-Australian_Open-QF-Lleyton_Hewitt-David_Nalbandian,Lleyton Hewitt,David Nalbandian,R,R,M,20050126.0,Australian Open,QF,,,Hard,,5.0,0,Natf
+20050117-M-Australian_Open-R128-Novak_Djokovic-Marat_Safin,Novak Djokovic,Marat Safin,R,R,M,20050117.0,Australian Open,R128,20:20,Rod Laver Arena,Hard,Carlos Ramos,5.0,0,1HandBH
+20050114-M-Australian_Open-R16-Lleyton_Hewitt-Rafael_Nadal,Lleyton Hewitt,Rafael Nadal,R,L,M,20050114.0,Australian Open,R16,,,Hard,,5.0,0,Natf
+20050108-M-Doha-F-Roger_Federer-Ivan_Ljubicic,Roger Federer,Ivan Ljubicic,R,R,M,20050108.0,Doha,F,6:00 PM,Center,Hard,Romano Grillotti,3.0,1,Edo
+20041120-M-Masters_Cup-SF-Lleyton_Hewitt-Andy_Roddick,Lleyton Hewitt,Andy Roddick,R,R,M,20041120.0,Masters Cup,SF,,,Hard,,3.0,1,Natf
+20041117-M-Masters_Cup-RR-Roger_Federer-Lleyton_Hewitt,Roger Federer,Lleyton Hewitt,R,R,M,20041117.0,Masters Cup,RR,,Centre,Hard,Steve Ullrich,3.0,1,Palaver
+20041115-M-Masters_Cup-SF-Roger_Federer-Marat_Safin,Roger Federer,Marat Safin,R,R,M,20041115.0,Masters Cup,SF,,,Hard,,3.0,1,Skarmydable
+20041115-M-Masters_Cup-F-Roger_Federer-Lleyton_Hewitt,Roger Federer,Lleyton Hewitt,R,R,M,20041115.0,Masters Cup,F,,,Hard,,3.0,1,Isaac
+20041026-M-St_Petersburg-R32-Sargis_Sargsian-Irakli_Labadze,Sargis Sargsian,Irakli Labadze,R,L,M,20041026.0,St Petersburg,R32,,,Carpet,Pascal Maria,3.0,1,Edo
+20041025-M-St_Petersburg-F-Karol_Beck-Mikhail_Youzhny,Karol Beck,Mikhail Youzhny,R,R,M,20041025.0,St Petersburg,F,,,Carpet,,3.0,1,Isaac
+20041003-M-Bangkok-F-Andy_Roddick-Roger_Federer,Andy Roddick,Roger Federer,R,R,M,20041003.0,Bangkok,F,,Centre,Hard,Carlos Bernardes,3.0,1,Edo
+20040912-M-US_Open-F-Lleyton_Hewitt-Roger_Federer,Lleyton Hewitt,Roger Federer,R,R,M,20040912.0,US Open,F,,Arthur Ashe,Hard,Norm Chryst,5.0,1,Edo
+20040911-M-US_Open-SF-Roger_Federer-Tim_Henman,Roger Federer,Tim Henman,R,R,M,20040911.0,US Open,SF,12am,Ashe,Hard,Wayne McKewen,5.0,1,Edo
+20040911-M-US_Open-SF-Lleyton_Hewitt-Joachim_Johansson,Lleyton Hewitt,Joachim Johansson,R,R,M,20040911.0,US Open,SF,,Centre,Hard,,5.0,1,Natf
+20040909-M-US_Open-QF-Lleyton_Hewitt-Tommy_Haas,Lleyton Hewitt,Tommy Haas,R,R,M,20040909.0,US Open,QF,,,Hard,,5.0,1,Natf
+20040808-M-Cincinnati_Masters-F-Andre_Agassi-Lleyton_Hewitt,Andre Agassi,Lleyton Hewitt,R,R,M,20040808.0,Cincinnati Masters,F,4pm,Centre,Hard,Lars Graff,3.0,1,Edo
+20040807-M-Cincinnati_Masters-SF-Lleyton_Hewitt-Tommy_Robredo,Lleyton Hewitt,Tommy Robredo,R,R,M,20040807.0,Cincinnati Masters,SF,,,Hard,,3.0,1,Natf
+20040807-M-Cincinnati_Masters-SF-Andy_Roddick-Andre_Agassi,Andy Roddick,Andre Agassi,R,R,M,20040807.0,Cincinnati Masters,SF,,,Hard,,3.0,1,Isaac
+20040801-M-Canada_Masters-F-Roger_Federer-Andy_Roddick,Roger Federer,Andy Roddick,R,R,M,20040801.0,Canada Masters,F,Day Match,Toronto,Hard,Carlos Bernardes,3.0,1,Edo
+20040726-M-Canada_Masters-R32-Andy_Roddick-Feliciano_Lopez,Andy Roddick,Feliciano Lopez,R,L,M,20040726.0,Canada Masters,R32,,Center ,Hard,,3.0,1,Isaac
+20040711-M-Gstaad-F-Roger_Federer-Igor_Andreev,Roger Federer,Igor Andreev,R,R,M,20040711.0,Gstaad,F,,Centre,Clay,Cedric Mourier,5.0,1,Edo
+20040709-M-Gstaad-QF-Roger_Federer-Radek_Stepanek,Roger Federer,Radek Stepanek,R,R,M,20040709.0,Gstaad,QF,4pm,Central,Clay,Cedric Mourier,3.0,1,Edo
+20040704-M-Wimbledon-F-Roger_Federer-Andy_Roddick,Roger Federer,Andy Roddick,R,R,M,20040704.0,Wimbledon,F,2:00 PM,Centre,Grass,Mike Morrissey,5.0,0,Edo
+20040703-M-Wimbledon-SF-Sebastien_Grosjean-Roger_Federer,Sebastien Grosjean,Roger Federer,R,R,M,20040703.0,Wimbledon,SF,2pm,Centre,Grass,,5.0,0,Edo
+20040703-M-Wimbledon-SF-Mario_Ancic-Andy_Roddick,Mario Ancic,Andy Roddick,R,R,M,20040703.0,Wimbledon,SF,6pm,Court 1,Grass,Andreas Egli,5.0,0,Edo
+20040630-M-Wimbledon-QF-Roger_Federer-Lleyton_Hewitt,Roger Federer,Lleyton Hewitt,R,R,M,20040630.0,Wimbledon,QF,,Centre,Grass,Carlos Ramos,5.0,0,Palaver
+20040613-M-Halle-F-Roger_Federer-Mardy_Fish,Roger Federer,Mardy Fish,R,R,M,20040613.0,Halle,F,2:00 PM,Stadion,Grass,Carlos Bernardes,3.0,0,Edo
+20040606-M-Roland_Garros-F-Gaston_Gaudio-Guillermo_Coria,Gaston Gaudio,Guillermo Coria,R,R,M,20040606.0,Roland Garros,F,3:00 PM,Philippe Chatrier,Clay,Cedric Mourier,5.0,0,Edo
+20040516-M-Hamburg_Masters-F-Roger_Federer-Guillermo_Coria,Roger Federer,Guillermo Coria,R,R,M,20040516.0,Hamburg Masters,F,3:00 PM,,Clay,Mohamed Lahyani,5.0,1,Edo
+20040515-M-Hamburg_Masters-SF-Roger_Federer-Lleyton_Hewitt,Roger Federer,Lleyton Hewitt,R,R,M,20040515.0,Hamburg Masters,SF,,Centre,Clay,,3.0,1,Palaver
+20040509-M-Rome_Masters-F-Carlos_Moya-David_Nalbandian,Carlos Moya,David Nalbandian,R,R,M,20040509.0,Rome Masters,F,,Centrale,Clay,Lars Graff,5.0,1,Salvo
+20040328-M-Miami_Masters-R32-Roger_Federer-Rafael_Nadal,Roger Federer,Rafael Nadal,R,L,M,20040328.0,Miami Masters,R32,,,Hard,,3.0,1,Isaac
+20040328-M-Miami_Masters-F-Andy_Roddick-Guillermo_Coria,Andy Roddick,Guillermo Coria,R,R,M,20040328.0,Miami Masters,F,3:00 PM,Stadium,Hard,Lars Graff,5.0,1,Edo
+20040328-M-Miami_Masters-F-Andy_Roddick-Guillermo_Coira,Andy Roddick,Guillermo Coira,R,R,M,20040328.0,Miami Masters,F,3:00 PM,Stadium,Hard,Lars Graff,5.0,1,Edo
+20040314-M-Indian_Wells_Masters-F-Roger_Federer-Tim_Henman,Roger Federer,Tim Henman,R,R,M,20040314.0,Indian Wells Masters,F,2:00:00 PM,Centre,Hard,Steve Ullrich,3.0,1,Edo
+20040306-M-Dubai-F-Roger_Federer-Feliciano_Lopez,Roger Federer,Feliciano Lopez,R,L,M,20040306.0,Dubai,F,7pm,Centre,Hard,Romano Grillotti,3.0,1,Edo
+20040201-M-Australian_Open-F-Roger_Federer-Marat_Safin,Roger Federer,Marat Safin,R,R,M,20040201.0,Australian Open,F,,,Hard,,5.0,0,Amy
+20040130-M-Australian_Open-SF-Roger_Federer-Juan_Carlos_Ferrero,Roger Federer,Juan Carlos Ferrero,R,R,M,20040130.0,Australian Open,SF,5pm,Rod Laver Arena,Hard,Pascal Maria,5.0,0,Edo
+20040129-M-Australian_Open-SF-Andre_Agassi-Marat_Safin,Andre Agassi,Marat Safin,R,R,M,20040129.0,Australian Open,SF,,Rod Laver Arena,Hard,,5.0,0,Palaver
+20040127-M-Australian_Open-QF-Andy_Roddick-Marat_Safin,Andy Roddick,Marat Safin,R,R,M,20040127.0,Australian Open,QF,,,Hard,Gerry Armstrong,5.0,0,Palaver
+20040126-M-Australian_Open-R16-Roger_Federer-Lleyton_Hewitt,Roger Federer,Lleyton Hewitt,R,R,M,20040126.0,Australian Open,R16,,Rod Laver Arena,Hard,,5.0,0,Palaver
+20031116-M-Masters_Cup-F-Roger_Federer-Andre_Agassi,Roger Federer,Andre Agassi,R,R,M,20031116.0,Masters Cup,F,16:00:00,Centre,Hard,Mike Morrissey,5.0,1,Edo
+20031110-M-Masters_Cup-RR-Roger_Federer-Juan_Carlos_Ferrero,Roger Federer,Juan Carlos Ferrero,R,R,M,20031110.0,Masters Cup,RR,,,Hard,,3.0,1,Isaac
+20031019-M-Madrid_Masters-F-Juan_Carlos_Ferrero-Nicolas_Massu,Juan Carlos Ferrero,Nicolas Massu,R,R,M,20031019.0,Madrid Masters,F,3:00:00 PM,Pista Central,Hard,Mohamed Lahyani,5.0,1,Edo
+20031012-M-Vienna-F-Roger_Federer-Carlos_Moya,Roger Federer,Carlos Moya,R,R,M,20031012.0,Vienna,F,,,Hard,Lars Graff,5.0,1,Edo
+20030921-M-Davis_Cup_World_Group_SF-RR-Roger_Federer-Lleyton_Hewitt,Roger Federer,Lleyton Hewitt,R,R,M,20030921.0,Davis Cup World Group SF,RR,,Rod Laver Arena,Hard,Javier Moreno,5.0,0,Palaver
+20030907-M-US_Open-F-Andy_Roddick-Juan_Carlos_Ferrero,Andy Roddick,Juan Carlos Ferrero,R,R,M,20030907.0,US Open,F,4:00 PM,Ashe,Hard,Wayne McKewen,5.0,1,Edo
+20030906-M-US_Open-SF-Andy_Roddick-David_Nalbandian,Andy Roddick,David Nalbandian,R,R,M,20030906.0,US Open,SF,3pm,Ashe,Hard,,5.0,1,Edo
+20030906-M-US_Open-SF-Andre_Agassi-Juan_Carlos_Ferrero,Andre Agassi,Juan Carlos Ferrero,R,R,M,20030906.0,US Open,SF,12am,Ashe,Hard,Gerry Armstrong,5.0,1,Edo
+20030817-M-Cincinnati_Masters-F-Andy_Roddick-Mardy_Fish,Andy Roddick,Mardy Fish,R,R,M,20030817.0,Cincinnati Masters,F,3:00:00 PM,Center,Hard,Gerry Armstrong,3.0,1,Edo
+20030810-M-Canada_Masters-F-Andy_Roddick-David_Nalbandian,Andy Roddick,David Nalbandian,R,R,M,20030810.0,Canada Masters,F,Day Match,Montreal,Hard,Romano Grillotti,3.0,1,Edo
+20030809-M-Canada_Masters-SF-Roger_Federer-Andy_Roddick,Roger Federer,Andy Roddick,R,R,M,20030809.0,Canada Masters,SF,,,Hard,,3.0,1,Isaac
+20030804-M-Canada_Masters-R16-Roger_Federer-Tommy_Robredo,Roger Federer,Tommy Robredo,R,R,M,20030804.0,Canada Masters,R16,,,Hard,,3.0,1,Isaac
+20030713-M-Gstaad-F-Roger_Federer-Jiri_Novak,Roger Federer,Jiri Novak,R,R,M,20030713.0,Gstaad,F,3pm,Centre,Clay,Mohamed Lahyani,5.0,1,Edo
+20030706-M-Wimbledon-F-Roger_Federer-Mark_Philippoussis,Roger Federer,Mark Philippoussis,R,R,M,20030706.0,Wimbledon,F,2:00 PM,Centre,Grass,Gerry Armostrong,5.0,0,Edo
+20030701-M-Wimbledon-SF-Mark_Philippoussis-Sebastien_Grosjean,Mark Philippoussis,Sebastien Grosjean,R,R,M,20030701.0,Wimbledon,SF,3pm,Court 1,Grass,Andreas Egli,5.0,0,Edo
+20030701-M-Wimbledon-SF-Andy_Roddick-Roger_Federer,Andy Roddick,Roger Federer,R,R,M,20030701.0,Wimbledon,SF,2pm,Centre,Grass,Eric Molina,5.0,0,Edo
+20030615-M-Halle-F-Roger_Federer-Nicolas_Kiefer,Roger Federer,Nicolas Kiefer,R,R,M,20030615.0,Halle,F,2:00 PM,Stadion,Grass,Romano Grillotti,3.0,1,Edo
+20030608-M-Roland_Garros-F-Martin_Verkerk-Juan_Carlos_Ferrero,Martin Verkerk,Juan Carlos Ferrero,R,R,M,20030608.0,Roland Garros,F,15:00:00,Philippe Chatrier,Clay,Pascal Maria,5.0,0,Edo
+20030518-M-Hamburg_Masters-F-Guillermo_Coria-Agustin_Calleri,Guillermo Coria,Agustin Calleri,R,R,M,20030518.0,Hamburg Masters,F,3:00 PM,Central,Clay,Lars Graff,5.0,1,Edo
+20030511-M-Rome_Masters-F-Felix_Mantilla-Roger_Federer,Felix Mantilla,Roger Federer,R,R,M,20030511.0,Rome Masters,F,3:00 PM,Central,Clay,Romano Grillotti,5.0,1,Edo
+20030505-M-Rome_Masters-R64-David_Ferrer-Andre_Agassi,David Ferrer,Andre Agassi,R,R,M,20030505.0,Rome Masters,R64,,Centrale,Clay,Romano Grillotti,3.0,1,Salvo
+20030504-M-Munich-F-Roger_Federer-Jarkko_Nieminen,Roger Federer,Jarkko Nieminen,R,L,M,20030504.0,Munich,F,,,Clay,Sune Alenkaer,3.0,1,Edo
+20030330-M-Miami_Masters-F-Andre_Agassi-Carlos_Moya,Andre Agassi,Carlos Moya,R,R,M,20030330.0,Miami Masters,F,,Stadium,Hard,Carlos Bernardes,3.0,1,Salvo
+20030316-M-Indian_Wells_Masters-F-Lleyton_Hewitt-Gustavo_Kuerten,Lleyton Hewitt,Gustavo Kuerten,R,R,M,20030316.0,Indian Wells Masters,F,,Center,Hard,Lars Graff,3.0,1,Salvo
+20030301-M-Dubai-F-Roger_Federer-Jiri_Novak,Roger Federer,Jiri Novak,R,R,M,20030301.0,Dubai,F,9pm,Centre,Hard,Gerry Armstrong,3.0,1,Edo
+20030216-M-Marseille-F-Jonas_Bjorkman-Roger_Federer,Jonas Bjorkman,Roger Federer,R,R,M,20030216.0,Marseille,F,,Centre,Hard,Stephane Apostolou,3.0,1,Edo
+20030126-M-Australian_Open-F-Rainer_Schuettler-Andre_Agassi,Rainer Schuettler,Andre Agassi,R,R,M,20030126.0,Australian Open,F,3:00 PM,Rod Laver Arena,Hard,,5.0,0,Edo
+20030125-M-Australian_Open-SF-Wayne_Ferreira-Andre_Agassi,Wayne Ferreira,Andre Agassi,R,R,M,20030125.0,Australian Open,SF,6.30pm,Rod Laver Arena,Hard,,5.0,0,Edo
+20030125-M-Australian_Open-SF-Rainer_Schuettler-Andy_Roddick,Rainer Schuettler,Andy Roddick,R,R,M,20030125.0,Australian Open,SF,8pm,Rod Laver Arena,Hard,Lars Graff,5.0,0,Edo
+20021117-M-Masters_Cup-F-Lleyton_Hewitt-Juan_Carlos_Ferrero,Lleyton Hewitt,Juan Carlos Ferrero,R,R,M,20021117.0,Masters Cup,F,,Centre,Hard,Carlos Bernardes,5.0,1,Edo
+20021116-M-Masters_Cup-SF-Roger_Federer-Lleyton_Hewitt,Roger Federer,Lleyton Hewitt,R,R,M,20021116.0,Masters Cup,SF,,Centre,Hard,,3.0,1,Palaver
+20021111-M-Masters_Cup-RR-Andre_Agassi-Jiri_Novak,Andre Agassi,Jiri Novak,R,R,M,20021111.0,Masters Cup,RR,,,Hard,,3.0,1,Isaac
+20021110-M-Paris_Masters-F-Marat_Safin-Lleyton_Hewitt,Marat Safin,Lleyton Hewitt,R,R,M,20021110.0,Paris Masters,F,,,Hard,,5.0,1,Isaac
+20021101-M-Paris_Masters-QF-Roger_Federer-Lleyton_Hewitt,Roger Federer,Lleyton Hewitt,R,R,M,20021101.0,Paris Masters,QF,,,Carpet,Pascal Maria,3.0,1,Natf
+20021013-M-Vienna-F-Roger_Federer-Jiri_Novak,Roger Federer,Jiri Novak,R,R,M,20021013.0,Vienna,F,,,Hard,Gerry Armstrong,5.0,1,Edo
+20020908-M-US_Open-F-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,20020908.0,US Open,F,4:00 PM,Ashe,Hard,Norm Chryst,5.0,0,Edo
+20020907-M-US_Open-SF-Pete_Sampras-Sjeng_Schalken,Pete Sampras,Sjeng Schalken,R,R,M,20020907.0,US Open,SF,1pm,Ashe,Hard,,5.0,1,Edo
+20020907-M-US_Open-SF-Lleyton_Hewitt-Andre_Agassi,Lleyton Hewitt,Andre Agassi,R,R,M,20020907.0,US Open,SF,,,Hard,,5.0,1,Natf
+20020811-M-Cincinnati_Masters-F-Carlos_Moya-Lleyton_Hewitt,Carlos Moya,Lleyton Hewitt,R,R,M,20020811.0,Cincinnati Masters,F,4:00:00 PM,Center,Hard,Norm Chryst,3.0,1,Edo
+20020810-M-Cincinnati_Masters-QF-Andre_Agassi-Lleyton_Hewitt,Andre Agassi,Lleyton Hewitt,R,R,M,20020810.0,Cincinnati Masters,QF,,,Hard,,3.0,1,Natf
+20020804-M-Canada_Masters-F-Andy_Roddick-Guillermo_Canas,Andy Roddick,Guillermo Canas,R,R,M,20020804.0,Canada Masters,F,Day Match,Toronto,Hard,Steve Ullrich,3.0,1,Edo
+20020707-M-Wimbledon-F-David_Nalbandian-Lleyton_Hewitt,David Nalbandian,Lleyton Hewitt,R,R,M,20020707.0,Wimbledon,F,14:00:00,Centre,Grass,Mike Morrissey,5.0,0,Edo
+20020705-M-Wimbledon-SF-Lleyton_Hewitt-Tim_Henman,Lleyton Hewitt,Tim Henman,R,R,M,20020705.0,Wimbledon,SF,,Centre,Grass,,5.0,0,Natf
+20020705-M-Wimbledon-SF-David_Nalbandian-Xavier_Malisse,David Nalbandian,Xavier Malisse,R,R,M,20020705.0,Wimbledon,SF,4.30pm,Court 1,Grass,Pascal Maria,5.0,0,Edo
+20020609-M-Roland_Garros-F-Albert_Costa-Juan_Carlos_Ferrero,Albert Costa,Juan Carlos Ferrero,R,R,M,20020609.0,Roland Garros,F,15:00:00,Philippe Chatrier,Clay,Pascal Maria,5.0,0,Edo
+20020519-M-Hamburg_Masters-F-Roger_Federer-Marat_Safin,Roger Federer,Marat Safin,R,R,M,20020519.0,Hamburg Masters,F,3:00 PM,Central,Clay,Carlos Bernardes,5.0,1,Edo
+20020512-M-Rome_Masters-F-Tommy_Haas-Andre_Agassi,Tommy Haas,Andre Agassi,R,R,M,20020512.0,Rome Masters,F,3PM,Centrale,Clay,Romano Gallotti,5.0,1,Edo
+20020428-M-Houston-SF-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,20020428.0,Houston,SF,,,Hard,,3.0,1,Isaac
+20020329-M-Miami_Masters-SF-Roger_Federer-Lleyton_Hewitt,Roger Federer,Lleyton Hewitt,R,R,M,20020329.0,Miami Masters,SF,,Center,Hard,,3.0,1,Palaver
+20020324-M-Miami_Masters-F-Roger_Federer-Andre_Agassi,Roger Federer,Andre Agassi,R,R,M,20020324.0,Miami Masters,F,3:00:00 PM,Centre,Hard,Lars Graff,5.0,1,Edo
+20020317-M-Indian_Wells_Masters-F-Tim_Henman-Lleyton_Hewitt,Tim Henman,Lleyton Hewitt,R,R,M,20020317.0,Indian Wells Masters,F,2:00:00 PM,Stadium 1,Hard,Carlos Bernardes,3.0,1,Edo
+20020303-M-San_Jose-F-Lleyton_Hewitt-Andre_Agassi,Lleyton Hewitt,Andre Agassi,R,R,M,20020303.0,San Jose,F,,,Hard,,3.0,1,Natf
+20020203-M-Milan-F-Roger_Federer-Davide_Sanguinetti,Roger Federer,Davide Sanguinetti,R,R,M,20020203.0,Milan,F,,Centre,Carpet,Mohamed Lahyani,3.0,1,Edo
+20020127-M-Australian_Open-F-Thomas_Johansson-Marat_Safin,Thomas Johansson,Marat Safin,R,R,M,20020127.0,Australian Open,F,3:00 PM,Centre,Hard,Dennis Overberg,5.0,0,Edo
+20020126-M-Australian_Open-SF-Tommy_Haas-Marat_Safin,Tommy Haas,Marat Safin,R,R,M,20020126.0,Australian Open,SF,3pm,Rod Laver Arena,Hard,Mike Morrissey,5.0,0,Edo
+20020126-M-Australian_Open-SF-Thomas_Johansson-Jiri_Novak,Thomas Johansson,Jiri Novak,R,R,M,20020126.0,Australian Open,SF,6.30pm,Rod Laver Arena,Hard,Andreas Egli,5.0,0,Edo
+20020113-M-Sydney-F-Roger_Federer-Juan_Ignacio_Chela,Roger Federer,Juan Ignacio Chela,R,R,M,20020113.0,Sydney,F,,Centre,Hard,,3.0,1,Edo
+20011118-M-Masters_Cup-F-Sebastien_Grosjean-Lleyton_Hewitt,Sebastien Grosjean,Lleyton Hewitt,R,R,M,20011118.0,Masters Cup,F,,Superdome,Hard,Mike Morrissey,5.0,1,Edo
+20011117-M-Masters_Cup-SF-Juan_Carlos_Ferrero-Lleyton_Hewitt,Juan Carlos Ferrero,Lleyton Hewitt,R,R,M,20011117.0,Masters Cup,SF,,,Hard,,3.0,1,Natf
+20011112-M-Masters_Cup-RR-Patrick_Rafter-Andre_Agassi,Patrick Rafter,Andre Agassi,R,R,M,20011112.0,Masters Cup,RR,,,Hard,,3.0,1,Isaac
+20011028-M-Basel-F-Tim_Henman-Roger_Federer,Tim Henman,Roger Federer,R,R,M,20011028.0,Basel,F,,Centre,Carpet,Norm Chryst,5.0,1,Edo
+20010909-M-US_Open-F-Pete_Sampras-Lleyton_Hewitt,Pete Sampras,Lleyton Hewitt,R,R,M,20010909.0,US Open,F,3:00 PM,Ashe,Hard,,5.0,1,Edo
+20010908-M-US_Open-SF-Pete_Sampras-Marat_Safin,Pete Sampras,Marat Safin,R,R,M,20010908.0,US Open,SF,2pm,Ashe,Hard,Wayne McKewen,5.0,1,Edo
+20010907-M-US_Open-SF-Yevgeny_Kafelnikov-Lleyton_Hewitt,Yevgeny Kafelnikov,Lleyton Hewitt,R,R,M,20010907.0,US Open,SF,,Arthur Ashe,Hard,,5.0,1,abmk
+20010906-M-US_Open-QF-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,20010906.0,US Open,QF,,Arthur Ashe Stadium,Hard,Steve Ullrich,5.0,1,Salvo
+20010827-M-US_Open-R128-Mike_Bryan-Andre_Agassi,Mike Bryan,Andre Agassi,R,R,M,20010827.0,US Open,R128,21:30,Arthur Ashe Stadium,Hard,,5.0,1,1HandBH
+20010805-M-Canada_Masters-F-Patrick_Rafter-Andrei_Pavel,Patrick Rafter,Andrei Pavel,R,R,M,20010805.0,Canada Masters,F,3pm,Montreal,Hard,Norm Chryst,3.0,1,Edo
+20010709-M-Wimbledon-F-Goran_Ivanisevic-Patrick_Rafter,Goran Ivanisevic,Patrick Rafter,L,R,M,20010709.0,Wimbledon,F,12:00:00,Centre,Grass,Jorge Diaz,5.0,0,Edo
+20010707-M-Wimbledon-SF-Patrick_Rafter-Andre_Agassi,Patrick Rafter,Andre Agassi,R,R,M,20010707.0,Wimbledon,SF,,Centre,Grass,,5.0,0,Palaver
+20010707-M-Wimbledon-SF-Goran_Ivanisevic-Tim_Henman,Goran Ivanisevic,Tim Henman,L,R,M,20010707.0,Wimbledon,SF,4.30pm,Centre,Grass,Andreas Egli,5.0,0,Edo
+20010702-M-Wimbledon-R16-Roger_Federer-Pete_Sampras,Roger Federer,Pete Sampras,R,R,M,20010702.0,Wimbledon,R16,14:30:00,Centre,Grass,Mohamed Lahyani,5.0,0,Edo
+20010622-M-s_Hertogenbosch-SF-Roger_Federer-Lleyton_Hewitt,Roger Federer,Lleyton Hewitt,R,R,M,20010622.0,s Hertogenbosch,SF,,Grass,,,3.0,1,Palaver
+20010611-M-Halle-QF-Patrick_Rafter-Roger_Federer,Patrick Rafter,Roger Federer,R,R,M,20010611.0,Halle,QF,,,Grass,,3.0,1,Amy
+20010610-M-Roland_Garros-F-Alex_Corretja-Gustavo_Kuerten,Alex Corretja,Gustavo Kuerten,R,R,M,20010610.0,Roland Garros,F,15:00:00,Philippe Chatrier,Clay,Cedric Mourier,5.0,0,Edo
+20010604-M-Roland_Garros-R16-Wayne_Arthurs-Roger_Federer,Wayne Arthurs,Roger Federer,L,R,M,20010604.0,Roland Garros,R16,,,Clay,,5.0,0,Michal
+20010508-M-Rome_Masters-R64-Marcelo_Rios-Davide_Sanguinetti,Marcelo Rios,Davide Sanguinetti,L,R,M,20010508.0,Rome Masters,R64,,Pallacorda,Clay,Steve Ulrich,3.0,1,Salvo
+20010508-M-Rome_Masters-R32-Roger_Federer-Marat_Safin,Roger Federer,Marat Safin,R,R,M,20010508.0,Rome Masters,R32,,Centrale,Clay,Pedro Bravo,3.0,1,Salvo
+20010328-M-Miami_Masters-R16-Alex_Corretja-Patrick_Rafter,Alex Corretja,Patrick Rafter,R,R,M,20010328.0,Miami Masters,R16,,Stadium,Hard,Steve Ullrich,3.0,1,MaGav
+20010325-M-Miami_Masters-F-Jan_Michael_Gambill-Andre_Agassi,Jan Michael Gambill,Andre Agassi,R,R,M,20010325.0,Miami Masters,F,3:00 PM,Stadium,Hard,,5.0,1,Edo
+20010319-M-Miami_Masters-R32-Pete_Sampras-Andy_Roddick,Pete Sampras,Andy Roddick,R,R,M,20010319.0,Miami Masters,R32,,,Hard,,3.0,1,Isaac
+20010318-M-Indian_Wells_Masters-F-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,20010318.0,Indian Wells Masters,F,2:00:00 PM,Stadium 1,Hard,Norm Chryst,5.0,1,Edo
+20010317-M-Indian_Wells_Masters-SF-Lleyton_Hewitt-Andre_Agassi,Lleyton Hewitt,Andre Agassi,R,R,M,20010317.0,Indian Wells Masters,SF,,,Hard,,3.0,1,Natf
+20010312-M-Indian_Wells-QF-Nicolas_Lapentti-Andre_Agassi,Nicolas Lapentti,Andre Agassi,R,R,M,20010312.0,Indian Wells,QF,,,Hard,,3.0,1,Isaac
+20010225-M-Rotterdam-F-Roger_Federer-Nicolas_Escude,Roger Federer,Nicolas Escude,R,R,M,20010225.0,Rotterdam,F,,Centre,Hard,Romano Grillotti,3.0,1,Edo
+20010204-M-Milan-F-Julien_Boutter-Roger_Federer,Julien Boutter,Roger Federer,R,R,M,20010204.0,Milan,F,,Centre,Carpet,Lars Graf,3.0,1,Edo
+20010128-M-Australian_Open-F-Arnaud_Clement-Andre_Agassi,Arnaud Clement,Andre Agassi,R,R,M,20010128.0,Australian Open,F,3:00 PM,Centre,Hard,Wayne McKewen,5.0,0,Edo
+20010126-M-Australian_Open-SF-Patrick_Rafter-Andre_Agassi,Patrick Rafter,Andre Agassi,R,R,M,20010126.0,Australian Open,SF,,Rod Laver Arena,Hard,,5.0,0,MaGav
+20001203-M-Tour_Finals-F-Andre_Agassi-Gustavo_Kuerten,Andre Agassi,Gustavo Kuerten,R,R,M,20001203.0,Tour Finals,F,4:00 PM,Lisbon,Carpet,Lars Graff,5.0,1,Edo
+20001202-M-Tour_Finals-SF-Pete_Sampras-Gustavo_Kuerten,Pete Sampras,Gustavo Kuerten,R,R,M,20001202.0,Tour Finals,SF,,Centre,Hard,Jorge Dias,3.0,1,MaGav
+20001127-M-Tour_Finals-SF-Marat_Safin-Andre_Agassi,Marat Safin,Andre Agassi,R,R,M,20001127.0,Tour Finals,SF,,,Hard,,3.0,1,EricJ
+20001127-M-Tour_Finals-RR-Pete_Sampras-Lleyton_Hewitt,Pete Sampras,Lleyton Hewitt,R,R,M,20001127.0,Tour Finals,RR,,,Hard,,3.0,1,Natf
+20001119-M-Paris_Masters-F-Mark_Philippoussis-Marat_Safin,Mark Philippoussis,Marat Safin,R,R,M,20001119.0,Paris Masters,F,4:15 PM,Centre,Carpet,Lars Graff,5.0,1,Edo
+20001105-M-Stuttgart_Masters-F-Lleyton_Hewitt-Wayne_Ferreira,Lleyton Hewitt,Wayne Ferreira,R,R,M,20001105.0,Stuttgart Masters,F,3pm,Centre,Hard,Rudy Berger,5.0,1,Edo
+20001029-M-Basel-F-Thomas_Enqvist-Roger_Federer,Thomas Enqvist,Roger Federer,R,R,M,20001029.0,Basel,F,,Centre,Indoor Hard,,5.0,1,Daya
+20001028-M-Basel-SF-Lleyton_Hewitt-Roger_Federer,Lleyton Hewitt,Roger Federer,R,R,M,20001028.0,Basel,SF,16:10,,Carpet,,3.0,1,Palaver
+20000928-M-Olympics-F-Yevgeny_Kafelnikov-Tommy_Haas,Yevgeny Kafelnikov,Tommy Haas,R,R,M,20000928.0,Olympics,F,,Centre,Hard,Bruno Rebeuh,5.0,0,Salvo
+20000910-M-US_Open-F-Pete_Sampras-Marat_Safin,Pete Sampras,Marat Safin,R,R,M,20000910.0,US Open,F,3:00 PM,Ashe,Hard,Steve Ullrich,5.0,0,Edo
+20000909-M-US_Open-SF-Pete_Sampras-Lleyton_Hewitt,Pete Sampras,Lleyton Hewitt,R,R,M,20000909.0,US Open,SF,,Arthur Ashe Stadium,Hard,Jorge Dias,5.0,1,Palaver
+20000909-M-US_Open-SF-Marat_Safin-Todd_Martin,Marat Safin,Todd Martin,R,R,M,20000909.0,US Open,SF,11am,Ashe,Hard,Tony Nimmons,5.0,1,Edo
+20000709-M-Wimbledon-F-Patrick_Rafter-Pete_Sampras,Patrick Rafter,Pete Sampras,R,R,M,20000709.0,Wimbledon,F,2:00 PM,Centre,Grass,Michael Morrissey,5.0,0,Edo
+20000708-M-Wimbledon-SF-Pete_Sampras-Vladimir_Voltchkov,Pete Sampras,Vladimir Voltchkov,R,R,M,20000708.0,Wimbledon,SF,4.30pm,Centre,Grass,Wayne McKewen,5.0,0,Edo
+20000708-M-Wimbledon-SF-Patrick_Rafter-Andre_Agassi,Patrick Rafter,Andre Agassi,R,R,M,20000708.0,Wimbledon,SF,,Centre,Grass,Lars Graff,5.0,0,Palaver
+20000619-M-Queens_Club-F-Pete_Sampras-Lleyton_Hewitt,Pete Sampras,Lleyton Hewitt,R,R,M,20000619.0,Queens Club,F,,,Grass,,3.0,1,Natf
+20000612-M-Queens_Club-QF-Bob_Bryan-Pete_Sampras,Bob Bryan,Pete Sampras,L,R,M,20000612.0,Queens Club,QF,,,Grass,,3.0,1,Isaac
+20000611-M-Roland_Garros-F-Magnus_Norman-Gustavo_Kuerten,Magnus Norman,Gustavo Kuerten,R,R,M,20000611.0,Roland Garros,F,15:00:00,Central,Clay,Pareau,5.0,0,Edo
+20000609-M-Roland_Garros-SF-Gustavo_Kuerten-Juan_Carlos_Ferrero,Gustavo Kuerten,Juan Carlos Ferrero,R,R,M,20000609.0,Roland Garros,SF,4.00pm,Chatrier,Clay,Cedric Mourier,5.0,0,Edo
+20000604-M-Roland_Garros-R16-Alex_Corretja-Roger_Federer,Alex Corretja,Roger Federer,R,R,M,20000604.0,Roland Garros,R16,,,Clay,,5.0,0,Michal
+20000514-M-Rome_Masters-F-Magnus_Norman-Gustavo_Kuerten,Magnus Norman,Gustavo Kuerten,R,R,M,20000514.0,Rome Masters,F,,Centrale,Clay,Lars Graff,5.0,1,Salvo
+20000326-M-Miami_Masters-F-Pete_Sampras-Gustavo_Kuerten,Pete Sampras,Gustavo Kuerten,R,R,M,20000326.0,Miami Masters,F,3:00 PM,Stadium,Hard,Steve Ullrich,5.0,1,Edo
+20000213-M-Marseille-F-Marc_Rosset-Roger_Federer,Marc Rosset,Roger Federer,R,R,M,20000213.0,Marseille,F,,Centre,Hard,Romano Grillotti,3.0,1,Edo
+20000205-M-Davis_Cup_World_Group_R1-RR-Roger_Federer-Lleyton_Hewitt,Roger Federer,Lleyton Hewitt,R,R,M,20000205.0,Davis Cup World Group R1,RR,,,Carpet,,5.0,0,Palaver
+20000130-M-Australian_Open-F-Yevgeny_Kafelnikov-Andre_Agassi,Yevgeny Kafelnikov,Andre Agassi,R,R,M,20000130.0,Australian Open,F,3:00 PM,Rod Laver Arena,Hard,,5.0,0,Edo
+20000128-M-Australian_Open-SF-Yevgeny_Kafelnikov-Magnus_Norman,Yevgeny Kafelnikov,Magnus Norman,R,R,M,20000128.0,Australian Open,SF,3pm,Rod Laver Arena,Hard,Bruno Rebeuh,5.0,0,Edo
+20000128-M-Australian_Open-SF-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,20000128.0,Australian Open,SF,7pm,Rod Laver Arena,Hard,Rudi Berger,5.0,0,Edo
+20000119-M-Australian_Open-R64-Jan_Kroslak-Roger_Federer,Jan Kroslak,Roger Federer,R,R,M,20000119.0,Australian Open,R64,,,Hard,,5.0,0,Michal
+19991128-M-Tour_Finals-F-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,19991128.0,Tour Finals,F,4:00 PM,Hannover,Carpet,Romano Grillotti,5.0,1,Edo
+19991122-M-Tour_Finals-RR-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,19991122.0,Tour Finals,RR,,,Hard,,3.0,1,Isaac
+19991107-M-Paris_Masters-F-Andre_Agassi-Marat_Safin,Andre Agassi,Marat Safin,R,R,M,19991107.0,Paris Masters,F,3pm,Centre,Carpet,Rudy Berger,5.0,1,Edo
+19990912-M-US_Open-F-Todd_Martin-Andre_Agassi,Todd Martin,Andre Agassi,R,R,M,19990912.0,US Open,F,4:00 PM,Ashe,Hard,Norm Chryst,5.0,1,Edo
+19990904-M-US_Open-SF-Yevgeny_Kafelnikov-Andre_Agassi,Yevgeny Kafelnikov,Andre Agassi,R,R,M,19990904.0,US Open,SF,2.30pm,Ashe,Hard,Mike Morrissey,5.0,1,Edo
+19990904-M-US_Open-SF-Todd_Martin-Cedric_Pioline,Todd Martin,Cedric Pioline,R,R,M,19990904.0,US Open,SF,11am,Ashe,Hard,Steve Ullrich,5.0,1,Edo
+19990815-M-Cincinnati_Masters-F-Patrick_Rafter-Pete_Sampras,Patrick Rafter,Pete Sampras,R,R,M,19990815.0,Cincinnati Masters,F,4:00:00 PM,Center,Hard,Norm Chryst,3.0,1,Edo
+19990716-M-Davis_Cup_World_Group_QF-RR-Roger_Federer-Xavier_Malisse,Roger Federer,Xavier Malisse,R,R,M,19990716.0,Davis Cup World Group QF,RR,,,Clay,,5.0,0,Daya
+19990704-M-Wimbledon-F-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,19990704.0,Wimbledon,F,2:00 PM,Centre,Grass,,5.0,0,Edo
+19990703-M-Wimbledon-SF-Tim_Henman-Pete_Sampras,Tim Henman,Pete Sampras,R,R,M,19990703.0,Wimbledon,SF,1pm,Centre,Grass,Bruno Rebeuh,5.0,0,Edo
+19990606-M-Roland_Garros-F-Andrei_Medvedev-Andre_Agassi,Andrei Medvedev,Andre Agassi,R,R,M,19990606.0,Roland Garros,F,15:00:00,Central,Clay,Pareau,5.0,0,Edo
+19990604-M-Roland_Garros-SF-Dominik_Hrbaty-Andre_Agassi,Dominik Hrbaty,Andre Agassi,R,R,M,19990604.0,Roland Garros,SF,4.00pm,Chatrier,Clay,Jorge Dias,5.0,0,Edo
+19990602-M-Wimbledon-SF-Patrick_Rafter-Andre_Agassi,Patrick Rafter,Andre Agassi,R,R,M,19990602.0,Wimbledon,SF,,1,Grass,,5.0,0,Palaver
+19990516-M-Rome_Masters-F-Patrick_Rafter-Gustavo_Kuerten,Patrick Rafter,Gustavo Kuerten,R,R,M,19990516.0,Rome Masters,F,3PM,Centrale,Clay,Romano Grillotti,5.0,1,Edo
+19990509-M-Hamburg_Masters-F-Marcelo_Rios-Mariano_Zabaleta,Marcelo Rios,Mariano Zabaleta,L,R,M,19990509.0,Hamburg Masters,F,3:00 PM,Central,Clay,Steve Ullrich,5.0,1,Edo
+19990508-M-Hamburg_Masters-SF-Marcelo_Rios-Carlos_Moya,Marcelo Rios,Carlos Moya,L,R,M,19990508.0,Hamburg Masters,SF,,,Clay,,3.0,1,Isaac
+19990425-M-Monte_Carlo_Masters-F-Marcelo_Rios-Gustavo_Kuerten,Marcelo Rios,Gustavo Kuerten,L,R,M,19990425.0,Monte Carlo Masters,F,3:00:00 PM,Central,Clay,Romano Grillotti,5.0,1,Edo
+19990314-M-Indian_Wells_Masters-F-Carlos_Moya-Mark_Philippoussis,Carlos Moya,Mark Philippoussis,R,R,M,19990314.0,Indian Wells Masters,F,2:00:00 PM,Stadium 1,Hard,Steve Ullrich,5.0,1,Edo
+19990131-M-Australian_Open-F-Yevgeny_Kafelnikov-Thomas_Enqvist,Yevgeny Kafelnikov,Thomas Enqvist,R,R,M,19990131.0,Australian Open,F,3:00 PM,Rod Laver Arena,Hard,Wayne McKewen,5.0,0,Edo
+19990129-M-Australian_Open-SF-Yevgeny_Kafelnikov-Tommy_Haas,Yevgeny Kafelnikov,Tommy Haas,R,R,M,19990129.0,Australian Open,SF,,Centre,Hard,Wayne McKewen,5.0,0,MaGav
+19990129-M-Australian_Open-SF-Nicolas_Lapentti-Thomas_Enqvist,Nicolas Lapentti,Thomas Enqvist,R,R,M,19990129.0,Australian Open,SF,2pm,Rod Laver Arena,Hard,Denis Overberg,5.0,0,Edo
+19981129-M-Tour_Finals-F-Alex_Corretja-Carlos_Moya,Alex Corretja,Carlos Moya,R,R,M,19981129.0,Tour Finals,F,4:00 PM,Centre,Hard,Lars Graff,5.0,1,Edo
+19981123-M-Tour_Finals-RR-Pete_Sampras-Karol_Kucera,Pete Sampras,Karol Kucera,R,R,M,19981123.0,Tour Finals,RR,,,Hard,,3.0,1,Isaac
+19981123-M-Tour_Finals-RR-Pete_Sampras-Carlos_Moya,Pete Sampras,Carlos Moya,R,R,M,19981123.0,Tour Finals,RR,,,Hard,,3.0,1,Isaac
+19981108-M-Paris_Masters-F-Pete_Sampras-Greg_Rusedski,Pete Sampras,Greg Rusedski,R,L,M,19981108.0,Paris Masters,F,4:15 PM,Centre,Hard,Lars Graff,5.0,1,Edo
+19981102-M-Paris_Masters-R32-Todd_Woodbridge-Marcelo_Rios,Todd Woodbridge,Marcelo Rios,R,L,M,19981102.0,Paris Masters,R32,,,Hard,,3.0,1,Isaac
+19981101-M-Stuttgart_Masters-F-Yevgeny_Kafelnikov-Richard_Krajicek,Yevgeny Kafelnikov,Richard Krajicek,R,R,M,19981101.0,Stuttgart Masters,F,4:00 PM,Centre,Hard,Rudi Berger,5.0,1,Edo
+19981005-M-Basel-R32-Andre_Agassi-Roger_Federer,Andre Agassi,Roger Federer,R,R,M,19981005.0,Basel,R32,,,Hard,,3.0,1,Amy
+19980913-M-US_Open-F-Patrick_Rafter-Mark_Philippoussis,Patrick Rafter,Mark Philippoussis,R,R,M,19980913.0,US Open,F,,Ashe,Hard,Steve Ullrich,5.0,1,Edo
+19980912-M-US_Open-SF-Patrick_Rafter-Pete_Sampras,Patrick Rafter,Pete Sampras,R,R,M,19980912.0,US Open,SF,4pm,Ashe,Hard,Wayne McKewen,5.0,1,Edo
+19980817-M-New_Haven-R32-Pete_Sampras-Lleyton_Hewitt,Pete Sampras,Lleyton Hewitt,R,R,M,19980817.0,New Haven,R32,,,Hard,,3.0,1,Isaac
+19980816-M-Cincinnati_Masters-F-Pete_Sampras-Patrick_Rafter,Pete Sampras,Patrick Rafter,R,R,M,19980816.0,Cincinnati Masters,F,4:00:00 PM,Center,Hard,,3.0,1,Edo
+19980810-M-Cincinnati_Masters-SF-Yevgeny_Kafelnikov-Patrick_Rafter,Yevgeny Kafelnikov,Patrick Rafter,R,R,M,19980810.0,Cincinnati Masters,SF,,,Hard,,3.0,1,Isaac
+19980809-M-Canada_Masters-F-Patrick_Rafter-Richard_Krajicek,Patrick Rafter,Richard Krajicek,R,R,M,19980809.0,Canada Masters,F,3pm,Centre,Hard,Rudi Berger,3.0,1,Edo
+19980802-M-Kitzbuhel-SF-Andrea_Gaudenzi-Francisco_Clavet,Andrea Gaudenzi,Francisco Clavet,R,L,M,19980802.0,Kitzbuhel,SF,,Centre,Clay,Roland Herfel,3.0,1,Edo
+19980705-M-Wimbledon-F-Goran_Ivanisevic-Pete_Sampras,Goran Ivanisevic,Pete Sampras,L,R,M,19980705.0,Wimbledon,F,2:00 PM,Centre,Grass,Michael Morrissey,5.0,0,Edo
+19980704-M-Wimbledon-SF-Goran_Ivanisevic-Richard_Krajicek,Goran Ivanisevic,Richard Krajicek,L,R,M,19980704.0,Wimbledon,SF,13pm,Centre,Grass,Craven,5.0,0,Edo
+19980622-M-Wimbledon-SF-Tim_Henman-Pete_Sampras,Tim Henman,Pete Sampras,R,R,M,19980622.0,Wimbledon,SF,,Centre,Grass,Jorge Dias,5.0,0,MaGav
+19980607-M-Roland_Garros-F-Alex_Corretja-Carlos_Moya,Alex Corretja,Carlos Moya,R,R,M,19980607.0,Roland Garros,F,15:00:00,Central,Clay,Bruno Rebeuh,5.0,0,Edo
+19980329-M-Miami_Masters-F-Marcelo_Rios-Andre_Agassi,Marcelo Rios,Andre Agassi,L,R,M,19980329.0,Miami Masters,F,,Stadium,Hard,Paulo Pereira,5.0,1,Salvo
+19980315-M-Indian_Wells_Masters-F-Marcelo_Rios-Greg_Rusedski,Marcelo Rios,Greg Rusedski,L,L,M,19980315.0,Indian Wells Masters,F,2:00:00 PM,Stadium 1,Hard,Lars Graff,5.0,1,Edo
+19980223-M-Philadelphia-F-Pete_Sampras-Thomas_Enqvist,Pete Sampras,Thomas Enqvist,R,R,M,19980223.0,Philadelphia,F,,,Hard,,3.0,1,Isaac
+19980209-M-San_Jose-F-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,19980209.0,San Jose,F,,,Hard,,3.0,1,Isaac
+19980201-M-Australian_Open-F-Petr_Korda-Marcelo_Rios,Petr Korda,Marcelo Rios,L,L,M,19980201.0,Australian Open,F,3:00 PM,Rod Laver Arena,Hard,,5.0,0,Edo
+19971116-M-Tour_Finals-F-Pete_Sampras-Yevgeny_Kafelnikov,Pete Sampras,Yevgeny Kafelnikov,R,R,M,19971116.0,Tour Finals,F,4:00 PM,Centre,Carpet,Rudi Berger,5.0,1,Edo
+19971110-M-Tour_Finals-SF-Pete_Sampras-Jonas_Bjorkman,Pete Sampras,Jonas Bjorkman,R,R,M,19971110.0,Tour Finals,SF,,,Hard,,3.0,1,Isaac
+19971110-M-Tour_Finals-RR-Patrick_Rafter-Pete_Sampras,Patrick Rafter,Pete Sampras,R,R,M,19971110.0,Tour Finals,RR,,,Hard,,3.0,1,Isaac
+19971102-M-Paris_Masters-F-Pete_Sampras-Jonas_Bjorkman,Pete Sampras,Jonas Bjorkman,R,R,M,19971102.0,Paris Masters,F,4:15 PM,Centre,Carpet,Bruno Rebeuh,5.0,1,Edo
+19971027-M-Paris_Masters-SF-Pete_Sampras-Yevgeny_Kafelnikov,Pete Sampras,Yevgeny Kafelnikov,R,R,M,19971027.0,Paris Masters,SF,,,Hard,,3.0,1,Isaac
+19971020-M-Stuttgart_Masters-R32-Pete_Sampras-Magnus_Gustafsson,Pete Sampras,Magnus Gustafsson,R,R,M,19971020.0,Stuttgart Masters,R32,,,Hard,Rudi Berger,3.0,1,Isaac
+19970923-M-Grand_Slam_Cup-QF-Pete_Sampras-Jonas_Bjorkman,Pete Sampras,Jonas Bjorkman,R,R,M,19970923.0,Grand Slam Cup,QF,,,Hard,,3.0,1,Isaac
+19970907-M-US_Open-F-Patrick_Rafter-Greg_Rusedski,Patrick Rafter,Greg Rusedski,R,L,M,19970907.0,US Open,F,4:00 PM,Ashe,Hard,,5.0,1,Edo
+19970905-M-US_Open-SF-Michael_Chang-Patrick_Rafter,Michael Chang,Patrick Rafter,R,R,M,19970905.0,US Open,SF,3pm,Ashe,Hard,Norm Chryst,5.0,1,Edo
+19970810-M-Cincinnati_Masters-F-Pete_Sampras-Thomas_Muster,Pete Sampras,Thomas Muster,R,L,M,19970810.0,Cincinnati Masters,F,3pm,Centre,Hard,Lars Graff,3.0,1,Edo
+19970803-M-Canada_Masters-F-Chris_Woodruff-Gustavo_Kuerten,Chris Woodruff,Gustavo Kuerten,R,R,M,19970803.0,Canada Masters,F,3pm,Montreal,Hard,,3.0,1,Edo
+19970706-M-Wimbledon-F-Cedric_Pioline-Pete_Sampras,Cedric Pioline,Pete Sampras,R,R,M,19970706.0,Wimbledon,F,2:00 PM,Centre,Grass,Gerry Armstrong,5.0,0,Edo
+19970704-M-Wimbledon-SF-Pete_Sampras-Todd_Woodbridge,Pete Sampras,Todd Woodbridge,R,R,M,19970704.0,Wimbledon,SF,3pm,Centre,Grass,Andreas Egli,5.0,0,Edo
+19970608-M-Roland_Garros-F-Sergi_Bruguera-Gustavo_Kuerten,Sergi Bruguera,Gustavo Kuerten,R,R,M,19970608.0,Roland Garros,F,15:00:00,Central,Clay,Bruno Rebeuh,5.0,0,Edo
+19970606-M-Roland_Garros-SF-Patrick_Rafter-Sergi_Bruguera,Patrick Rafter,Sergi Bruguera,R,R,M,19970606.0,Roland Garros,SF,,Centre,Clay,Jorge Dias,5.0,0,MaGav
+19970518-M-Rome_Masters-F-Alex_Corretja-Marcelo_Rios,Alex Corretja,Marcelo Rios,R,L,M,19970518.0,Rome Masters,F,3PM,Centrale,Clay,,5.0,1,Edo
+19970323-M-Miami_Masters-F-Sergi_Bruguera-Thomas_Muster,Sergi Bruguera,Thomas Muster,R,R,M,19970323.0,Miami Masters,F,3:00 PM,Stadium,Hard,Steve Ullrich,5.0,1,Edo
+19970126-M-Australian_Open-F-Pete_Sampras-Carlos_Moya,Pete Sampras,Carlos Moya,R,R,M,19970126.0,Australian Open,F,3:00 PM,Centre,Hard,Wayne McKewen,5.0,0,Edo
+19970125-M-Australian_Open-SF-Pete_Sampras-Thomas_Muster,Pete Sampras,Thomas Muster,R,L,M,19970125.0,Australian Open,SF,3pm,Rod Laver Arena,Hard,,5.0,0,Edo
+19961124-M-Tour_Finals-F-Boris_Becker-Pete_Sampras,Boris Becker,Pete Sampras,R,R,M,19961124.0,Tour Finals,F,4:00 PM,Centre,Carpet,Gerry Armstrong,5.0,1,Edo
+19961119-M-Tour_Finals-RR-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,19961119.0,Tour Finals,RR,,,Hard,,3.0,1,Isaac
+19961105-M-Paris_Masters-F-Yevgeny_Kafelnikov-Thomas_Enqvist,Yevgeny Kafelnikov,Thomas Enqvist,R,R,M,19961105.0,Paris Masters,F,3pm,Centre,Carpet,Gerry Armstrong,5.0,1,Edo
+19961027-M-Stuttgart_Masters-F-Pete_Sampras-Boris_Becker,Pete Sampras,Boris Becker,R,R,M,19961027.0,Stuttgart Masters,F,4:00 PM,Centre,Carpet,Rudi Berger,5.0,1,Edo
+19960908-M-US_Open-F-Pete_Sampras-Michael_Chang,Pete Sampras,Michael Chang,R,R,M,19960908.0,US Open,F,6:00 PM,Ashe,Hard,Rich Kaufman,5.0,1,Edo
+19960825-M-Canada_Masters-F-Todd_Woodbridge-Wayne_Ferreira,Todd Woodbridge,Wayne Ferreira,R,R,M,19960825.0,Canada Masters,F,3pm,Centre,Hard,Paulo Pereira,3.0,1,Edo
+19960811-M-Cincinnati_Masters-F-Michael_Chang-Andre_Agassi,Michael Chang,Andre Agassi,R,R,M,19960811.0,Cincinnati Masters,F,4:00:00 PM,Center,Hard,Norm Chryst,3.0,1,Edo
+19960804-M-Olympics-F-Sergi_Bruguera-Andre_Agassi,Sergi Bruguera,Andre Agassi,R,R,M,19960804.0,Olympics,F,,Centre,Hard,Wayne McKewen,5.0,0,Salvo
+19960707-M-Wimbledon-F-Richard_Krajicek-Malivai_Washington,,Malivai Washington,R,R,M,19960707.0,Wimbledon,F,2:00 PM,Centre,Grass,John Frame,5.0,0,Edo
+19960707-M-Wimbledon-F-Richard_Kraijcek-Malivai_Washington,Richard Kraijcek,Malivai Washington,R,R,M,19960707.0,Wimbledon,F,2:00 PM,Centre,Grass,John Frame,5.0,0,Edo
+19960616-M-Queens_Club-F-Stefan_Edberg-Boris_Becker,Stefan Edberg,Boris Becker,R,R,M,19960616.0,Queens Club,F,2pm,Centre,Grass,Dana Loconto,3.0,1,Edo
+19960609-M-Roland_Garros-F-Michael_Stich-Yevgeny_Kafelnikov,Michael Stich,Yevgeny Kafelnikov,R,R,M,19960609.0,Roland Garros,F,15:00:00,Central,Clay,Bruno Rebeuh,5.0,0,Edo
+19960519-M-Rome_Masters-F-Richard_Krajicek-Thomas_Muster,Richard Krajicek,Thomas Muster,R,L,M,19960519.0,Rome Masters,F,3pm,Centrale,Clay,Paulo Pereira,5.0,1,Edo
+19960428-M-Monte_Carlo_Masters-F-Albert_Costa-Thomas_Muster,Albert Costa,Thomas Muster,R,L,M,19960428.0,Monte Carlo Masters,F,3:00:00 PM,Central,Clay,Rudi Berger,5.0,1,Edo
+19960128-M-Australian_Open-F-Michael_Chang-Boris_Becker,Michael Chang,Boris Becker,R,R,M,19960128.0,Australian Open,F,3:00 PM,Rod Laver Arena,Hard,,5.0,0,Edo
+19960126-M-Australian_Open-SF-Mark_Woodforde-Boris_Becker,Mark Woodforde,Boris Becker,L,R,M,19960126.0,Australian Open,SF,5pm,Rod Laver Arena,Hard,,5.0,0,Edo
+19960119-M-Australian_Open-R32-Mark_Philippoussis-Pete_Sampras,Mark Philippoussis,Pete Sampras,R,R,M,19960119.0,Australian Open,R32,,,Hard,,5.0,0,Palaver
+19951119-M-Tour_Finals-F-Michael_Chang-Boris_Becker,Michael Chang,Boris Becker,R,R,M,19951119.0,Tour Finals,F,4:00 PM,Centre,Carpet,Steve Ullrich,5.0,1,Edo
+19951105-M-Paris_Masters-F-Pete_Sampras-Boris_Becker,Pete Sampras,Boris Becker,R,R,M,19951105.0,Paris Masters,F,4:15 PM,Centre,Carpet,,5.0,1,Edo
+19950929-M-Basel-QF-Stefan_Edberg-Boris_Becker,Stefan Edberg,Boris Becker,R,R,M,19950929.0,Basel,QF,,Centre,Hard,Lars Graff,3.0,1,Edo
+19950910-M-US_Open-F-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,19950910.0,US Open,F,4:00 PM,Ashe,Hard,Steve Ullrich,5.0,1,Edo
+19950813-M-Cincinnati_Masters-F-Michael_Chang-Andre_Agassi,Michael Chang,Andre Agassi,R,R,M,19950813.0,Cincinnati Masters,F,4:00:00 PM,Center,Hard,Richard Kaufman,3.0,1,Edo
+19950730-M-Canada_Masters-F-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,19950730.0,Canada Masters,F,3pm,Montreal,Hard,,3.0,1,Edo
+19950709-M-Wimbledon-F-Pete_Sampras-Boris_Becker,Pete Sampras,Boris Becker,R,R,M,19950709.0,Wimbledon,F,2:00 PM,Centre,Grass,,5.0,0,Edo
+19950708-M-Wimbledon-SF-Pete_Sampras-Goran_Ivanisevic,Pete Sampras,Goran Ivanisevic,R,L,M,19950708.0,Wimbledon,SF,1pm,Centre,Grass,Gerry Armstrong,5.0,0,Edo
+19950707-M-Wimbledon-SF-Boris_Becker-Andre_Agassi,Boris Becker,Andre Agassi,R,R,M,19950707.0,Wimbledon,SF,4.00pm,Court 1,Grass,Mike Morrissey,5.0,0,Edo
+19950611-M-Roland_Garros-F-Michael_Chang-Thomas_Muster,Michael Chang,Thomas Muster,R,L,M,19950611.0,Roland Garros,F,15:00:00,Central,Clay,Bruno Rebeuh,5.0,0,Edo
+19950522-M-Rome_Masters-F-Sergi_Bruguera-Thomas_Muster,Sergi Bruguera,Thomas Muster,R,L,M,19950522.0,Rome Masters,F,,Centrale,Clay,Rudi Berger,5.0,1,Salvo
+19950514-M-Hamburg_Masters-F-Andrei_Medvedev-Goran_Ivanisevic,Andrei Medvedev,Goran Ivanisevic,R,L,M,19950514.0,Hamburg Masters,F,3pm,Centre,Clay,Paulo Pereira,5.0,1,Edo
+19950430-M-Monte_Carlo_Masters-F-Boris_Becker-Thomas_Muster,Boris Becker,Thomas Muster,R,L,M,19950430.0,Monte Carlo Masters,F,3:00:00 PM,Central,Clay,Gerry Armstrong,5.0,1,Edo
+19950319-M-Miami_Masters-F-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,19950319.0,Miami Masters,F,3:00 PM,Stadium,Hard,Richard Kaufman,3.0,1,Edo
+19950312-M-Indian_Wells_Masters-F-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,19950312.0,Indian Wells Masters,F,2:00:00 PM,Stadium 1,Hard,Steve Ullrich,5.0,1,Edo
+19950311-M-Indian_Wells_Masters-SF-Pete_Sampras-Stefan_Edberg,Pete Sampras,Stefan Edberg,R,R,M,19950311.0,Indian Wells Masters,SF,2pm,Central,Hard,Paulo Pereira,3.0,1,Edo
+19950129-M-Australian_Open-F-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,19950129.0,Australian Open,F,3:00 PM,Centre,Hard,,5.0,0,Edo
+19950127-M-Australian_Open-SF-Michael_Chang-Pete_Sampras,Michael Chang,Pete Sampras,R,R,M,19950127.0,Australian Open,SF,3pm,Rod Laver Arena,Hard,Mike Morrissey,5.0,0,Edo
+19950124-M-Australian_Open-QF-Jim_Courier-Pete_Sampras,Jim Courier,Pete Sampras,R,R,M,19950124.0,Australian Open,QF,9:11 PM,Centre,Hard,,5.0,0,Palaver
+19941120-M-Tour_Finals-F-Pete_Sampras-Boris_Becker,Pete Sampras,Boris Becker,R,R,M,19941120.0,Tour Finals,F,4:00 PM,Centre,Carpet,Gerry Armstrong,5.0,1,Edo
+19941119-M-Tour_Finals-SF-Pete_Sampras-Andre_Agassi,Pete Sampras,Andre Agassi,R,R,M,19941119.0,Tour Finals,SF,,,Hard,,3.0,1,Isaac
+19941116-M-Tour_Finals-RR-Pete_Sampras-Stefan_Edberg,Pete Sampras,Stefan Edberg,R,R,M,19941116.0,Tour Finals,RR,,,Carpet,Rudi Berger,3.0,1,Edo
+19941116-M-Tour_Finals-RR-Michael_Chang-Andre_Agassi,Michael Chang,Andre Agassi,R,R,M,19941116.0,Tour Finals,RR,,,Hard,,3.0,1,Isaac
+19941106-M-Paris_Masters-F-Andre_Agassi-Marc_Rosset,Andre Agassi,Marc Rosset,R,R,M,19941106.0,Paris Masters,F,4:15 PM,Centre,Carpet,Jorge Dias,5.0,1,Edo
+19941030-M-Stockholm-F-Boris_Becker-Goran_Ivanisevic,Boris Becker,Goran Ivanisevic,R,L,M,19941030.0,Stockholm,F,2:00 PM,Centre,Carpet,Jorge Dias,5.0,1,Edo
+19940911-M-US_Open-F-Michael_Stich-Andre_Agassi,Michael Stich,Andre Agassi,R,R,M,19940911.0,US Open,F,4:00 PM,Ashe,Hard,David Littlefield,5.0,1,Edo
+19940813-M-Cincinnati_Masters-SF-Stefan_Edberg-Michael_Stich,Stefan Edberg,Michael Stich,R,R,M,19940813.0,Cincinnati Masters,SF,6pm,Central,Hard,Dana Loconto,3.0,1,Edo
+19940731-M-Canada_Masters-F-Jason_Stoltenberg-Andre_Agassi,Jason Stoltenberg,Andre Agassi,R,R,M,19940731.0,Canada Masters,F,3pm,Toronto,Hard,Richard Kaufman,3.0,1,Edo
+19940703-M-Wimbledon-F-Pete_Sampras-Goran_Ivanisevic,Pete Sampras,Goran Ivanisevic,R,L,M,19940703.0,Wimbledon,F,2:00 PM,Centre,Grass,Michael Morrissey,5.0,0,Edo
+19940702-M-Wimbledon-SF-Todd_Martin-Pete_Sampras,Todd Martin,Pete Sampras,R,R,M,19940702.0,Wimbledon,SF,1pm,Centre,Grass,Bruno Rebeuh,5.0,0,Edo
+19940605-M-Roland_Garros-F-Sergi_Bruguera-Alberto_Berasategui,Sergi Bruguera,Alberto Berasategui,R,R,M,19940605.0,Roland Garros,F,15:00:00,Central,Clay,Bruno Rebeuh,5.0,0,Edo
+19940515-M-Rome_Masters-F-Pete_Sampras-Boris_Becker,Pete Sampras,Boris Becker,R,R,M,19940515.0,Rome Masters,F,,Centrale,Clay,Paulo Pereira,5.0,1,Salvo
+19940508-M-Hamburg_Masters-F-Yevgeny_Kafelnikov-Andrei_Medvedev,Yevgeny Kafelnikov,Andrei Medvedev,R,R,M,19940508.0,Hamburg Masters,F,3pm,Central,Clay,Paulo Pereira,5.0,1,Edo
+19940424-M-Monte_Carlo_Masters-F-Sergi_Bruguera-Andrei_Medvedev,Sergi Bruguera,Andrei Medvedev,R,R,M,19940424.0,Monte Carlo Masters,F,2.30pm,Centre,Clay,Pedro Bravo,5.0,1,Edo
+19940423-M-Monte_Carlo_Masters-SF-Sergi_Bruguera-Stefan_Edberg,Sergi Bruguera,Stefan Edberg,R,R,M,19940423.0,Monte Carlo Masters,SF,3pm,Centre,Clay,John Frame,3.0,1,Edo
+19940313-M-Miami_Masters-F-Andre_Agassi-Pete_Sampras,Andre Agassi,Pete Sampras,R,R,M,19940313.0,Miami Masters,F,3:00 PM,Stadium,Hard,Rich Kaufman,3.0,1,Edo
+19940306-M-Indian_Wells_Masters-F-Pete_Sampras-Petr_Korda,Pete Sampras,Petr Korda,R,L,M,19940306.0,Indian Wells Masters,F,3pm,Centre,Hard,Steve Ullrich,5.0,1,Edo
+19940305-M-Indian_Wells_Masters-SF-Pete_Sampras-Stefan_Edberg,Pete Sampras,Stefan Edberg,R,R,M,19940305.0,Indian Wells Masters,SF,2pm,Central,Hard,Paulo Pereira,3.0,1,Edo
+19940130-M-Australian_Open-F-Pete_Sampras-Todd_Martin,Pete Sampras,Todd Martin,R,R,M,19940130.0,Australian Open,F,3:00 PM,Centre,Hard,Wayne McKewen,5.0,0,Edo
+19940128-M-Australian_Open-SF-Pete_Sampras-Jim_Courier,Pete Sampras,Jim Courier,R,R,M,19940128.0,Australian Open,SF,,,Hard,,5.0,0,Palaver
+19940127-M-Australian_Open-SF-Todd_Martin-Stefan_Edberg,Todd Martin,Stefan Edberg,R,R,M,19940127.0,Australian Open,SF,,,Hard,,5.0,0,Palaver
+19931121-M-Tour_Finals-F-Pete_Sampras-Michael_Stich,Pete Sampras,Michael Stich,R,R,M,19931121.0,Tour Finals,F,4:00 PM,Centre,Carpet,,5.0,1,Edo
+19931118-M-Tour_Finals-RR-Pete_Sampras-Stefan_Edberg,Pete Sampras,Stefan Edberg,R,R,M,19931118.0,Tour Finals,RR,4:00 PM,,Carpet,Rudi Berger,3.0,0,Edo
+19931107-M-Paris_Masters-SF-Stefan_Edberg-Goran_Ivanisevic,Stefan Edberg,Goran Ivanisevic,R,L,M,19931107.0,Paris Masters,SF,2pm,Central,Carpet,Bruno Rebeuh,3.0,1,Edo
+19931107-M-Paris_Masters-F-Andrei_Medvedev-Goran_Ivanisevic,Andrei Medvedev,Goran Ivanisevic,R,L,M,19931107.0,Paris Masters,F,4:15 PM,Centre,Carpet,Paulo Pereira,5.0,1,Edo
+19931031-M-Stockholm_Masters-F-Michael_Stich-Goran_Ivanisevic,Michael Stich,Goran Ivanisevic,R,L,M,19931031.0,Stockholm Masters,F,2:00 PM,Centre,Carpet,Rudi Berger,5.0,1,Edo
+19930912-M-US_Open-F-Cedric_Pioline-Pete_Sampras,Cedric Pioline,Pete Sampras,R,R,M,19930912.0,US Open,F,4:00 PM,Ashe,Hard,,5.0,0,Edo
+19930911-M-US_Open-SF-Pete_Sampras-Alexander_Volkov,Pete Sampras,Alexander Volkov,R,L,M,19930911.0,US Open,SF,5pm,Ashe,Hard,Wayne McKewen,5.0,1,Edo
+19930815-M-Cincinnati_Masters-F-Stefan_Edberg-Michael_Chang,Stefan Edberg,Michael Chang,R,R,M,19930815.0,Cincinnati Masters,F,,Center,Hard,Richard Kaufman,3.0,1,Palaver
+19930814-M-Cincinnati_Masters-SF-Stefan_Edberg-Pete_Sampras,Stefan Edberg,Pete Sampras,R,R,M,19930814.0,Cincinnati Masters,SF,,Center,Hard,Rudi Berger,3.0,1,Palaver
+19930814-M-Cincinnati_Masters-SF-Michael_Chang-Andre_Agassi,Michael Chang,Andre Agassi,R,R,M,19930814.0,Cincinnati Masters,SF,,Center,Hard,Jorge Dias,3.0,1,Palaver
+19930801-M-Canada_Masters-F-Todd_Martin-Mikael_Pernfors,Todd Martin,Mikael Pernfors,R,R,M,19930801.0,Canada Masters,F,3pm,,Hard,Dana Loconto,3.0,1,Edo
+19930704-M-Wimbledon-F-Jim_Courier-Pete_Sampras,Jim Courier,Pete Sampras,R,R,M,19930704.0,Wimbledon,F,2:00 PM,Centre,Grass,Sultan Gangji,5.0,0,Edo
+19930703-M-Wimbledon-SF-Pete_Sampras-Boris_Becker,Pete Sampras,Boris Becker,R,R,M,19930703.0,Wimbledon,SF,1pm,Centre,Grass,Ian McKewen,5.0,0,Edo
+19930702-M-Wimbledon-SF-Jim_Courier-Stefan_Edberg,Jim Courier,Stefan Edberg,R,R,M,19930702.0,Wimbledon,SF,3:30 PM,Centre,Grass,Gerry Armstrong,5.0,0,Edo
+19930606-M-Roland_Garros-F-Jim_Courier-Sergi_Bruguera,Jim Courier,Sergi Bruguera,R,R,M,19930606.0,Roland Garros,F,15:00:00,Central,Clay,Bruno Rebeuh,5.0,0,Edo
+19930516-M-Rome_Masters-F-Jim_Courier-Goran_Ivanisevic,Jim Courier,Goran Ivanisevic,R,L,M,19930516.0,Rome Masters,F,3PM,Centrale,Clay,Jorge Dias,5.0,1,Edo
+19930509-M-Hamburg_Masters-F-Michael_Stich-Andrei_Chesnokov,Michael Stich,Andrei Chesnokov,R,R,M,19930509.0,Hamburg Masters,F,3pm,Centre,Clay,Paulo Pereira,5.0,1,Edo
+19930502-M-Madrid-F-Stefan_Edberg-Sergi_Bruguera,Stefan Edberg,Sergi Bruguera,R,R,M,19930502.0,Madrid,F,3pm,Centre,Clay,Dana Loconto,5.0,1,Edo
+19930424-M-Monte_Carlo_Masters-SF-Cedric_Pioline-Stefan_Edberg,Cedric Pioline,Stefan Edberg,R,R,M,19930424.0,Monte Carlo Masters,SF,1pm,Central,Clay,Lionel Laskar,3.0,1,Edo
+19930321-M-Miami_Masters-F-Pete_Sampras-Malivai_Washington,Pete Sampras,Malivai Washington,R,R,M,19930321.0,Miami Masters,F,3:00 PM,Stadium,Hard,Richard Kaufman,3.0,1,Edo
+19930307-M-Indian_Wells_Masters-F-Jim_Courier-Wayne_Ferreira,Jim Courier,Wayne Ferreira,R,R,M,19930307.0,Indian Wells Masters,F,2:00:00 PM,Stadium 1,Hard,Gerry Armstrong,5.0,1,Edo
+19930131-M-Australian_Open-F-Jim_Courier-Stefan_Edberg,Jim Courier,Stefan Edberg,R,R,M,19930131.0,Australian Open,F,2:00 PM,Centre,Hard,Wayne McKewen,5.0,0,Edo
+19930128-M-Australian_Open-SF-Pete_Sampras-Stefan_Edberg,Pete Sampras,Stefan Edberg,R,R,M,19930128.0,Australian Open,SF,,,Hard,,5.0,0,Palaver
+19921122-M-Tour_Finals-F-Jim_Courier-Boris_Becker,Jim Courier,Boris Becker,R,R,M,19921122.0,Tour Finals,F,4:00 PM,Centre,Carpet,Rudi Berger,5.0,1,Edo
+19921108-M-Paris_Masters-F-Guy_Forget-Boris_Becker,Guy Forget,Boris Becker,L,R,M,19921108.0,Paris Masters,F,4:15 PM,Centre,Carpet,,5.0,1,Edo
+19921101-M-Stockholm_Masters-F-Guy_Forget-Goran_Ivanisevic,Guy Forget,Goran Ivanisevic,L,L,M,19921101.0,Stockholm Masters,F,2:00 PM,Centre,Carpet,Rudi Berger,5.0,1,Edo
+19921031-M-Stockholm_Masters-SF-Stefan_Edberg-Goran_Ivanisevic,Stefan Edberg,Goran Ivanisevic,R,L,M,19921031.0,Stockholm Masters,SF,,Centre,Carpet,,3.0,1,Edo
+19921031-M-Stockholm_Masters-SF-Guy_Forget-Pete_Sampras,Guy Forget,Pete Sampras,L,R,M,19921031.0,Stockholm Masters,SF,,Centre,Carpet,,3.0,1,Palaver
+19920913-M-US_Open-F-Pete_Sampras-Stefan_Edberg,Pete Sampras,Stefan Edberg,R,R,M,19920913.0,US Open,F,4:00 PM,Ashe,Hard,,5.0,1,Edo
+19920912-M-US_Open-SF-Michael_Chang-Stefan_Edberg,Michael Chang,Stefan Edberg,R,R,M,19920912.0,US Open,SF,11am,Ashe,Hard,Bruno Rebeuh,5.0,1,Edo
+19920905-M-US_Open-SF-Jim_Courier-Pete_Sampras,Jim Courier,Pete Sampras,R,R,M,19920905.0,US Open,SF,7pm,Ashe,Hard,David Littlefield,5.0,1,Edo
+19920823-M-New_Haven-SF-Ivan_Lendl-Stefan_Edberg,Ivan Lendl,Stefan Edberg,R,R,M,19920823.0,New Haven,SF,,,Hard,Dana Loconto,3.0,1,Palaver
+19920816-M-Cincinnati_Masters-F-Pete_Sampras-Ivan_Lendl,Pete Sampras,Ivan Lendl,R,R,M,19920816.0,Cincinnati Masters,F,,Center,Hard,Paulo Perreira,3.0,1,Palaver
+19920815-M-Cincinnati_Masters-SF-Pete_Sampras-Stefan_Edberg,Pete Sampras,Stefan Edberg,R,R,M,19920815.0,Cincinnati Masters,SF,,Center,Hard,Paulo Pereira,3.0,1,Palaver
+19920815-M-Cincinnati_Masters-SF-Michael_Chang-Ivan_Lendl,Michael Chang,Ivan Lendl,R,R,M,19920815.0,Cincinnati Masters,SF,,Center,Hard,Dana Loconto,3.0,1,Palaver
+19920808-M-Olympics-F-Marc_Rosset-Jordi_Arrese,Marc Rosset,Jordi Arrese,R,R,M,19920808.0,Olympics,F,,Central,Clay,Bruno Rebeuh,5.0,0,Salvo
+19920726-M-Canada_Masters-F-Andre_Agassi-Ivan_Lendl,Andre Agassi,Ivan Lendl,R,R,M,19920726.0,Canada Masters,F,3pm,Toronto,Hard,Jorge Dias,3.0,1,Edo
+19920724-M-Canada_Masters-SF-Ivan_Lendl-Wally_Masur,Ivan Lendl,Wally Masur,R,R,M,19920724.0,Canada Masters,SF,,Centre,Hard,Jorge Dias,3.0,1,Palaver
+19920705-M-Wimbledon-F-Andre_Agassi-Goran_Ivanisevic,Andre Agassi,Goran Ivanisevic,R,L,M,19920705.0,Wimbledon,F,2:00 PM,Centre,Grass,John Frame,5.0,0,Edo
+19920704-M-Wimbledon-SF-Pete_Sampras-Goran_Ivanisevic,Pete Sampras,Goran Ivanisevic,R,L,M,19920704.0,Wimbledon,SF,11.30am,Court 1,Grass,Bruno Rebeuh,5.0,0,Edo
+19920704-M-Wimbledon-SF-John_Mcenroe-Andre_Agassi,John Mcenroe,Andre Agassi,L,R,M,19920704.0,Wimbledon,SF,,Centre,Grass,Jay Snyder,5.0,0,Salvo
+19920607-M-Roland_Garros-F-Jim_Courier-Petr_Korda,Jim Courier,Petr Korda,R,L,M,19920607.0,Roland Garros,F,15:00:00,Central,Clay,Bruno Rebeuh,5.0,0,Edo
+19920517-M-Rome_Masters-F-Jim_Courier-Carlos_Costa,Jim Courier,Carlos Costa,R,R,M,19920517.0,Rome Masters,F,3PM,Centrale,Clay,Paulo Pereira,5.0,1,Edo
+19920510-M-Hamburg_Masters-F-Stefan_Edberg-Michael_Stich,Stefan Edberg,Michael Stich,R,R,M,19920510.0,Hamburg Masters,F,3pm,Central,Clay,Rudi Berger,3.0,1,Edo
+19920426-M-Monte_Carlo_Masters-F-Aaron_Krickstein-Thomas_Muster,Aaron Krickstein,Thomas Muster,R,L,M,19920426.0,Monte Carlo Masters,F,3:00:00 PM,Central,Clay,Gerry Armstrong,5.0,1,Edo
+19920126-M-Australian_Open-F-Jim_Courier-Stefan_Edberg,Jim Courier,Stefan Edberg,R,R,M,19920126.0,Australian Open,F,,Centre,Hard,,5.0,0,Edo
+19920125-M-Australian_Open-SF-Wayne_Ferreira-Stefan_Edberg,Wayne Ferreira,Stefan Edberg,R,R,M,19920125.0,Australian Open,SF,11am,Rod Laver Arena,Hard,Bruno Rebeuh,5.0,1,Edo
+19920122-M-Australian_Open-QF-Stefan_Edberg-Ivan_Lendl,Stefan Edberg,Ivan Lendl,R,R,M,19920122.0,Australian Open,QF,,Centre,Hard,,5.0,0,Palaver
+19911117-M-Tour_Finals-F-Pete_Sampras-Jim_Courier,Pete Sampras,Jim Courier,R,R,M,19911117.0,Tour Finals,F,4:00 PM,Centre,Carpet,Paulo Pereira,5.0,1,Edo
+19911103-M-Paris_Masters-F-Pete_Sampras-Guy_Forget,Pete Sampras,Guy Forget,R,L,M,19911103.0,Paris Masters,F,4:15 PM,Centre,Carpet,Richard Ings,5.0,1,Edo
+19911027-M-Stockholm-F-Boris_Becker-Stefan_Edberg,Boris Becker,Stefan Edberg,R,R,M,19911027.0,Stockholm,F,2:00 PM,Centre,Carpet,Richard Ings,5.0,1,Edo
+19910908-M-US_Open-F-Jim_Courier-Stefan_Edberg,Jim Courier,Stefan Edberg,R,R,M,19910908.0,US Open,F,3:00 PM,Stadium,Hard,Norm Chryst,5.0,1,Edo
+19910907-M-US_Open-SF-Ivan_Lendl-Stefan_Edberg,Ivan Lendl,Stefan Edberg,R,R,M,19910907.0,US Open,SF,,,Hard,David Littlefield,5.0,1,Palaver
+19910811-M-Cincinnati_Masters-F-Pete_Sampras-Guy_Forget,Pete Sampras,Guy Forget,R,L,M,19910811.0,Cincinnati Masters,F,,Centre,Hard,Dana Loconto,3.0,1,Palaver
+19910728-M-Canada_Masters-F-Petr_Korda-Andrei_Chesnokov,Petr Korda,Andrei Chesnokov,L,R,M,19910728.0,Canada Masters,F,3pm,Montreal,Hard,Richard Ings,3.0,1,Edo
+19910707-M-Wimbledon-F-Boris_Becker-Michael_Stich,Boris Becker,Michael Stich,R,R,M,19910707.0,Wimbledon,F,2:00 PM,Centre,Grass,John Bryson,5.0,0,Edo
+19910706-M-Wimbledon-SF-Michael_Stich-Stefan_Edberg,Michael Stich,Stefan Edberg,R,R,M,19910706.0,Wimbledon,SF,1pm,Centre,Grass,Wayne McKewen,5.0,0,Edo
+19910706-M-Wimbledon-SF-Michael_Stich-Stefan_Edberg,Michael Stich,Stefan Edberg,R,R,M,19910706.0,Wimbledon,SF,1pm,Centre,Grass,Wayne McKewen,5.0,0,Edo
+19910706-M-Wimbledon-SF-David_Wheaton-Boris_Becker,David Wheaton,Boris Becker,R,R,M,19910706.0,Wimbledon,SF,4.30pm,Court 1,Grass,,5.0,0,Edo
+19910609-M-Roland_Garros-F-Andre_Agassi-Jim_Courier,Andre Agassi,Jim Courier,R,R,M,19910609.0,Roland Garros,F,15:00:00,Central,Clay,Bruno Rebeuh,5.0,0,Edo
+19910512-M-Hamburg_Masters-F-Karel_Novacek-Magnus_Gustafsson,Karel Novacek,Magnus Gustafsson,R,R,M,19910512.0,Hamburg Masters,F,3pm,Central,Clay,Rudi Berger,5.0,1,Edo
+19910428-M-Monte_Carlo_Masters-F-Sergi_Bruguera-Boris_Becker,Sergi Bruguera,Boris Becker,R,R,M,19910428.0,Monte Carlo Masters,F,2pm,Central,Clay,Paulo Pereira,5.0,1,Edo
+19910310-M-Indian_Wells_Masters-F-Jim_Courier-Guy_Forget,Jim Courier,Guy Forget,R,L,M,19910310.0,Indian Wells Masters,F,2:00:00 PM,Stadium 1,Hard,Dana Loconto,5.0,1,Edo
+19910127-M-Australian_Open-F-Ivan_Lendl-Boris_Becker,Ivan Lendl,Boris Becker,R,R,M,19910127.0,Australian Open,F,,Centre,Hard,,5.0,0,Edo
+19910125-M-Australian_Open-SF-Stefan_Edberg-Ivan_Lendl,Stefan Edberg,Ivan Lendl,R,R,M,19910125.0,Australian Open,SF,,Centre,Hard,David Littlefield,5.0,0,Palaver
+19901118-M-Tour_Finals-F-Andre_Agassi-Stefan_Edberg,Andre Agassi,Stefan Edberg,R,R,M,19901118.0,Tour Finals,F,4:00 PM,Centre,Carpet,Rudi Berger,5.0,1,Edo
+19901104-M-Paris_Masters-F-Boris_Becker-Stefan_Edberg,Boris Becker,Stefan Edberg,R,R,M,19901104.0,Paris Masters,F,,Palais omnisports de Paris-Bercy,Carpet,Richard Ings,5.0,1,Salvo
+19901028-M-Stockholm-F-Stefan_Edberg-Boris_Becker,Stefan Edberg,Boris Becker,R,R,M,19901028.0,Stockholm,F,2:00 PM,Centre,Grass,,5.0,1,Edo
+19901007-M-Sydney_Indoor-F-Boris_Becker-Stefan_Edberg,Boris Becker,Stefan Edberg,R,R,M,19901007.0,Sydney Indoor,F,2pm,Centre,Hard,Paolo Pereira,5.0,1,Edo
+19901006-M-Sydney_Indoor-SF-Stefan_Edberg-Ivan_Lendl,Stefan Edberg,Ivan Lendl,R,R,M,19901006.0,Sydney Indoor,SF,,Centre,Hard,,3.0,1,Palaver
+19900909-M-US_Open-F-Andre_Agassi-Pete_Sampras,Andre Agassi,Pete Sampras,R,R,M,19900909.0,US Open,F,4:00 PM,Ashe,Hard,David Littlefield,5.0,1,Edo
+19900908-M-US_Open-SF-John_Mcenroe-Pete_Sampras,John Mcenroe,Pete Sampras,L,R,M,19900908.0,US Open,SF,5pm,Ashe,Hard,Steve Ullrich,5.0,1,Edo
+19900908-M-US_Open-SF-Andre_Agassi-Boris_Becker,Andre Agassi,Boris Becker,R,R,M,19900908.0,US Open,SF,12am,Ashe,Hard,Bruno Rebeuh,5.0,1,Edo
+19900812-M-Cincinnati_Masters-F-Brad_Gilbert-Stefan_Edberg,Brad Gilbert,Stefan Edberg,R,R,M,19900812.0,Cincinnati Masters,F,4:00:00 PM,Center,Hard,Richard Kaufman,3.0,1,Edo
+19900805-M-Los_Angeles-F-Michael_Chang-Stefan_Edberg,Michael Chang,Stefan Edberg,R,R,M,19900805.0,Los Angeles,F,3pm,Centre,Hard,Steve Ulrich,3.0,1,Edo
+19900708-M-Wimbledon-F-Boris_Becker-Stefan_Edberg,Boris Becker,Stefan Edberg,R,R,M,19900708.0,Wimbledon,F,2:00 PM,Centre,Grass,Jeremy Shales,5.0,0,Edo
+19900707-M-Wimbledon-SF-Stefan_Edberg-Ivan_Lendl,Stefan Edberg,Ivan Lendl,R,R,M,19900707.0,Wimbledon,SF,1pm,Centre,Grass,,5.0,0,Edo
+19900706-M-Wimbledon-SF-Boris_Becker-Goran_Ivanisevic,Boris Becker,Goran Ivanisevic,R,L,M,19900706.0,Wimbledon,SF,3pm,Court 1,Grass,,5.0,0,Edo
+19900616-M-Queens_Club-SF-Stefan_Edberg-Boris_Becker,Stefan Edberg,Boris Becker,R,R,M,19900616.0,Queens Club,SF,2pm,Centre,Grass,,3.0,1,Edo
+19900611-M-Queens_Club-F-Boris_Becker-Ivan_Lendl,Boris Becker,Ivan Lendl,R,R,M,19900611.0,Queens Club,F,,,Grass,,3.0,1,Isaac
+19900610-M-Roland_Garros-F-Andres_Gomez-Andre_Agassi,Andres Gomez,Andre Agassi,L,R,M,19900610.0,Roland Garros,F,15:00:00,Central,Clay,Rebeuh,5.0,0,Edo
+19900513-M-Hamburg_Masters-F-Juan_Aguilera-Boris_Becker,Juan Aguilera,Boris Becker,R,R,M,19900513.0,Hamburg Masters,F,3pm,Central,Clay,Zoltan Bognar,5.0,1,Edo
+19900429-M-Monte_Carlo_Masters-F-Andrei_Chesnokov-Thomas_Muster,Andrei Chesnokov,Thomas Muster,R,L,M,19900429.0,Monte Carlo Masters,F,2pm,Central,Clay,Richard Ings,5.0,1,Edo
+19900325-M-Miami_Masters-F-Andre_Agassi-Stefan_Edberg,Andre Agassi,Stefan Edberg,R,R,M,19900325.0,Miami Masters,F,3:00 PM,Stadium,Hard,Paulo Pereira,5.0,1,Edo
+19900311-M-Indian_Wells_Masters-F-Andre_Agassi-Stefan_Edberg,Andre Agassi,Stefan Edberg,R,R,M,19900311.0,Indian Wells Masters,F,2:00:00 PM,Stadium 1,Hard,Gerry Armstrong,5.0,1,Edo
+19900128-M-Australian_Open-F-Ivan_Lendl-Stefan_Edberg,Ivan Lendl,Stefan Edberg,R,R,M,19900128.0,Australian Open,F,,Centre,Hard,,5.0,0,Edo
+19900127-M-Australian_Open-SF-Mats_Wilander-Stefan_Edberg,Mats Wilander,Stefan Edberg,R,R,M,19900127.0,Australian Open,SF,,Rod Laver Arena,Hard,David Littlefield,5.0,1,Edo
+19891203-M-Tour_Finals-F-Stefan_Edberg-Boris_Becker,Stefan Edberg,Boris Becker,R,R,M,19891203.0,Tour Finals,F,4:00 PM,Centre,Carpet,Richard Kaufman,5.0,1,Edo
+19891105-M-Paris_Masters-F-Stefan_Edberg-Boris_Becker,Stefan Edberg,Boris Becker,R,R,M,19891105.0,Paris Masters,F,3pm,Centre,Carpet,Bruno Rebeuh,5.0,1,Edo
+19890910-M-US_Open-F-Boris_Becker-Ivan_Lendl,Boris Becker,Ivan Lendl,R,R,M,19890910.0,US Open,F,4:00 PM,Centre,Hard,Dana Loconto,5.0,0,Edo
+19890909-M-US_Open-SF-Boris_Becker-Aaron_Krickstein,Boris Becker,Aaron Krickstein,R,R,M,19890909.0,US Open,SF,12am,Ashe,Hard,David Littlefield,5.0,1,Edo
+19890909-M-US_Open-SF-Andre_Agassi-Ivan_Lendl,Andre Agassi,Ivan Lendl,R,R,M,19890909.0,US Open,SF,5am,Ashe,Hard,Richard Kaufman,5.0,1,Edo
+19890905-M-US_Open-R16-Jimmy_Connors-Stefan_Edberg,Jimmy Connors,Stefan Edberg,L,R,M,19890905.0,US Open,R16,7:00 PM,Stadium,Hard,Rudy Berger / Richard Ings,5.0,1,Edo
+19890709-M-Wimbledon-F-Boris_Becker-Stefan_Edberg,Boris Becker,Stefan Edberg,R,R,M,19890709.0,Wimbledon,F,,Centre,Grass,,5.0,0,Edo
+19890708-M-Wimbledon-SF-Ivan_Lendl-Boris_Becker,Ivan Lendl,Boris Becker,R,R,M,19890708.0,Wimbledon,SF,12:00,Court 1,Grass,Paulo Pereira,5.0,0,Edo
+19890701-M-Wimbledon-SF-Stefan_Edberg-John_Mcenroe,Stefan Edberg,John McEnroe,R,L,M,19890701.0,Wimbledon,SF,1pm,Centre,Grass,Richard Ings,5.0,0,Edo
+19890611-M-Roland_Garros-F-Michael_Chang-Stefan_Edberg,Michael Chang,Stefan Edberg,R,R,M,19890611.0,Roland Garros,F,15:00:00,Central,Clay,Bruno Rebeuh,5.0,0,Edo
+19890609-M-Roland_Garros-SF-Stefan_Edberg-Boris_Becker,Stefan Edberg,Boris Becker,R,R,M,19890609.0,Roland Garros,SF,4pm,Philippe Chatrier,Clay,Richard Kaufman,5.0,0,Edo
+19890129-M-Australian_Open-F-Ivan_Lendl-Miroslav_Mecir,Ivan Lendl,Miroslav Mecir,R,R,M,19890129.0,Australian Open,F,,Centre,Hard,Rudy Berger,5.0,0,Edo
+19881202-M-Masters_Cup-F-Boris_Becker-Ivan_Lendl,Boris Becker,Ivan Lendl,R,R,M,19881202.0,Masters Cup,F,,,Carpet (Hard),,5.0,1,Isaac
+19880911-M-US_Open-F-Mats_Wilander-Ivan_Lendl,Mats Wilander,Ivan Lendl,R,R,M,19880911.0,US Open,F,4:00 PM,Centre,Hard,Jay Snyder,5.0,1,Edo
+19880704-M-Wimbledon-F-Stefan_Edberg-Boris_Becker,Stefan Edberg,Boris Becker,R,R,M,19880704.0,Wimbledon,F,2:00 PM,Centre,Grass,Gerry Armstrong,5.0,0,Edo
+19880702-M-Wimbledon-SF-Stefan_Edberg-Miroslav_Mecir,Stefan Edberg,Miroslav Mecir,R,R,M,19880702.0,Wimbledon,SF,2pm,Centre,Grass,,5.0,0,Edo
+19880605-M-Roland_Garros-F-Mats_Wilander-Henri_Leconte,Mats Wilander,Henri Leconte,R,L,M,19880605.0,Roland Garros,F,15:00:00,Central,Clay,Kaufman,5.0,0,Edo
+19880427-M-Hamburg-R32-Boris_Becker-Mansour_Bahrami,Boris Becker,Mansour Bahrami,R,R,M,19880427.0,Hamburg,R32,12:30,Centre,Clay,Gerald Armstrong,3.0,1,1HandBH
+19880124-M-Australian_Open-F-Pat_Cash-Mats_Wilander,Pat Cash,Mats Wilander,R,R,M,19880124.0,Australian Open,F,3:00 PM,Centre,Hard,Richard Ings,5.0,0,Edo
+19880123-M-Australian_Open-SF-Stefan_Edberg-Mats_Wilander,Stefan Edberg,Mats Wilander,R,R,M,19880123.0,Australian Open,SF,12am,Rod Laver Arena,Hard,Richard Kaufman,5.0,1,Edo
+19871206-M-Masters-F-Mats_Wilander-Ivan_Lendl,Mats Wilander,Ivan Lendl,R,R,M,19871206.0,Masters,F,8pm,Centre,Carpet,Richard Kaufman,5.0,1,Edo
+19871108-M-Stockholm-F-Jonas_Svensson-Stefan_Edberg,Jonas Svensson,Stefan Edberg,R,R,M,19871108.0,Stockholm,F,,Centre,Hard,Rudolf Berger,5.0,1,Edo
+19871025-M-Tokyo_Indoor-F-Stefan_Edberg-Ivan_Lendl,Stefan Edberg,Ivan Lendl,R,R,M,19871025.0,Tokyo Indoor,F,,Centre,Carpet,Gerry Armstrong,3.0,1,Palaver
+19870914-M-US_Open-F-Ivan_Lendl-Mats_Wilander,Ivan Lendl,Mats Wilander,R,R,M,19870914.0,US Open,F,2:00 PM,Stadium,Hard,Richard Kaufman,5.0,1,Edo
+19870912-M-US_Open-SF-Stefan_Edberg-Mats_Wilander,Stefan Edberg,Mats Wilander,R,R,M,19870912.0,US Open,SF,10am,Ashe,Hard,,5.0,1,Edo
+19870905-M-US_Open-R32-John_Mcenroe-Slobodan_Zivojinovic,John Mcenroe,Slobodan Zivojinovic,L,R,M,19870905.0,US Open,R32,3:00 PM,Centre,Hard,Richard Ings,5.0,1,Edo
+19870901-M-US_Open-QF-John_Mcenroe-Ivan_Lendl,John Mcenroe,Ivan Lendl,L,R,M,19870901.0,US Open,QF,,,Clay,,3.0,1,Isaac
+19870823-M-Cincinnati-F-Boris_Becker-Stefan_Edberg,Boris Becker,Stefan Edberg,R,R,M,19870823.0,Cincinnati,F,3pm,Centre,Hard,Richard Kaufman,3.0,1,Edo
+19870705-M-Wimbledon-F-Pat_Cash-Ivan_Lendl,Pat Cash,Ivan Lendl,R,R,M,19870705.0,Wimbledon,F,2:00 PM,Centre,Grass,Winyard,5.0,0,Edo
+19870704-M-Wimbledon-SF-Stefan_Edberg-Ivan_Lendl,Stefan Edberg,Ivan Lendl,R,R,M,19870704.0,Wimbledon,SF,2pm,Centre,Grass,,5.0,0,Edo
+19870607-M-Roland_Garros-F-Mats_Wilander-Ivan_Lendl,Mats Wilander,Ivan Lendl,R,R,M,19870607.0,Roland Garros,F,15:30:00,Central,Clay,Jacques Dorfmann,5.0,0,Edo
+19870222-M-Indian_Wells-F-Stefan_Edberg-Boris_Becker,Stefan Edberg,Boris Becker,R,R,M,19870222.0,Indian Wells,F,3pm,Centre,Hard,Gerry Armstrong,5.0,1,Edo
+19870125-M-Australian_Open-F-Stefan_Edberg-Pat_Cash,Stefan Edberg,Pat Cash,R,R,M,19870125.0,Australian Open,F,2:00 PM,Kooyong,Grass,Jeremy Shales,5.0,0,Edo
+19861207-M-Masters-F-Boris_Becker-Ivan_Lendl,Boris Becker,Ivan Lendl,R,R,M,19861207.0,Masters,F,8pm,Centre,Carpet,Richard Kaufman,5.0,1,Edo
+19861109-M-Stockholm-F-Mats_Wilander-Stefan_Edberg,Mats Wilander,Stefan Edberg,R,R,M,19861109.0,Stockholm,F,3pm,Centre,Hard,Goran Sandstrom,5.0,1,Edo
+19861026-M-Tokyo_Indoor-F-Stefan_Edberg-Boris_Becker,Stefan Edberg,Boris Becker,R,R,M,19861026.0,Tokyo Indoor,F,2pm,Centre,Carpet,Richard Kaufman,3.0,1,Edo
+19860907-M-US_Open-F-Miroslav_Mecir-Ivan_Lendl,Miroslav Mecir,Ivan Lendl,R,R,M,19860907.0,US Open,F,2:00 PM,Stadium,Hard,Don Wiley,5.0,1,Edo
+19860706-M-Wimbledon-F-Boris_Becker-Ivan_Lendl,Boris Becker,Ivan Lendl,R,R,M,19860706.0,Wimbledon,F,2:00 PM,Centre,Grass,Grime,5.0,0,Edo
+19860704-M-Wimbledon-SF-Henri_Leconte-Boris_Becker,Henri Leconte,Boris Becker,L,R,M,19860704.0,Wimbledon,SF,2pm,Court 1,Grass,Jeremy Shales,5.0,0,Edo
+19860608-M-Roland_Garros-F-Mikael_Pernfors-Ivan_Lendl,Mikael Pernfors,Ivan Lendl,R,R,M,19860608.0,Roland Garros,F,15:30:00,Central,Clay,Jacques Dorfmann,5.0,0,Edo
+19860114-M-Masters-F-Boris_Becker-Ivan_Lendl,Boris Becker,Ivan Lendl,R,R,M,19860114.0,Masters,F,8pm,Centre,Carpet,Richard Kaufman,5.0,1,Edo
+19851208-M-Australian_Open-F-Stefan_Edberg-Mats_Wilander,Stefan Edberg,Mats Wilander,R,R,M,19851208.0,Australian Open,F,,Kooyong,Grass,Richard Kafmann,5.0,0,Edo
+19851207-M-Australian_Open-SF-Stefan_Edberg-Ivan_Lendl,Stefan Edberg,Ivan Lendl,R,R,M,19851207.0,Australian Open,SF,,Centre,Grass,,5.0,0,Palaver
+19850908-M-US_Open-F-John_Mcenroe-Ivan_Lendl,John Mcenroe,Ivan Lendl,L,R,M,19850908.0,US Open,F,4:00 PM,Centre,Hard,,5.0,1,Edo
+19850907-M-US_Open-SF-Mats_Wilander-John_Mcenroe,Mats Wilander,John Mcenroe,R,L,M,19850907.0,US Open,SF,3pm,Center,Hard,Richard Kaufman,5.0,1,Edo
+19850825-M-Cincinnati-F-Mats_Wilander-Boris_Becker,Mats Wilander,Boris Becker,R,R,M,19850825.0,Cincinnati,F,,Center,Hard,Jeremy Shales,3.0,1,Salvo
+19850707-M-Wimbledon-F-Boris_Becker-Kevin_Curren,Boris Becker,Kevin Curren,R,R,M,19850707.0,Wimbledon,F,2:00 PM,Centre,Grass,,5.0,0,Edo
+19850609-M-Roland_Garros-F-Mats_Wilander-Ivan_Lendl,Mats Wilander,Ivan Lendl,R,R,M,19850609.0,Roland Garros,F,15:00:00,Central,Clay,Jacques Dorfmann,5.0,0,Edo
+19841209-M-Australian_Open-F-Mats_Wilander-Kevin_Curren,Mats Wilander,Kevin Curren,R,R,M,19841209.0,Australian Open,F,3pm,Kooyong,Grass,John ?,5.0,0,Edo
+19840909-M-US_Open-F-John_Mcenroe-Ivan_Lendl,John Mcenroe,Ivan Lendl,L,R,M,19840909.0,US Open,F,4:00 PM,Centre,Hard,,5.0,1,Edo
+19840908-M-US_Open-SF-Pat_Cash-Ivan_Lendl,Pat Cash,Ivan Lendl,R,R,M,19840908.0,US Open,SF,,,Hard,Charles Beck,5.0,1,Palaver
+19840908-M-US_Open-SF-John_Mcenroe-Jimmy_Connors,John Mcenroe,Jimmy Connors,L,L,M,19840908.0,US Open,SF,,,Hard,,5.0,1,Palaver
+19840708-M-Wimbledon-F-John_Mcenroe-Jimmy_Connors,John Mcenroe,Jimmy Connors,L,L,M,19840708.0,Wimbledon,F,2:00 PM,Centre,Grass,David Mercer,5.0,0,Edo
+19840610-M-Roland_Garros-F-John_Mcenroe-Ivan_Lendl,John Mcenroe,Ivan Lendl,L,R,M,19840610.0,Roland Garros,F,15:00:00,Central,Clay,Jacques Dorfmann,5.0,0,Edo
+19840506-M-Forest_Hills_WCT-F-John_Mcenroe-Ivan_Lendl,John Mcenroe,Ivan Lendl,L,R,M,19840506.0,Forest Hills WCT,F,,,Clay,,3.0,1,Isaac
+19840115-M-Masters-F-John_Mcenroe-Ivan_Lendl,John Mcenroe,Ivan Lendl,L,R,M,19840115.0,Masters,F,8pm,Centre,Carpet,Charlie Beck,5.0,1,Edo
+19831211-M-Australian_Open-F-Mats_Wilander-Ivan_Lendl,Mats Wilander,Ivan Lendl,R,R,M,19831211.0,Australian Open,F,3:00 PM,Kooyong,Grass,,5.0,0,Edo
+19830911-M-US_Open-F-Jimmy_Connors-Ivan_Lendl,Jimmy Connors,Ivan Lendl,L,R,M,19830911.0,US Open,F,4:00 PM,Centre,Hard,Kaufman,5.0,1,Edo
+19830703-M-Wimbledon-F-Chris_Lewis-John_Mcenroe,Chris Lewis,John Mcenroe,R,L,M,19830703.0,Wimbledon,F,2:00 PM,Centre,Grass,Malcom Huntington,5.0,0,Edo
+19830605-M-Roland_Garros-F-Mats_Wilander-Yannick_Noah,Mats Wilander,Yannick Noah,R,R,M,19830605.0,Roland Garros,F,14:00:00,Central,Clay,Jacques Dorfmann,5.0,0,Edo
+19821213-M-Australian_Open-F-Steve_Denton-Johan_Kriek,Steve Denton,Johan Kriek,R,R,M,19821213.0,Australian Open,F,3:00 PM,Kooyong,Grass,Jim Entink,5.0,0,Edo
+19820912-M-US_Open-F-Jimmy_Connors-Ivan_Lendl,Jimmy Connors,Ivan Lendl,L,R,M,19820912.0,US Open,F,4:00 PM,Centre,Hard,Jay Snyder,5.0,1,Edo
+19820704-M-Wimbledon-F-John_Mcenroe-Jimmy_Connors,John Mcenroe,Jimmy Connors,L,L,M,19820704.0,Wimbledon,F,2:00 PM,Centre,Grass,,5.0,0,Edo
+19820606-M-Roland_Garros-F-Guillermo_Vilas-Mats_Wilander,Guillermo Vilas,Mats Wilander,L,R,M,19820606.0,Roland Garros,F,14:00:00,Central,Clay,Jacques Dorfmann,5.0,0,Edo
+19810913-M-US_Open-F-John_Mcenroe-Bjorn_Borg,John Mcenroe,Bjorn Borg,L,R,M,19810913.0,US Open,F,,Centre,Hard,,5.0,1,Edo
+19810912-M-US_Open-SF-Jimmy_Connors-Bjorn_Borg,Jimmy Connors,Bjorn Borg,L,R,M,19810912.0,US Open,SF,5pm,Center,Hard,Winslow 'Mike' Blanchard,5.0,1,Edo
+19810704-M-Wimbledon-F-John_Mcenroe-Bjorn_Borg,John Mcenroe,Bjorn Borg,L,R,M,19810704.0,Wimbledon,F,2:00 PM,Centre,Grass,Bob Jenkins,5.0,0,Edo
+19810607-M-Roland_Garros-F-Bjorn_Borg-Ivan_Lendl,Bjorn Borg,Ivan Lendl,R,R,M,19810607.0,Roland Garros,F,14:30:00,Central,Clay,Jacques Dorfmann,5.0,0,Edo
+19810118-M-Masters-F-Ivan_Lendl-Bjorn_Borg,Ivan Lendl,Bjorn Borg,R,R,M,19810118.0,Masters,F,,Centre,Carpet,,5.0,1,Edo
+19810104-M-Australian_Open-F-Kim_Warwick-Brian_Teacher,Kim Warwick,Brian Teacher,R,R,M,19810104.0,Australian Open,F,3:00 PM,Kooyong,Grass,Max Atkins,5.0,0,Edo
+19800907-M-US_Open-F-John_Mcenroe-Bjorn_Borg,John Mcenroe,Bjorn Borg,L,R,M,19800907.0,US Open,F,4:00 PM,Centre,Hard,Slye,5.0,1,Edo
+19800906-M-US_Open-SF-John_Mcenroe-Jimmy_Connors,John Mcenroe,Jimmy Connors,L,L,M,19800906.0,US Open,SF,3pm,Center,Hard,Don Wiley,5.0,1,Edo
+19800705-M-Wimbledon-F-John_Mcenroe-Bjorn_Borg,John Mcenroe,Bjorn Borg,L,R,M,19800705.0,Wimbledon,F,2:00 PM,Centre,Grass,Gerry Armstrong,5.0,0,Eric
+19800608-M-Roland_Garros-F-Vitas_Gerulaitis-Bjorn_Borg,Vitas Gerulaitis,Bjorn Borg,R,R,M,19800608.0,Roland Garros,F,14:00:00,Central,Clay,,5.0,0,Edo
+19780611-M-Roland_Garros-F-Bjorn_Borg-Guillermo_Vilas,Bjorn Borg,Guillermo Vilas,R,L,M,19780611.0,Roland Garros,F,,,Clay,,3.0,1,Isaac
+19780125-M-Pepsi_Grand_Slam-SF-Brian_Gottfried-Bjorn_Borg,Brian Gottfried,Bjorn Borg,R,R,M,19780125.0,Pepsi Grand Slam,SF,,,Clay,,3.0,1,Isaac
+19751219-M-Davis_Cup_World_Group_F-RR-Bjorn_Borg-Jiri_Hrebec,Bjorn Borg,Jiri Hrebec,R,R,M,19751219.0,Davis Cup World Group F,RR,,,Hard,,3.0,1,Isaac
+19750101-M-Australian_Open-F-Jimmy_Connors-John_Newcombe,Jimmy Connors,John Newcombe,L,R,M,19750101.0,Australian Open,F,,Centre,Grass,,5.0,0,Palaver
+19740714-M-Bastad-F-Bjorn_Borg-Adriano_Panatta,Bjorn Borg,Adriano Panatta,R,R,M,19740714.0,Bastad,F,,Central,Clay,,5.0,0,Edo


### PR DESCRIPTION
On row 490, the 'Court' column mistakenly contains the next 220 rows' worth of data. Moving these back out into their own separate rows